### PR TITLE
fix(image): 修复共享动画详情封面首次加载问题

### DIFF
--- a/composeApp/src/commonMain/kotlin/network/api/files/FileApi.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/files/FileApi.kt
@@ -34,6 +34,13 @@ class FileApi(private val client: HttpClient) {
             val fileVersion = findFileVersion(fileUrl)
             return "https://api.vrchat.cloud/api/1/image/$fileId/$fileVersion/$fileSize"
         }
+
+        fun convertFileUrlToOriginal(fileUrl: String): String {
+            if (fileUrl.isEmpty()) return ""
+            val fileId = findFileId(fileUrl)
+            val fileVersion = findFileVersion(fileUrl)
+            return "https://api.vrchat.cloud/api/1/file/$fileId/$fileVersion/file"
+        }
     }
 
     suspend fun findImageFileLocal(fileUrl: String, fileSize: Int = 128): String {

--- a/composeApp/src/commonMain/kotlin/network/api/files/ImageUrlResolver.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/files/ImageUrlResolver.kt
@@ -1,0 +1,10 @@
+package io.github.vrcmteam.vrcm.network.api.files
+
+internal fun resolveOriginalImageUrl(
+    imageUrl: String?,
+    thumbnailImageUrl: String?,
+): String? = (imageUrl?.takeIf { it.isNotBlank() }
+    ?: thumbnailImageUrl?.takeIf { it.isNotBlank() })
+    ?.let { url ->
+        if (FileApi.findFileId(url).isEmpty()) url else FileApi.convertFileUrlToOriginal(url)
+    }

--- a/composeApp/src/commonMain/kotlin/presentation/compoments/AImage.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/AImage.kt
@@ -22,6 +22,8 @@ import coil3.PlatformContext
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import coil3.size.Precision
+import coil3.size.Size
 import org.koin.compose.koinInject
 
 /**
@@ -79,6 +81,7 @@ fun AImage(
     error: Painter? = remember(color) { ColorPainter(color) },
     placeholder: Painter? = remember(color) { ColorPainter(color) },
     contentScale: ContentScale = ContentScale.Crop,
+    loadOriginalSize: Boolean = false,
 ) {
     val imageLoader: ImageLoader = koinInject()
     val platformContext = koinInject<PlatformContext>()
@@ -88,6 +91,8 @@ fun AImage(
             is String -> remember(imageData) {
                 ImageRequest.Builder(platformContext)
                     .data(imageData)
+                    .apply { if (loadOriginalSize) size(Size.ORIGINAL) }
+                    .precision(Precision.EXACT)
                     .crossfade(600)
                     .build()
             }

--- a/composeApp/src/commonMain/kotlin/presentation/compoments/AImage.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/AImage.kt
@@ -88,11 +88,15 @@ fun AImage(
     val isLoading = remember(imageData) { mutableStateOf(true) }
     val imageRequest: Any? =
         when (imageData) {
-            is String -> remember(imageData) {
+            is String -> remember(imageData, loadOriginalSize) {
                 ImageRequest.Builder(platformContext)
                     .data(imageData)
-                    .apply { if (loadOriginalSize) size(Size.ORIGINAL) }
-                    .precision(Precision.EXACT)
+                    .apply {
+                        if (loadOriginalSize) {
+                            size(Size.ORIGINAL)
+                            precision(Precision.EXACT)
+                        }
+                    }
                     .crossfade(600)
                     .build()
             }
@@ -121,4 +125,3 @@ fun AImage(
         onError = { isLoading.value = false }
     )
 }
-

--- a/composeApp/src/commonMain/kotlin/presentation/compoments/ProfileScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/ProfileScaffold.kt
@@ -191,9 +191,10 @@ private fun ProfileImage(
                         bottomStart = (ContactPointShape * ratio).dp,
                         bottomEnd = (ContactPointShape * ratio).dp
                     )
-                )
+            )
                 .blur(blurDp),
             imageData = imageUrl,
+            loadOriginalSize = true,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/presentation/compoments/SharedTransitionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/SharedTransitionScreen.kt
@@ -56,6 +56,9 @@ val LocalSharedSuffixKey: ProvidableCompositionLocal<String> =
 val LocalAnimatedVisibilityScope: ProvidableCompositionLocal<AnimatedVisibilityScope> =
     staticCompositionLocalOf { error("AnimatedVisibilityScope is not provided") }
 
+internal fun sharedContentKey(key: String, suffixKey: String, useSuffixKey: Boolean): String =
+    if (!useSuffixKey || suffixKey.isBlank()) key else "$key:$suffixKey"
+
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun Modifier.sharedElementBy(
@@ -71,7 +74,7 @@ fun Modifier.sharedElementBy(
     with(sharedTransitionScope) {
         val suffixKey = LocalSharedSuffixKey.current
         this@sharedElementBy.sharedElement(
-            sharedContentState = rememberSharedContentState(if (!useSuffixKey || suffixKey.isBlank())key else "$key:$suffixKey"),
+            sharedContentState = rememberSharedContentState(sharedContentKey(key, suffixKey, useSuffixKey)),
             animatedVisibilityScope = animatedVisibilityScope,
             boundsTransform = boundsTransform,
             renderInOverlayDuringTransition = renderInOverlayDuringTransition,
@@ -97,7 +100,7 @@ fun Modifier.sharedBoundsBy(
     with(sharedTransitionScope) {
         val suffixKey = LocalSharedSuffixKey.current
         this@sharedBoundsBy.sharedBounds(
-            sharedContentState = rememberSharedContentState(if (!useSuffixKey || suffixKey.isBlank())key else "$key:$suffixKey"),
+            sharedContentState = rememberSharedContentState(sharedContentKey(key, suffixKey, useSuffixKey)),
             animatedVisibilityScope = animatedVisibilityScope,
             resizeMode = resizeMode,
             boundsTransform = boundsTransform,
@@ -106,5 +109,4 @@ fun Modifier.sharedBoundsBy(
             clipInOverlayDuringTransition = clipInOverlayDuringTransition
         )
     }
-
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/avatar/AvatarProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/avatar/AvatarProfileScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -25,6 +26,7 @@ import cafe.adriel.voyager.koin.koinScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import io.github.vrcmteam.vrcm.core.extensions.toLocalDate
 import io.github.vrcmteam.vrcm.presentation.compoments.ATooltipBox
+import io.github.vrcmteam.vrcm.presentation.compoments.LocalSharedSuffixKey
 import io.github.vrcmteam.vrcm.presentation.compoments.ProfileScaffold
 import io.github.vrcmteam.vrcm.presentation.compoments.sharedBoundsBy
 import io.github.vrcmteam.vrcm.presentation.extensions.currentNavigator
@@ -55,16 +57,18 @@ class AvatarProfileScreen(
 
         val displayedAvatar = refreshedAvatar ?: avatarProfileVo
 
-        ProfileScaffold(
-            imageModifier = Modifier.sharedBoundsBy("${displayedAvatar.avatarId}AvatarImage"),
-            profileImageUrl = displayedAvatar.avatarImageUrl,
-            iconUrl = null,
-            onReturn = { navigator.pop() },
-        ) { ratio, contentMinHeight ->
-            AvatarProfileContent(
-                avatarProfileVo = displayedAvatar,
-                contentMinHeight = contentMinHeight,
-            )
+        CompositionLocalProvider(LocalSharedSuffixKey provides sharedSuffixKey) {
+            ProfileScaffold(
+                imageModifier = Modifier.sharedBoundsBy("${displayedAvatar.avatarId}AvatarImage"),
+                profileImageUrl = displayedAvatar.avatarImageUrl,
+                iconUrl = null,
+                onReturn = { navigator.pop() },
+            ) { ratio, contentMinHeight ->
+                AvatarProfileContent(
+                    avatarProfileVo = displayedAvatar,
+                    contentMinHeight = contentMinHeight,
+                )
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
@@ -13,6 +13,7 @@ import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteGroupData
 import io.github.vrcmteam.vrcm.network.api.friends.date.FriendData
 import io.github.vrcmteam.vrcm.network.api.avatars.AvatarsApi
 import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
+import io.github.vrcmteam.vrcm.network.api.files.FileApi
 import io.github.vrcmteam.vrcm.network.api.users.UsersApi
 import io.github.vrcmteam.vrcm.network.api.users.data.UserData
 import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
@@ -409,7 +410,7 @@ class FriendListPagerModel(
                 favorites = world.favorites ?: 0,
                 featured = world.featured == true,
                 heat = world.heat ?: 0,
-                imageUrl = world.imageUrl.orEmpty(),
+                imageUrl = FileApi.convertFileUrlToOriginal(world.imageUrl.orEmpty()),
                 labsPublicationDate = world.labsPublicationDate.orEmpty(),
                 organization = world.organization.orEmpty(),
                 popularity = world.popularity ?: 0,

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
@@ -13,7 +13,7 @@ import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteGroupData
 import io.github.vrcmteam.vrcm.network.api.friends.date.FriendData
 import io.github.vrcmteam.vrcm.network.api.avatars.AvatarsApi
 import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
-import io.github.vrcmteam.vrcm.network.api.files.FileApi
+import io.github.vrcmteam.vrcm.network.api.files.resolveOriginalImageUrl
 import io.github.vrcmteam.vrcm.network.api.users.UsersApi
 import io.github.vrcmteam.vrcm.network.api.users.data.UserData
 import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
@@ -397,41 +397,7 @@ class FriendListPagerModel(
         }.sortedWith(compareBy<FavoritedWorld> { it.id == "???" }.thenBy { it.name }) // 隐藏世界排到最后，再按名称排序
 
         // 将FavoritedWorld列表转换为WorldData列表
-        _worldList.value = filteredWorlds.map { world ->
-            WorldData(
-                id = world.id,
-                favoriteId = world.favoriteId,
-                name = world.name,
-                authorId = world.authorId.orEmpty(),
-                authorName = world.authorName.orEmpty(),
-                capacity = world.capacity ?: 0,
-                createdAt = world.createdAt.orEmpty(),
-                description = world.description.orEmpty(),
-                favorites = world.favorites ?: 0,
-                featured = world.featured == true,
-                heat = world.heat ?: 0,
-                imageUrl = FileApi.convertFileUrlToOriginal(world.imageUrl.orEmpty()),
-                labsPublicationDate = world.labsPublicationDate.orEmpty(),
-                organization = world.organization.orEmpty(),
-                popularity = world.popularity ?: 0,
-                publicationDate = world.publicationDate.orEmpty(),
-                recommendedCapacity = world.recommendedCapacity ?: 0,
-                releaseStatus = world.releaseStatus.orEmpty(),
-                tags = world.tags,
-                thumbnailImageUrl = world.thumbnailImageUrl.orEmpty(),
-                udonProducts = world.udonProducts,
-                unityPackages = world.unityPackages,
-                updatedAt = world.updatedAt.orEmpty(),
-                version = world.version ?: 0,
-                visits = world.visits ?: 0,
-                // 设置其他可能需要的字段
-                namespace = null,
-                privateOccupants = null,
-                publicOccupants = null,
-                instances = null,
-                previewYoutubeId = world.previewYoutubeId
-            )
-        }
+        _worldList.value = filteredWorlds.map { it.toSearchWorldData() }
     }
 
     /**
@@ -524,6 +490,39 @@ class FriendListPagerModel(
         }
     }
 }
+
+internal fun FavoritedWorld.toSearchWorldData(): WorldData = WorldData(
+    id = id,
+    favoriteId = favoriteId,
+    name = name,
+    authorId = authorId.orEmpty(),
+    authorName = authorName.orEmpty(),
+    capacity = capacity ?: 0,
+    createdAt = createdAt.orEmpty(),
+    description = description.orEmpty(),
+    favorites = favorites ?: 0,
+    featured = featured == true,
+    heat = heat ?: 0,
+    imageUrl = resolveOriginalImageUrl(imageUrl, thumbnailImageUrl).orEmpty(),
+    labsPublicationDate = labsPublicationDate.orEmpty(),
+    organization = organization.orEmpty(),
+    popularity = popularity ?: 0,
+    publicationDate = publicationDate.orEmpty(),
+    recommendedCapacity = recommendedCapacity ?: 0,
+    releaseStatus = releaseStatus.orEmpty(),
+    tags = tags,
+    thumbnailImageUrl = thumbnailImageUrl.orEmpty(),
+    udonProducts = udonProducts,
+    unityPackages = unityPackages,
+    updatedAt = updatedAt.orEmpty(),
+    version = version ?: 0,
+    visits = visits ?: 0,
+    namespace = null,
+    privateOccupants = null,
+    publicOccupants = null,
+    instances = null,
+    previewYoutubeId = previewYoutubeId,
+)
 
 
 private fun WorldData.toFavoritedWorldForLocal(localGroupName: String, wid: String): FavoritedWorld {

--- a/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreen.kt
@@ -598,6 +598,7 @@ private fun ColumnScope.ProfileContent(
     if (currentUser.isSelf) {
         UserCreatedAvatarsSection(
             avatars = createdAvatars,
+            sharedSuffixKey = sharedSuffixKey,
         )
     }
 
@@ -1040,7 +1041,8 @@ private class CardListDetailScreen(
                                 CardScreenType.AVATAR -> {
                                     item.avatarData?.let { avatar ->
                                         navigator push AvatarProfileScreen(
-                                            avatarProfileVo = AvatarProfileVo(avatar)
+                                            avatarProfileVo = AvatarProfileVo(avatar),
+                                            sharedSuffixKey = sharedSuffixKey,
                                         )
                                     }
                                 }
@@ -1193,6 +1195,7 @@ private fun UserCreatedWorldsSection(
 @Composable
 private fun UserCreatedAvatarsSection(
     avatars: List<AvatarData>,
+    sharedSuffixKey: String = "",
 ) {
     if (avatars.isEmpty()) return
     val navigator = currentNavigator
@@ -1214,7 +1217,8 @@ private fun UserCreatedAvatarsSection(
                 navigator push AvatarProfileScreen(
                     avatarProfileVo = AvatarProfileVo(
                         avatar.copy(imageUrl = originalImageUrl(avatar.imageUrl).orEmpty())
-                    )
+                    ),
+                    sharedSuffixKey = sharedSuffixKey,
                 )
             },
             onNavigateToDetail = { list ->
@@ -1230,7 +1234,8 @@ private fun UserCreatedAvatarsSection(
                         avatarData = it.copy(imageUrl = originalImageUrl(it.imageUrl).orEmpty())
                     ) },
                     sectionKey = createdAvatarsTitle,
-                    screenType = CardScreenType.AVATAR
+                    screenType = CardScreenType.AVATAR,
+                    sharedSuffixKey = sharedSuffixKey,
                 )
             }
         )

--- a/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreen.kt
@@ -74,11 +74,12 @@ internal class OneShotScrollRestorer(savedPosition: Int) {
     }
 }
 
-private fun originalImageUrl(imageUrl: String?): String? = imageUrl
-    ?.takeIf { it.isNotBlank() }
-    ?.let { url ->
-        if (FileApi.findFileId(url).isEmpty()) url else FileApi.convertFileUrlToOriginal(url)
-    }
+internal fun originalImageUrl(imageUrl: String?, thumbnailImageUrl: String?): String? =
+    (imageUrl?.takeIf { it.isNotBlank() }
+        ?: thumbnailImageUrl?.takeIf { it.isNotBlank() })
+        ?.let { url ->
+            if (FileApi.findFileId(url).isEmpty()) url else FileApi.convertFileUrlToOriginal(url)
+        }
 
 data class UserProfileScreen(
     private val userProfileVO: UserProfileVo,
@@ -585,7 +586,7 @@ private fun ColumnScope.ProfileContent(
             } else {
                 navigator push WorldProfileScreen(
                     worldProfileVO = WorldProfileVo(world).copy(
-                        worldImageUrl = originalImageUrl(world.imageUrl)
+                        worldImageUrl = originalImageUrl(world.imageUrl, world.thumbnailImageUrl)
                     ),
                     sharedSuffixKey = sharedSuffixKey,
                     sharedKeyPrefix = "Created_"
@@ -616,7 +617,7 @@ private fun ColumnScope.ProfileContent(
                     worldProfileVO = WorldProfileVo(
                         worldId = world.id,
                         worldName = world.name,
-                        worldImageUrl = originalImageUrl(world.imageUrl),
+                        worldImageUrl = originalImageUrl(world.imageUrl, world.thumbnailImageUrl),
                         thumbnailImageUrl = world.thumbnailImageUrl?.ifBlank { null },
                         worldDescription = world.description.orEmpty(),
                         authorID = world.authorId,
@@ -1157,7 +1158,7 @@ private fun UserCreatedWorldsSection(
         StackedLocationCardList(
             items = worlds,
             key = { it.id },
-            imageUrl = { originalImageUrl(it.imageUrl) },
+            imageUrl = { originalImageUrl(it.imageUrl, it.thumbnailImageUrl) },
             title = { it.name },
             subtitle = { it.description ?: "" },
             detailTitle = createdWorldsTitle,
@@ -1169,13 +1170,13 @@ private fun UserCreatedWorldsSection(
                     items = list.map { world ->
                         CardItemVo(
                             id = world.id,
-                            imageUrl = originalImageUrl(world.imageUrl),
+                            imageUrl = originalImageUrl(world.imageUrl, world.thumbnailImageUrl),
                             thumbnailUrl = null,
                             title = world.name,
                             subtitle = world.description ?: "",
                             authorName = world.authorName,
                             worldProfileVO = WorldProfileVo(world).copy(
-                                worldImageUrl = originalImageUrl(world.imageUrl)
+                                worldImageUrl = originalImageUrl(world.imageUrl, world.thumbnailImageUrl)
                             )
                         )
                     },
@@ -1208,7 +1209,7 @@ private fun UserCreatedAvatarsSection(
         StackedLocationCardList(
             items = avatars,
             key = { it.id },
-            imageUrl = { originalImageUrl(it.imageUrl) },
+            imageUrl = { originalImageUrl(it.imageUrl, it.thumbnailImageUrl) },
             title = { it.name },
             subtitle = { it.description ?: it.authorName },
             detailTitle = createdAvatarsTitle,
@@ -1216,7 +1217,12 @@ private fun UserCreatedAvatarsSection(
             onClickItem = { avatar ->
                 navigator push AvatarProfileScreen(
                     avatarProfileVo = AvatarProfileVo(
-                        avatar.copy(imageUrl = originalImageUrl(avatar.imageUrl).orEmpty())
+                        avatar.copy(
+                            imageUrl = originalImageUrl(
+                                avatar.imageUrl,
+                                avatar.thumbnailImageUrl,
+                            ).orEmpty()
+                        )
                     ),
                     sharedSuffixKey = sharedSuffixKey,
                 )
@@ -1226,12 +1232,14 @@ private fun UserCreatedAvatarsSection(
                     title = createdAvatarsTitle,
                     items = list.map { CardItemVo(
                         id = it.id,
-                        imageUrl = originalImageUrl(it.imageUrl),
+                        imageUrl = originalImageUrl(it.imageUrl, it.thumbnailImageUrl),
                         thumbnailUrl = null,
                         title = it.name,
                         subtitle = it.description?.takeIf { d -> d.isNotBlank() } ?: it.authorName,
                         authorName = it.authorName,
-                        avatarData = it.copy(imageUrl = originalImageUrl(it.imageUrl).orEmpty())
+                        avatarData = it.copy(
+                            imageUrl = originalImageUrl(it.imageUrl, it.thumbnailImageUrl).orEmpty()
+                        )
                     ) },
                     sectionKey = createdAvatarsTitle,
                     screenType = CardScreenType.AVATAR,
@@ -1267,7 +1275,7 @@ private fun UserFavoritedWorldsSection(
                 StackedLocationCardList(
                     items = worlds,
                     key = { it.favoriteId },
-                    imageUrl = { originalImageUrl(it.imageUrl) },
+                    imageUrl = { originalImageUrl(it.imageUrl, it.thumbnailImageUrl) },
                     title = { if (it.id == "???") it.favoriteId ?: it.name else it.name },
                     subtitle = { it.description?.takeIf { d -> d.isNotBlank() } ?: "${it.occupants ?: 0} 👤" },
                     detailTitle = groupName,
@@ -1285,7 +1293,7 @@ private fun UserFavoritedWorldsSection(
                                 CardItemVo(
                                     id = world.id,
                                     listKey = world.favoriteId,
-                                    imageUrl = originalImageUrl(world.imageUrl),
+                                    imageUrl = originalImageUrl(world.imageUrl, world.thumbnailImageUrl),
                                     thumbnailUrl = null,
                                     title = if (world.id == "???") world.favoriteId ?: world.name else world.name,
                                     subtitle = world.description?.takeIf { d -> d.isNotBlank() } ?: "${world.occupants ?: 0} 👤",
@@ -1293,7 +1301,10 @@ private fun UserFavoritedWorldsSection(
                                     worldProfileVO = WorldProfileVo(
                                         worldId = world.id,
                                         worldName = world.name,
-                                        worldImageUrl = originalImageUrl(world.imageUrl),
+                                        worldImageUrl = originalImageUrl(
+                                            world.imageUrl,
+                                            world.thumbnailImageUrl,
+                                        ),
                                         thumbnailImageUrl = world.thumbnailImageUrl?.ifBlank { null },
                                         worldDescription = world.description.orEmpty(),
                                         authorID = world.authorId,

--- a/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreen.kt
@@ -30,7 +30,7 @@ import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.getAppPlatform
 import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
 import io.github.vrcmteam.vrcm.network.api.attributes.FriendRequestStatus.*
-import io.github.vrcmteam.vrcm.network.api.files.FileApi
+import io.github.vrcmteam.vrcm.network.api.files.resolveOriginalImageUrl
 import io.github.vrcmteam.vrcm.presentation.compoments.*
 import io.github.vrcmteam.vrcm.presentation.compoments.isHiddenWorld
 import io.github.vrcmteam.vrcm.presentation.compoments.ToastText
@@ -73,13 +73,6 @@ internal class OneShotScrollRestorer(savedPosition: Int) {
         return position
     }
 }
-
-internal fun originalImageUrl(imageUrl: String?, thumbnailImageUrl: String?): String? =
-    (imageUrl?.takeIf { it.isNotBlank() }
-        ?: thumbnailImageUrl?.takeIf { it.isNotBlank() })
-        ?.let { url ->
-            if (FileApi.findFileId(url).isEmpty()) url else FileApi.convertFileUrlToOriginal(url)
-        }
 
 data class UserProfileScreen(
     private val userProfileVO: UserProfileVo,
@@ -586,7 +579,7 @@ private fun ColumnScope.ProfileContent(
             } else {
                 navigator push WorldProfileScreen(
                     worldProfileVO = WorldProfileVo(world).copy(
-                        worldImageUrl = originalImageUrl(world.imageUrl, world.thumbnailImageUrl)
+                        worldImageUrl = resolveOriginalImageUrl(world.imageUrl, world.thumbnailImageUrl)
                     ),
                     sharedSuffixKey = sharedSuffixKey,
                     sharedKeyPrefix = "Created_"
@@ -617,7 +610,7 @@ private fun ColumnScope.ProfileContent(
                     worldProfileVO = WorldProfileVo(
                         worldId = world.id,
                         worldName = world.name,
-                        worldImageUrl = originalImageUrl(world.imageUrl, world.thumbnailImageUrl),
+                        worldImageUrl = resolveOriginalImageUrl(world.imageUrl, world.thumbnailImageUrl),
                         thumbnailImageUrl = world.thumbnailImageUrl?.ifBlank { null },
                         worldDescription = world.description.orEmpty(),
                         authorID = world.authorId,
@@ -1158,7 +1151,7 @@ private fun UserCreatedWorldsSection(
         StackedLocationCardList(
             items = worlds,
             key = { it.id },
-            imageUrl = { originalImageUrl(it.imageUrl, it.thumbnailImageUrl) },
+            imageUrl = { resolveOriginalImageUrl(it.imageUrl, it.thumbnailImageUrl) },
             title = { it.name },
             subtitle = { it.description ?: "" },
             detailTitle = createdWorldsTitle,
@@ -1170,13 +1163,13 @@ private fun UserCreatedWorldsSection(
                     items = list.map { world ->
                         CardItemVo(
                             id = world.id,
-                            imageUrl = originalImageUrl(world.imageUrl, world.thumbnailImageUrl),
+                            imageUrl = resolveOriginalImageUrl(world.imageUrl, world.thumbnailImageUrl),
                             thumbnailUrl = null,
                             title = world.name,
                             subtitle = world.description ?: "",
                             authorName = world.authorName,
                             worldProfileVO = WorldProfileVo(world).copy(
-                                worldImageUrl = originalImageUrl(world.imageUrl, world.thumbnailImageUrl)
+                                worldImageUrl = resolveOriginalImageUrl(world.imageUrl, world.thumbnailImageUrl)
                             )
                         )
                     },
@@ -1209,7 +1202,7 @@ private fun UserCreatedAvatarsSection(
         StackedLocationCardList(
             items = avatars,
             key = { it.id },
-            imageUrl = { originalImageUrl(it.imageUrl, it.thumbnailImageUrl) },
+            imageUrl = { resolveOriginalImageUrl(it.imageUrl, it.thumbnailImageUrl) },
             title = { it.name },
             subtitle = { it.description ?: it.authorName },
             detailTitle = createdAvatarsTitle,
@@ -1218,7 +1211,7 @@ private fun UserCreatedAvatarsSection(
                 navigator push AvatarProfileScreen(
                     avatarProfileVo = AvatarProfileVo(
                         avatar.copy(
-                            imageUrl = originalImageUrl(
+                            imageUrl = resolveOriginalImageUrl(
                                 avatar.imageUrl,
                                 avatar.thumbnailImageUrl,
                             ).orEmpty()
@@ -1232,13 +1225,13 @@ private fun UserCreatedAvatarsSection(
                     title = createdAvatarsTitle,
                     items = list.map { CardItemVo(
                         id = it.id,
-                        imageUrl = originalImageUrl(it.imageUrl, it.thumbnailImageUrl),
+                        imageUrl = resolveOriginalImageUrl(it.imageUrl, it.thumbnailImageUrl),
                         thumbnailUrl = null,
                         title = it.name,
                         subtitle = it.description?.takeIf { d -> d.isNotBlank() } ?: it.authorName,
                         authorName = it.authorName,
                         avatarData = it.copy(
-                            imageUrl = originalImageUrl(it.imageUrl, it.thumbnailImageUrl).orEmpty()
+                            imageUrl = resolveOriginalImageUrl(it.imageUrl, it.thumbnailImageUrl).orEmpty()
                         )
                     ) },
                     sectionKey = createdAvatarsTitle,
@@ -1275,7 +1268,7 @@ private fun UserFavoritedWorldsSection(
                 StackedLocationCardList(
                     items = worlds,
                     key = { it.favoriteId },
-                    imageUrl = { originalImageUrl(it.imageUrl, it.thumbnailImageUrl) },
+                    imageUrl = { resolveOriginalImageUrl(it.imageUrl, it.thumbnailImageUrl) },
                     title = { if (it.id == "???") it.favoriteId ?: it.name else it.name },
                     subtitle = { it.description?.takeIf { d -> d.isNotBlank() } ?: "${it.occupants ?: 0} 👤" },
                     detailTitle = groupName,
@@ -1293,7 +1286,7 @@ private fun UserFavoritedWorldsSection(
                                 CardItemVo(
                                     id = world.id,
                                     listKey = world.favoriteId,
-                                    imageUrl = originalImageUrl(world.imageUrl, world.thumbnailImageUrl),
+                                    imageUrl = resolveOriginalImageUrl(world.imageUrl, world.thumbnailImageUrl),
                                     thumbnailUrl = null,
                                     title = if (world.id == "???") world.favoriteId ?: world.name else world.name,
                                     subtitle = world.description?.takeIf { d -> d.isNotBlank() } ?: "${world.occupants ?: 0} 👤",
@@ -1301,7 +1294,7 @@ private fun UserFavoritedWorldsSection(
                                     worldProfileVO = WorldProfileVo(
                                         worldId = world.id,
                                         worldName = world.name,
-                                        worldImageUrl = originalImageUrl(
+                                        worldImageUrl = resolveOriginalImageUrl(
                                             world.imageUrl,
                                             world.thumbnailImageUrl,
                                         ),

--- a/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreen.kt
@@ -30,6 +30,7 @@ import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.getAppPlatform
 import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
 import io.github.vrcmteam.vrcm.network.api.attributes.FriendRequestStatus.*
+import io.github.vrcmteam.vrcm.network.api.files.FileApi
 import io.github.vrcmteam.vrcm.presentation.compoments.*
 import io.github.vrcmteam.vrcm.presentation.compoments.isHiddenWorld
 import io.github.vrcmteam.vrcm.presentation.compoments.ToastText
@@ -72,6 +73,12 @@ internal class OneShotScrollRestorer(savedPosition: Int) {
         return position
     }
 }
+
+private fun originalImageUrl(imageUrl: String?): String? = imageUrl
+    ?.takeIf { it.isNotBlank() }
+    ?.let { url ->
+        if (FileApi.findFileId(url).isEmpty()) url else FileApi.convertFileUrlToOriginal(url)
+    }
 
 data class UserProfileScreen(
     private val userProfileVO: UserProfileVo,
@@ -577,7 +584,9 @@ private fun ColumnScope.ProfileContent(
                 }
             } else {
                 navigator push WorldProfileScreen(
-                    worldProfileVO = WorldProfileVo(world),
+                    worldProfileVO = WorldProfileVo(world).copy(
+                        worldImageUrl = originalImageUrl(world.imageUrl)
+                    ),
                     sharedSuffixKey = sharedSuffixKey,
                     sharedKeyPrefix = "Created_"
                 )
@@ -606,7 +615,7 @@ private fun ColumnScope.ProfileContent(
                     worldProfileVO = WorldProfileVo(
                         worldId = world.id,
                         worldName = world.name,
-                        worldImageUrl = world.imageUrl?.ifBlank { null },
+                        worldImageUrl = originalImageUrl(world.imageUrl),
                         thumbnailImageUrl = world.thumbnailImageUrl?.ifBlank { null },
                         worldDescription = world.description.orEmpty(),
                         authorID = world.authorId,
@@ -997,14 +1006,15 @@ private class CardListDetailScreen(
                         itemTitle = { it.title },
                         itemSubtitle = { it.subtitle },
                         sectionKey = sectionKey,
-                        imageModifier = if (screenType == CardScreenType.WORLD || screenType == CardScreenType.FAVORITED_WORLD) {
-                            { item, modifier ->
+                        imageModifier = when (screenType) {
+                            CardScreenType.WORLD, CardScreenType.FAVORITED_WORLD -> { item, modifier ->
                                 worldImageSharedKey(sharedKeyPrefix, item.id)
                                     ?.let { modifier.sharedBoundsBy(it) }
                                     ?: modifier
                             }
-                        } else {
-                            { _, m -> m }
+                            CardScreenType.AVATAR -> { item, modifier ->
+                                modifier.sharedBoundsBy("${item.id}AvatarImage")
+                            }
                         },
                         onClickItem = { item ->
                             when (screenType) {
@@ -1145,7 +1155,7 @@ private fun UserCreatedWorldsSection(
         StackedLocationCardList(
             items = worlds,
             key = { it.id },
-            imageUrl = { it.thumbnailImageUrl ?: it.imageUrl },
+            imageUrl = { originalImageUrl(it.imageUrl) },
             title = { it.name },
             subtitle = { it.description ?: "" },
             detailTitle = createdWorldsTitle,
@@ -1157,12 +1167,14 @@ private fun UserCreatedWorldsSection(
                     items = list.map { world ->
                         CardItemVo(
                             id = world.id,
-                            imageUrl = world.thumbnailImageUrl ?: world.imageUrl,
-                            thumbnailUrl = world.thumbnailImageUrl,
+                            imageUrl = originalImageUrl(world.imageUrl),
+                            thumbnailUrl = null,
                             title = world.name,
                             subtitle = world.description ?: "",
                             authorName = world.authorName,
-                            worldProfileVO = WorldProfileVo(world)
+                            worldProfileVO = WorldProfileVo(world).copy(
+                                worldImageUrl = originalImageUrl(world.imageUrl)
+                            )
                         )
                     },
                     sectionKey = createdWorldsTitle,
@@ -1193,13 +1205,16 @@ private fun UserCreatedAvatarsSection(
         StackedLocationCardList(
             items = avatars,
             key = { it.id },
-            imageUrl = { it.thumbnailImageUrl ?: it.imageUrl },
+            imageUrl = { originalImageUrl(it.imageUrl) },
             title = { it.name },
             subtitle = { it.description ?: it.authorName },
             detailTitle = createdAvatarsTitle,
+            imageModifier = { item, modifier -> modifier.sharedBoundsBy("${item.id}AvatarImage") },
             onClickItem = { avatar ->
                 navigator push AvatarProfileScreen(
-                    avatarProfileVo = AvatarProfileVo(avatar)
+                    avatarProfileVo = AvatarProfileVo(
+                        avatar.copy(imageUrl = originalImageUrl(avatar.imageUrl).orEmpty())
+                    )
                 )
             },
             onNavigateToDetail = { list ->
@@ -1207,12 +1222,12 @@ private fun UserCreatedAvatarsSection(
                     title = createdAvatarsTitle,
                     items = list.map { CardItemVo(
                         id = it.id,
-                        imageUrl = it.thumbnailImageUrl ?: it.imageUrl,
-                        thumbnailUrl = it.thumbnailImageUrl,
+                        imageUrl = originalImageUrl(it.imageUrl),
+                        thumbnailUrl = null,
                         title = it.name,
                         subtitle = it.description?.takeIf { d -> d.isNotBlank() } ?: it.authorName,
                         authorName = it.authorName,
-                        avatarData = it
+                        avatarData = it.copy(imageUrl = originalImageUrl(it.imageUrl).orEmpty())
                     ) },
                     sectionKey = createdAvatarsTitle,
                     screenType = CardScreenType.AVATAR
@@ -1247,7 +1262,7 @@ private fun UserFavoritedWorldsSection(
                 StackedLocationCardList(
                     items = worlds,
                     key = { it.favoriteId },
-                    imageUrl = { (it.thumbnailImageUrl ?: it.imageUrl)?.ifBlank { null } },
+                    imageUrl = { originalImageUrl(it.imageUrl) },
                     title = { if (it.id == "???") it.favoriteId ?: it.name else it.name },
                     subtitle = { it.description?.takeIf { d -> d.isNotBlank() } ?: "${it.occupants ?: 0} 👤" },
                     detailTitle = groupName,
@@ -1265,15 +1280,15 @@ private fun UserFavoritedWorldsSection(
                                 CardItemVo(
                                     id = world.id,
                                     listKey = world.favoriteId,
-                                    imageUrl = (world.thumbnailImageUrl ?: world.imageUrl)?.ifBlank { null },
-                                    thumbnailUrl = world.thumbnailImageUrl?.ifBlank { null },
+                                    imageUrl = originalImageUrl(world.imageUrl),
+                                    thumbnailUrl = null,
                                     title = if (world.id == "???") world.favoriteId ?: world.name else world.name,
                                     subtitle = world.description?.takeIf { d -> d.isNotBlank() } ?: "${world.occupants ?: 0} 👤",
                                     authorName = world.authorName ?: "",
                                     worldProfileVO = WorldProfileVo(
                                         worldId = world.id,
                                         worldName = world.name,
-                                        worldImageUrl = world.imageUrl?.ifBlank { null },
+                                        worldImageUrl = originalImageUrl(world.imageUrl),
                                         thumbnailImageUrl = world.thumbnailImageUrl?.ifBlank { null },
                                         worldDescription = world.description.orEmpty(),
                                         authorID = world.authorId,

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
@@ -431,8 +431,9 @@ private fun RenderBackgroundImage(
             .sharedBoundsBy(
                 key = sharedKeyPrefix + worldId + "WorldImage",
                 renderInOverlayDuringTransition = false
-            ),
+        ),
         imageData = imageUrl,
+        loadOriginalSize = true,
     )
 }
 

--- a/composeApp/src/commonTest/kotlin/network/api/files/ImageUrlResolverTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/api/files/ImageUrlResolverTest.kt
@@ -1,15 +1,15 @@
-package io.github.vrcmteam.vrcm.presentation.screens.user
+package io.github.vrcmteam.vrcm.network.api.files
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
-class UserProfileImageUrlTest {
+class ImageUrlResolverTest {
     @Test
     fun nullImageUsesAvailableThumbnail() {
         assertEquals(
             "https://example.com/thumbnail.png",
-            originalImageUrl(
+            resolveOriginalImageUrl(
                 imageUrl = null,
                 thumbnailImageUrl = "https://example.com/thumbnail.png",
             ),
@@ -20,7 +20,7 @@ class UserProfileImageUrlTest {
     fun blankImageUsesThumbnailAndRestoresItsOriginalFileUrl() {
         assertEquals(
             "https://api.vrchat.cloud/api/1/file/file_thumbnail-only/7/file",
-            originalImageUrl(
+            resolveOriginalImageUrl(
                 imageUrl = "",
                 thumbnailImageUrl =
                     "https://api.vrchat.cloud/api/1/image/file_thumbnail-only/7/256",
@@ -32,7 +32,7 @@ class UserProfileImageUrlTest {
     fun availableImageTakesPriorityOverThumbnail() {
         assertEquals(
             "https://example.com/image.png",
-            originalImageUrl(
+            resolveOriginalImageUrl(
                 imageUrl = "https://example.com/image.png",
                 thumbnailImageUrl = "https://example.com/thumbnail.png",
             ),
@@ -43,7 +43,7 @@ class UserProfileImageUrlTest {
     fun availableFileImageIsRestoredBeforeThumbnailFallback() {
         assertEquals(
             "https://api.vrchat.cloud/api/1/file/file_primary/3/file",
-            originalImageUrl(
+            resolveOriginalImageUrl(
                 imageUrl = "https://api.vrchat.cloud/api/1/image/file_primary/3/256",
                 thumbnailImageUrl = "https://example.com/thumbnail.png",
             ),
@@ -52,6 +52,6 @@ class UserProfileImageUrlTest {
 
     @Test
     fun missingImageAndThumbnailReturnNull() {
-        assertNull(originalImageUrl(imageUrl = "", thumbnailImageUrl = null))
+        assertNull(resolveOriginalImageUrl(imageUrl = "", thumbnailImageUrl = null))
     }
 }

--- a/composeApp/src/commonTest/kotlin/presentation/compoments/SharedTransitionKeyTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/compoments/SharedTransitionKeyTest.kt
@@ -1,0 +1,30 @@
+package io.github.vrcmteam.vrcm.presentation.compoments
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SharedTransitionKeyTest {
+    @Test
+    fun nonBlankSuffixDistinguishesTheSharedContentKey() {
+        assertEquals(
+            "avtr_exampleAvatarImage:Search",
+            sharedContentKey(
+                key = "avtr_exampleAvatarImage",
+                suffixKey = "Search",
+                useSuffixKey = true,
+            ),
+        )
+    }
+
+    @Test
+    fun disabledSuffixKeepsTheBaseSharedContentKey() {
+        assertEquals(
+            "avtr_exampleAvatarImage",
+            sharedContentKey(
+                key = "avtr_exampleAvatarImage",
+                suffixKey = "Search",
+                useSuffixKey = false,
+            ),
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FavoritedWorldSearchMappingTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FavoritedWorldSearchMappingTest.kt
@@ -1,0 +1,27 @@
+package io.github.vrcmteam.vrcm.presentation.screens.home.pager
+
+import io.github.vrcmteam.vrcm.network.api.worlds.data.FavoritedWorld
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FavoritedWorldSearchMappingTest {
+    @Test
+    fun thumbnailOnlyFavoriteKeepsAUsableWorldImage() {
+        val world = FavoritedWorld(
+            id = "wrld_thumbnail_only",
+            name = "Thumbnail only",
+            imageUrl = null,
+            thumbnailImageUrl =
+                "https://api.vrchat.cloud/api/1/image/file_thumbnail-only/7/256",
+            favoriteId = "fvrt_thumbnail_only",
+            favoriteGroup = "worlds1",
+        )
+
+        val mapped = world.toSearchWorldData()
+
+        assertEquals(
+            "https://api.vrchat.cloud/api/1/file/file_thumbnail-only/7/file",
+            mapped.imageUrl,
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/presentation/screens/user/UserProfileImageUrlTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/user/UserProfileImageUrlTest.kt
@@ -1,0 +1,57 @@
+package io.github.vrcmteam.vrcm.presentation.screens.user
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class UserProfileImageUrlTest {
+    @Test
+    fun nullImageUsesAvailableThumbnail() {
+        assertEquals(
+            "https://example.com/thumbnail.png",
+            originalImageUrl(
+                imageUrl = null,
+                thumbnailImageUrl = "https://example.com/thumbnail.png",
+            ),
+        )
+    }
+
+    @Test
+    fun blankImageUsesThumbnailAndRestoresItsOriginalFileUrl() {
+        assertEquals(
+            "https://api.vrchat.cloud/api/1/file/file_thumbnail-only/7/file",
+            originalImageUrl(
+                imageUrl = "",
+                thumbnailImageUrl =
+                    "https://api.vrchat.cloud/api/1/image/file_thumbnail-only/7/256",
+            ),
+        )
+    }
+
+    @Test
+    fun availableImageTakesPriorityOverThumbnail() {
+        assertEquals(
+            "https://example.com/image.png",
+            originalImageUrl(
+                imageUrl = "https://example.com/image.png",
+                thumbnailImageUrl = "https://example.com/thumbnail.png",
+            ),
+        )
+    }
+
+    @Test
+    fun availableFileImageIsRestoredBeforeThumbnailFallback() {
+        assertEquals(
+            "https://api.vrchat.cloud/api/1/file/file_primary/3/file",
+            originalImageUrl(
+                imageUrl = "https://api.vrchat.cloud/api/1/image/file_primary/3/256",
+                thumbnailImageUrl = "https://example.com/thumbnail.png",
+            ),
+        )
+    }
+
+    @Test
+    fun missingImageAndThumbnailReturnNull() {
+        assertNull(originalImageUrl(imageUrl = "", thumbnailImageUrl = null))
+    }
+}


### PR DESCRIPTION
- 收藏、创建世界与创建模型列表统一请求 file 原图
- 详情页封面按原始尺寸解码，避免共享动画首帧尺寸导致低清缓存复用
- 为创建模型列表补充封面共享元素动画