### PR TITLE
回退社区气泡轮廓隔离，恢复重叠效果

### DIFF
--- a/composeApp/src/commonMain/kotlin/core/algorithms/ConvexHull.kt
+++ b/composeApp/src/commonMain/kotlin/core/algorithms/ConvexHull.kt
@@ -1,7 +1,6 @@
 package io.github.vrcmteam.vrcm.core.algorithms
 
 import androidx.compose.ui.geometry.Offset
-import kotlin.math.sqrt
 
 /**
  * Andrew 单调链凸包
@@ -33,28 +32,4 @@ fun convexHull(points: List<Offset>): List<Offset> {
     lower.removeAt(lower.size - 1)
     upper.removeAt(upper.size - 1)
     return lower + upper
-}
-
-/**
- * 排除会把社区轮廓拉进圈间走廊的离群成员，只保留空间核心点。
- */
-fun filterCorePoints(points: List<Offset>, factor: Float = 1.8f, minRadius: Float = 0f): List<Offset> {
-    if (points.size < 4) return points
-    var centerX = 0f
-    var centerY = 0f
-    points.forEach {
-        centerX += it.x
-        centerY += it.y
-    }
-    centerX /= points.size
-    centerY /= points.size
-    val distances = points.map { point ->
-        val dx = point.x - centerX
-        val dy = point.y - centerY
-        sqrt(dx * dx + dy * dy)
-    }
-    val median = distances.sorted()[distances.size / 2]
-    val threshold = maxOf(median * factor, minRadius)
-    val core = points.filterIndexed { index, _ -> distances[index] <= threshold }
-    return if (core.size >= 3) core else points
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/user/FriendNetworkScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/user/FriendNetworkScreen.kt
@@ -55,8 +55,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.PathFillType
-import androidx.compose.ui.graphics.PathOperation
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
@@ -76,7 +76,6 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import io.github.vrcmteam.vrcm.core.algorithms.ForceLayoutResult
 import io.github.vrcmteam.vrcm.core.algorithms.convexHull
-import io.github.vrcmteam.vrcm.core.algorithms.filterCorePoints
 import io.github.vrcmteam.vrcm.network.api.users.data.MutualFriendData
 import io.github.vrcmteam.vrcm.presentation.compoments.ABottomSheet
 import io.github.vrcmteam.vrcm.presentation.compoments.UserStateIcon
@@ -606,66 +605,34 @@ private fun FriendNetworkGraph(
         }
         // 真实社区的凸包气泡（扩张到头像外约 46dp）
         val hullPaddingPx = with(density) { 46.dp.toPx() }
-        val hullOutlineWidthPx = with(density) { 1.5.dp.toPx() }
+        val hullStrokeWidthPx = with(density) { 24.dp.toPx() }
         val hullPaths = remember(layout, communities, isEgoView) {
             if (isEgoView) return@remember emptyList()
-            val raw = communities.entries
+            communities.entries
                 .filter { it.value != FriendNetworkScreenModel.OTHER_COMMUNITY_ID }
                 .groupBy({ it.value }, { it.key })
-                .entries
-                .sortedBy { it.key }
                 .mapNotNull { (communityId, members) ->
                     val points = members.mapNotNull { positions[it] }
                     if (points.size < 3) return@mapNotNull null
-                    val corePoints = filterCorePoints(points, minRadius = hullPaddingPx)
-                    val hull = convexHull(corePoints)
-                    if (hull.size < 3) return@mapNotNull null
+                    val hull = convexHull(points)
+                    if (hull.size < 2) return@mapNotNull null
                     var centerX = 0f
                     var centerY = 0f
-                    corePoints.forEach { centerX += it.x; centerY += it.y }
-                    centerX /= corePoints.size
-                    centerY /= corePoints.size
-                    val expanded = hull.map { p ->
+                    points.forEach { centerX += it.x; centerY += it.y }
+                    centerX /= points.size
+                    centerY /= points.size
+                    val path = Path()
+                    hull.forEachIndexed { index, p ->
                         val dx = p.x - centerX
                         val dy = p.y - centerY
                         val len = sqrt(dx * dx + dy * dy)
-                        if (len > 0f) {
-                            Offset(p.x + dx / len * hullPaddingPx, p.y + dy / len * hullPaddingPx)
-                        } else {
-                            p
-                        }
-                    }
-                    val path = Path()
-                    val count = expanded.size
-                    path.moveTo(
-                        (expanded[0].x + expanded[1].x) / 2f,
-                        (expanded[0].y + expanded[1].y) / 2f,
-                    )
-                    for (index in 1..count) {
-                        val vertex = expanded[index % count]
-                        val next = expanded[(index + 1) % count]
-                        path.quadraticBezierTo(
-                            vertex.x,
-                            vertex.y,
-                            (vertex.x + next.x) / 2f,
-                            (vertex.y + next.y) / 2f,
-                        )
+                        val ex = if (len > 0f) p.x + dx / len * hullPaddingPx else p.x
+                        val ey = if (len > 0f) p.y + dy / len * hullPaddingPx else p.y
+                        if (index == 0) path.moveTo(ex, ey) else path.lineTo(ex, ey)
                     }
                     path.close()
                     HullPathData(communityId, FriendNetworkScreenModel.colorOfCommunity(communityId), path)
                 }
-            val clipped = mutableListOf<HullPathData>()
-            var occupied: Path? = null
-            raw.forEach { hull ->
-                val visible = occupied?.let {
-                    Path.combine(PathOperation.Difference, hull.path, it)
-                } ?: hull.path
-                clipped.add(HullPathData(hull.communityId, hull.color, visible))
-                occupied = occupied?.let {
-                    Path.combine(PathOperation.Union, it, hull.path)
-                } ?: hull.path
-            }
-            clipped
         }
         val viewCenter = Offset(viewWidthPx / 2f, viewHeightPx / 2f)
         val layoutCenter = Offset(layoutWidthPx / 2f, layoutHeightPx / 2f)
@@ -870,7 +837,7 @@ private fun FriendNetworkGraph(
                         drawPath(
                             path = hull.path,
                             color = hull.color.copy(alpha = strokeAlpha),
-                            style = Stroke(width = hullOutlineWidthPx)
+                            style = Stroke(width = hullStrokeWidthPx, join = StrokeJoin.Round)
                         )
                     }
 

--- a/composeApp/src/commonTest/kotlin/core/algorithms/ConvexHullTest.kt
+++ b/composeApp/src/commonTest/kotlin/core/algorithms/ConvexHullTest.kt
@@ -27,36 +27,6 @@ class ConvexHullTest {
     }
 
     @Test
-    fun corePointsFilterDropsCorridorStraddler() {
-        val cluster = listOf(
-            Offset(0f, 0f),
-            Offset(10f, 0f),
-            Offset(0f, 10f),
-            Offset(10f, 10f),
-            Offset(5f, 5f),
-        )
-        val corridorNode = Offset(300f, 300f)
-
-        val core = filterCorePoints(cluster + corridorNode)
-
-        assertEquals(cluster.toSet(), core.toSet())
-    }
-
-    @Test
-    fun corePointsFilterKeepsTightCommunityIntact() {
-        val cluster = listOf(
-            Offset(0f, 0f),
-            Offset(10f, 0f),
-            Offset(0f, 10f),
-            Offset(10f, 10f),
-            Offset(20f, 5f),
-        )
-
-        assertEquals(cluster, filterCorePoints(cluster, minRadius = 100f))
-        assertEquals(cluster.take(3), filterCorePoints(cluster.take(3)))
-    }
-
-    @Test
     fun tinyInputsPassThrough() {
         assertEquals(0, convexHull(emptyList()).size)
         assertEquals(1, convexHull(listOf(Offset(1f, 2f))).size)


### PR DESCRIPTION
回退 `7eed1d5`「隔离相邻社区气泡轮廓」，恢复社区气泡的重叠效果。

原提交为了避免相邻社区混色，做了两件事：凸包排除走廊离群成员、按社区顺序 `Path.combine` 扣除已占区域。实测下来重叠的观感更好（气泡边界互相交叠更符合社交圈子的实际关系），因此整体回退。

回退后：
- 气泡凸包重新包含社区全部成员（含被拉到走廊的骑墙者）
- 不再做差集扣除，相邻社区气泡自然重叠
- 一并移除 `filterCorePoints` 及其测试

desktop 全量测试通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)