### PR TITLE
fix(gallery): 修复 Print 图片共享元素动画

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/GalleryTabPager.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/GalleryTabPager.kt
@@ -291,7 +291,7 @@ sealed class GalleryTabPager(private val tagType: FileTagType) {
         }
     }
 
-    @OptIn(ExperimentalFoundationApi::class)
+    @OptIn(ExperimentalFoundationApi::class, ExperimentalSharedTransitionApi::class)
     @Composable
     private fun PrintItem(
         print: PrintData,
@@ -317,6 +317,11 @@ sealed class GalleryTabPager(private val tagType: FileTagType) {
                     modifier = Modifier
                         .fillMaxSize()
                         .clip(MaterialTheme.shapes.medium)
+                        .sharedBoundsBy(
+                            print.id,
+                            sharedTransitionScope = LocalSharedTransitionDialogScope.current,
+                            animatedVisibilityScope = this@AnimatedVisibility,
+                        )
                         .combinedClickable(
                             onClick = {
                                 if (galleryScreenModel.hasSelection(FileTagType.Print)) {


### PR DESCRIPTION
关联 #15

## 实现思路

Print 缩略图原先没有加入共享元素过渡，预览页虽然已经配置了动画，但找不到对应的起点。现在使用每张 Print 图片自身的唯一编号，把缩略图与预览图配成同一个共享元素，打开和关闭预览时都会沿用图库其他页面已有的过渡方式。

## 验收标准自查

- [x] 从图库 Print 页点击具体图片时，缩略图会平滑过渡到预览图。验证方式：缩略图和预览图使用相同的图片编号及同一对话框动画作用域，且桌面端公共界面代码编译通过。
- [x] 关闭预览时，图片会按同一共享元素关系返回原缩略图位置。验证方式：打开和关闭共用 Compose 的共享边界配对机制。
- [x] Print 页原有点击查看、长按批量选择、缩放和保存行为保持不变。验证方式：修改仅增加缩略图共享边界，不改变现有事件处理和预览逻辑；桌面测试通过。

## 自测结果

- `./gradlew :composeApp:desktopTest`：BUILD SUCCESSFUL。
- `check-gate.sh implement-issue 15`：quality gate: pass；门禁执行 `assembleDebug`，BUILD SUCCESSFUL。
- Android 真机隧道 `127.0.0.1:15038` 当前拒绝连接，因此未进行真机动画观感检查。

## 自评风险点

共享元素的配对和构建均已验证，但动画的实际观感仍建议评审时在设备上确认，尤其是快速连续打开、关闭时的表现。

## 实现说明(供追问)

### 关键决策

复用普通图库图片已经采用的共享边界方案，让 Print 缩略图和预览图以图片唯一编号配对。没有另写一套动画，因为两类图片进入的是同一个预览界面，复用现有机制能保持体验一致。

### 覆盖的场景

覆盖从 Print 网格打开图片预览，以及通过关闭按钮、背景点击、返回操作或已有拖动关闭逻辑退出预览时的共享元素过渡。批量选择状态下的点击仍执行选择，不会误开预览。

### 明确未覆盖

没有调整动画时长、缓动曲线、图片加载失败界面、缩放手势、保存图片和 Print 数据获取；这些均超出本 issue 的验收范围。由于真机隧道不可用，本次未覆盖设备上的主观动画观感检查。

### 关键假设

Print 的图片编号在当前列表中唯一且稳定。现有列表本身已用该编号作为项目键，预览页也已用同一编号注册共享边界。