### PR TITLE
fix(boop): boop通知正确显示好友头像，按钮功能恢复正常

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreenModel.kt
@@ -135,7 +135,7 @@ class HomeScreenModel(
     ) {
         when (item.responseTarget(action)) {
             NotificationResponseTarget.BOOP_USER_API -> {
-                item.linkedUserId?.let { boopUser(it, boopSuccessMessage, boopAlreadySentMessage) }
+                item.senderId?.let { boopUser(it, boopSuccessMessage, boopAlreadySentMessage) }
                 return
             }
             NotificationResponseTarget.NOTIFICATION_API -> Unit
@@ -234,7 +234,6 @@ class HomeScreenModel(
 
 
 }
-
 
 
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreenModel.kt
@@ -15,7 +15,11 @@ import io.github.vrcmteam.vrcm.network.api.users.data.UpdateUserInfoData
 import io.github.vrcmteam.vrcm.network.supports.VRCApiException
 import io.github.vrcmteam.vrcm.presentation.compoments.ToastText
 import io.github.vrcmteam.vrcm.presentation.extensions.onApiFailure
+import io.github.vrcmteam.vrcm.presentation.screens.home.data.BoopNotificationResolver
 import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationItemData
+import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationResponseTarget
+import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationUserPresentation
+import io.github.vrcmteam.vrcm.presentation.screens.home.data.responseTarget
 import io.github.vrcmteam.vrcm.presentation.screens.home.pager.FriendLocationPagerModel
 import io.github.vrcmteam.vrcm.service.AuthService
 import io.github.vrcmteam.vrcm.service.FriendService
@@ -33,6 +37,8 @@ class HomeScreenModel(
     private val friendLocationPagerModel: FriendLocationPagerModel,
     private val logger: Logger,
 ) : ScreenModel {
+
+    private val boopNotificationResolver = BoopNotificationResolver()
 
     private val _currentUser = mutableStateOf<CurrentUserData?>(null)
 
@@ -100,22 +106,22 @@ class HomeScreenModel(
         screenModelScope.launch(Dispatchers.IO) {
             authService.reTryAuthCatching { notificationApi.fetchNotifications() }
                 .onHomeFailure()
-                .onSuccess {
-                    _notifications.value = it.map { data ->
-                        val notification = NotificationItemData(data)
-                        val targetUserId = notification.linkedUserId
-                        if (data.type == "boop" && targetUserId != null) {
-                            runCatching { usersApi.fetchUser(targetUserId) }
-                                .getOrNull()
-                                ?.let { user ->
-                                    notification.copy(
-                                        imageUrl = user.profileImageUrl,
-                                        title = notification.title ?: user.displayName,
-                                    )
-                                }
-                                ?: notification
-                        } else {
-                            notification
+                .onSuccess { data ->
+                    val friendPresentations = friendService.friendMap.mapValues { (_, friend) ->
+                        NotificationUserPresentation(
+                            imageUrl = friend.profileImageUrl,
+                            displayName = friend.displayName,
+                        )
+                    }
+                    _notifications.value = boopNotificationResolver.resolve(
+                        notifications = data.map(::NotificationItemData),
+                        friends = friendPresentations,
+                    ) { userId ->
+                        usersApi.fetchUser(userId).let { user ->
+                            NotificationUserPresentation(
+                                imageUrl = user.profileImageUrl,
+                                displayName = user.displayName,
+                            )
                         }
                     }
                 }
@@ -127,9 +133,12 @@ class HomeScreenModel(
         boopSuccessMessage: String,
         boopAlreadySentMessage: String,
     ) {
-        if (item.type == "boop" && action.type.equals("reply", ignoreCase = true)) {
-            item.linkedUserId?.let { boopUser(it, boopSuccessMessage, boopAlreadySentMessage) }
-            return
+        when (item.responseTarget(action)) {
+            NotificationResponseTarget.BOOP_USER_API -> {
+                item.linkedUserId?.let { boopUser(it, boopSuccessMessage, boopAlreadySentMessage) }
+                return
+            }
+            NotificationResponseTarget.NOTIFICATION_API -> Unit
         }
 
         val id = item.id
@@ -225,7 +234,6 @@ class HomeScreenModel(
 
 
 }
-
 
 
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreenModel.kt
@@ -12,6 +12,7 @@ import io.github.vrcmteam.vrcm.network.api.auth.data.CurrentUserData
 import io.github.vrcmteam.vrcm.network.api.notification.NotificationApi
 import io.github.vrcmteam.vrcm.network.api.users.UsersApi
 import io.github.vrcmteam.vrcm.network.api.users.data.UpdateUserInfoData
+import io.github.vrcmteam.vrcm.network.supports.VRCApiException
 import io.github.vrcmteam.vrcm.presentation.compoments.ToastText
 import io.github.vrcmteam.vrcm.presentation.extensions.onApiFailure
 import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationItemData
@@ -77,6 +78,7 @@ class HomeScreenModel(
                                 message = user.displayName,
                                 createdAt = data.createdAt,
                                 senderUserId = data.senderUserId,
+                                link = "user:${data.senderUserId}",
                                 type = data.type.value,
                                 actions = listOf(
                                     NotificationItemData.ActionData(
@@ -100,12 +102,38 @@ class HomeScreenModel(
                 .onHomeFailure()
                 .onSuccess {
                     _notifications.value = it.map { data ->
-                        NotificationItemData(data)
+                        val notification = NotificationItemData(data)
+                        val targetUserId = notification.linkedUserId
+                        if (data.type == "boop" && targetUserId != null) {
+                            runCatching { usersApi.fetchUser(targetUserId) }
+                                .getOrNull()
+                                ?.let { user ->
+                                    notification.copy(
+                                        imageUrl = user.profileImageUrl,
+                                        title = notification.title ?: user.displayName,
+                                    )
+                                }
+                                ?: notification
+                        } else {
+                            notification
+                        }
                     }
                 }
         }
 
-    fun responseAllNotification(id: String, type: String, action: NotificationItemData.ActionData) {
+    fun responseAllNotification(
+        item: NotificationItemData,
+        action: NotificationItemData.ActionData,
+        boopSuccessMessage: String,
+        boopAlreadySentMessage: String,
+    ) {
+        if (item.type == "boop" && action.type.equals("reply", ignoreCase = true)) {
+            item.linkedUserId?.let { boopUser(it, boopSuccessMessage, boopAlreadySentMessage) }
+            return
+        }
+
+        val id = item.id
+        val type = item.type
         if (type == NotificationType.FriendRequest.value) {
             responseFriendRequest(id, action)
         } else {
@@ -123,6 +151,22 @@ class HomeScreenModel(
 
     private fun responseNotification(id: String, response: NotificationItemData.ActionData) = notificationAction {
         notificationApi.responseNotification(id, response)
+    }
+
+    private fun boopUser(userId: String, successMessage: String, alreadySentMessage: String) {
+        screenModelScope.launch(Dispatchers.IO) {
+            authService.reTryAuthCatching { usersApi.boop(userId) }
+                .onSuccess {
+                    SharedFlowCentre.toastText.emit(ToastText.Success(successMessage))
+                }
+                .onFailure { error ->
+                    if (error is VRCApiException && error.code == 429) {
+                        SharedFlowCentre.toastText.emit(ToastText.Info(alreadySentMessage))
+                    } else {
+                        Result.failure<Unit>(error).onHomeFailure()
+                    }
+                }
+        }
     }
 
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/data/BoopNotificationResolver.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/data/BoopNotificationResolver.kt
@@ -1,0 +1,76 @@
+package io.github.vrcmteam.vrcm.presentation.screens.home.data
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
+
+internal data class NotificationUserPresentation(
+    val imageUrl: String,
+    val displayName: String,
+)
+
+internal class BoopNotificationResolver(
+    maxConcurrentFetches: Int = 4,
+) {
+    private val fallbackSemaphore = Semaphore(maxConcurrentFetches)
+    private val fallbackCacheLock = Mutex()
+    private val fallbackCache = mutableMapOf<String, NotificationUserPresentation>()
+
+    init {
+        require(maxConcurrentFetches > 0)
+    }
+
+    suspend fun resolve(
+        notifications: List<NotificationItemData>,
+        friends: Map<String, NotificationUserPresentation>,
+        fetchUser: suspend (String) -> NotificationUserPresentation,
+    ): List<NotificationItemData> {
+        val cachedFallbacks = fallbackCacheLock.withLock { fallbackCache.toMap() }
+        val missingUserIds = notifications.asSequence()
+            .filter { it.type == "boop" }
+            .mapNotNull { it.linkedUserId }
+            .distinct()
+            .filterNot { it in friends || it in cachedFallbacks }
+            .toList()
+
+        val fetchedFallbacks = coroutineScope {
+            missingUserIds.map { userId ->
+                async {
+                    fetchFallback(userId, fetchUser)?.let { userId to it }
+                }
+            }.awaitAll().filterNotNull().toMap()
+        }
+        if (fetchedFallbacks.isNotEmpty()) {
+            fallbackCacheLock.withLock { fallbackCache.putAll(fetchedFallbacks) }
+        }
+
+        val presentations = cachedFallbacks + fetchedFallbacks + friends
+        return notifications.map { notification ->
+            if (notification.type != "boop") return@map notification
+            val presentation = notification.linkedUserId?.let(presentations::get)
+                ?: return@map notification
+            notification.copy(
+                imageUrl = presentation.imageUrl,
+                title = notification.title ?: presentation.displayName,
+            )
+        }
+    }
+
+    private suspend fun fetchFallback(
+        userId: String,
+        fetchUser: suspend (String) -> NotificationUserPresentation,
+    ): NotificationUserPresentation? = fallbackSemaphore.withPermit {
+        try {
+            fetchUser(userId)
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/data/BoopNotificationResolver.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/data/BoopNotificationResolver.kt
@@ -33,7 +33,7 @@ internal class BoopNotificationResolver(
         val cachedFallbacks = fallbackCacheLock.withLock { fallbackCache.toMap() }
         val missingUserIds = notifications.asSequence()
             .filter { it.type == "boop" }
-            .mapNotNull { it.linkedUserId }
+            .mapNotNull { it.senderId }
             .distinct()
             .filterNot { it in friends || it in cachedFallbacks }
             .toList()
@@ -52,7 +52,7 @@ internal class BoopNotificationResolver(
         val presentations = cachedFallbacks + fetchedFallbacks + friends
         return notifications.map { notification ->
             if (notification.type != "boop") return@map notification
-            val presentation = notification.linkedUserId?.let(presentations::get)
+            val presentation = notification.senderId?.let(presentations::get)
                 ?: return@map notification
             notification.copy(
                 imageUrl = presentation.imageUrl,

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/data/NotificationItemData.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/data/NotificationItemData.kt
@@ -13,6 +13,10 @@ data class NotificationItemData(
     val type: String,
     val actions: List<ActionData>
 ) {
+    /** The notification sender used by sender-specific actions such as opening a profile or replying to a Boop. */
+    val senderId: String?
+        get() = senderUserId.trim().takeIf { it.isNotEmpty() }
+
     /** The VRChat user targeted by a `user:usr_...` notification link. */
     val linkedUserId: String?
         get() = link

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/data/NotificationItemData.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/data/NotificationItemData.kt
@@ -22,7 +22,8 @@ data class NotificationItemData(
 
     data class ActionData(
         val data: String,
-        val type: String
+        val type: String,
+        val icon: String = "",
     )
 
     constructor(n: NotificationData) : this(
@@ -37,9 +38,24 @@ data class NotificationItemData(
         actions = n.responses.map { responses ->
             ActionData(
                 data = responses.responseData,
-                type = responses.type
+                type = responses.type,
+                icon = responses.icon,
             )
         }
     )
 
 }
+
+internal enum class NotificationResponseTarget {
+    BOOP_USER_API,
+    NOTIFICATION_API,
+}
+
+internal fun NotificationItemData.responseTarget(
+    action: NotificationItemData.ActionData,
+): NotificationResponseTarget =
+    if (type == "boop" && action.icon.equals("reply", ignoreCase = true)) {
+        NotificationResponseTarget.BOOP_USER_API
+    } else {
+        NotificationResponseTarget.NOTIFICATION_API
+    }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/data/NotificationItemData.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/data/NotificationItemData.kt
@@ -9,9 +9,17 @@ data class NotificationItemData(
     val message: String,
     val createdAt: String,
     val senderUserId: String,
+    val link: String?,
     val type: String,
     val actions: List<ActionData>
 ) {
+    /** The VRChat user targeted by a `user:usr_...` notification link. */
+    val linkedUserId: String?
+        get() = link
+            ?.takeIf { it.startsWith("user:") }
+            ?.removePrefix("user:")
+            ?.takeIf { it.isNotBlank() }
+
     data class ActionData(
         val data: String,
         val type: String
@@ -24,6 +32,7 @@ data class NotificationItemData(
         message = n.message,
         createdAt = n.createdAt,
         senderUserId = n.senderUserId.orEmpty(),
+        link = n.link,
         type = n.type,
         actions = n.responses.map { responses ->
             ActionData(

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/dialog/NotificationDialog.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/dialog/NotificationDialog.kt
@@ -105,6 +105,7 @@ private fun LazyItemScope.NotificationItem(
     var isExpand by remember { mutableStateOf(false) }
     var respondedAction by remember { mutableStateOf<NotificationItemData.ActionData?>(null) }
     val isFriendRequest = item.type == NotificationType.FriendRequest.value
+    val senderId = item.senderId.orEmpty()
     val linkedUserId = item.linkedUserId.orEmpty()
     val contentText = if (isFriendRequest) "${item.message} ${strings.notificationFriendRequest}" else item.message
     val navigator = LocalNavigator.currentOrThrow
@@ -123,15 +124,15 @@ private fun LazyItemScope.NotificationItem(
             ) {
                 AImage(
                     modifier = Modifier
-                        .enableIf(linkedUserId.isNotEmpty()) {
+                        .enableIf(senderId.isNotEmpty()) {
                             this.clickable {
                                 navigator push UserProfileScreen(
                                     userProfileVO = UserProfileVo(
-                                        id = linkedUserId,
+                                        id = senderId,
                                         profileImageUrl = item.imageUrl
                                     )
                                 )
-                            }.sharedBoundsBy("${linkedUserId}UserIcon")
+                            }.sharedBoundsBy("${senderId}UserIcon")
                         }
                         .size(120.dp, 80.dp)
                         .background(MaterialTheme.colorScheme.surfaceContainerHighest, MaterialTheme.shapes.medium)

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/dialog/NotificationDialog.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/dialog/NotificationDialog.kt
@@ -52,8 +52,15 @@ object NotificationDialog : SharedDialog {
                     .sortedByDescending { it.createdAt }
             }
         }
-        val onResponseNotification: (String, String, NotificationItemData.ActionData) -> Unit = { id, type, response ->
-            homeScreenModel.responseAllNotification(id, type, response)
+        val boopSuccessMessage = strings.profileBoopSuccess
+        val boopAlreadySentMessage = strings.profileBoopAlreadySent
+        val onResponseNotification: (NotificationItemData, NotificationItemData.ActionData) -> Unit = { item, response ->
+            homeScreenModel.responseAllNotification(
+                item = item,
+                action = response,
+                boopSuccessMessage = boopSuccessMessage,
+                boopAlreadySentMessage = boopAlreadySentMessage,
+            )
         }
 
         AnimatedContent(
@@ -93,11 +100,12 @@ object NotificationDialog : SharedDialog {
 @Composable
 private fun LazyItemScope.NotificationItem(
     item: NotificationItemData,
-    onResponse: (String, String, NotificationItemData.ActionData) -> Unit,
+    onResponse: (NotificationItemData, NotificationItemData.ActionData) -> Unit,
 ) {
     var isExpand by remember { mutableStateOf(false) }
-    var responded by remember { mutableStateOf(false) }
+    var respondedAction by remember { mutableStateOf<NotificationItemData.ActionData?>(null) }
     val isFriendRequest = item.type == NotificationType.FriendRequest.value
+    val linkedUserId = item.linkedUserId.orEmpty()
     val contentText = if (isFriendRequest) "${item.message} ${strings.notificationFriendRequest}" else item.message
     val navigator = LocalNavigator.currentOrThrow
     Box(
@@ -115,15 +123,15 @@ private fun LazyItemScope.NotificationItem(
             ) {
                 AImage(
                     modifier = Modifier
-                        .enableIf(isFriendRequest) {
+                        .enableIf(linkedUserId.isNotEmpty()) {
                             this.clickable {
                                 navigator push UserProfileScreen(
                                     userProfileVO = UserProfileVo(
-                                        id = item.senderUserId,
+                                        id = linkedUserId,
                                         profileImageUrl = item.imageUrl
                                     )
                                 )
-                            }.sharedBoundsBy("${item.senderUserId}UserIcon")
+                            }.sharedBoundsBy("${linkedUserId}UserIcon")
                         }
                         .size(120.dp, 80.dp)
                         .background(MaterialTheme.colorScheme.surfaceContainerHighest, MaterialTheme.shapes.medium)
@@ -173,13 +181,22 @@ private fun LazyItemScope.NotificationItem(
                 item.actions.forEach { action ->
                     FilledTonalButton(
                         modifier = Modifier.animateContentSize(),
-                        enabled = !responded,
+                        enabled = respondedAction != action,
                         colors = ButtonDefaults.outlinedButtonColors(
                             containerColor = MaterialTheme.colorScheme.tertiaryContainer,
                         ),
                         onClick = {
-                            responded = true
-                            onResponse(item.id, item.type, action)
+                            if (action.type.equals("link", ignoreCase = true) && linkedUserId.isNotEmpty()) {
+                                navigator push UserProfileScreen(
+                                    userProfileVO = UserProfileVo(
+                                        id = linkedUserId,
+                                        profileImageUrl = item.imageUrl
+                                    )
+                                )
+                            } else {
+                                respondedAction = action
+                                onResponse(item, action)
+                            }
                         }
                     ) {
                         Text(

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
@@ -257,6 +257,7 @@ sealed class LocaleStrings {
     open val userMutualGroups: String = "Mutual Groups"
     open val profileBoop: String = "Boop"
     open val profileBoopSuccess: String = "Boop sent"
+    open val profileBoopAlreadySent: String = "Already booped"
     open val profileInviteToMyInstance: String = "Invite to My Instance"
     open val profileInviteSent: String = "Invite sent"
     open val profileInviteNotInInstance: String = "You are not in an instance"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
@@ -245,6 +245,7 @@ internal object LocaleStringsJa : LocaleStrings() {
     override val userMutualGroups = "共通グループ"
     override val profileBoop = "Boop"
     override val profileBoopSuccess = "Boopを送信しました"
+    override val profileBoopAlreadySent = "すでにBoopを送信しています"
     override val profileInviteToMyInstance = "自分のインスタンスに招待"
     override val profileInviteSent = "招待を送信しました"
     override val profileInviteNotInInstance = "現在インスタンスに参加していません"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
@@ -245,6 +245,7 @@ internal object LocaleStringsZhHans : LocaleStrings() {
     override val userMutualGroups = "共同群组"
     override val profileBoop = "戳一下"
     override val profileBoopSuccess = "已戳一下"
+    override val profileBoopAlreadySent = "已经戳过了"
     override val profileInviteToMyInstance = "邀请来我的房间"
     override val profileInviteSent = "邀请已发送"
     override val profileInviteNotInInstance = "你当前不在任何房间中"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
@@ -245,6 +245,7 @@ internal object LocaleStringsZhHant : LocaleStrings() {
     override val userMutualGroups = "共同群組"
     override val profileBoop = "戳一下"
     override val profileBoopSuccess = "已戳一下"
+    override val profileBoopAlreadySent = "已經戳過了"
     override val profileInviteToMyInstance = "邀請來我的房間"
     override val profileInviteSent = "邀請已發送"
     override val profileInviteNotInInstance = "你當前不在任何房間中"

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/data/BoopNotificationResolverTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/data/BoopNotificationResolverTest.kt
@@ -1,0 +1,130 @@
+package io.github.vrcmteam.vrcm.presentation.screens.home.data
+
+import io.github.vrcmteam.vrcm.network.api.notification.data.NotificationData
+import io.github.vrcmteam.vrcm.network.api.notification.data.ResponseData
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class BoopNotificationResolverTest {
+    @Test
+    fun realBoopReplyTargetsUsersApi() {
+        val item = NotificationItemData(
+            notification(
+                responses = listOf(
+                    ResponseData(
+                        responseData = "",
+                        icon = "reply",
+                        text = "Boop back",
+                        textKey = "notification.boop.reply",
+                        type = "boop",
+                    )
+                )
+            )
+        )
+
+        assertEquals("reply", item.actions.single().icon)
+        assertEquals(
+            NotificationResponseTarget.BOOP_USER_API,
+            item.responseTarget(item.actions.single()),
+        )
+    }
+
+    @Test
+    fun duplicateSenderUsesOneFallbackRequestAndCachesIt() = runTest {
+        val resolver = BoopNotificationResolver()
+        val notifications = listOf(boop("first"), boop("second"))
+        var fetchCount = 0
+
+        val firstResult = resolver.resolve(notifications, friends = emptyMap()) {
+            fetchCount++
+            NotificationUserPresentation("https://example.com/avatar.png", "Sender")
+        }
+        val secondResult = resolver.resolve(notifications, friends = emptyMap()) {
+            fetchCount++
+            error("cached sender should not be fetched again")
+        }
+
+        assertEquals(1, fetchCount)
+        assertEquals(List(2) { "https://example.com/avatar.png" }, firstResult.map { it.imageUrl })
+        assertEquals(firstResult, secondResult)
+    }
+
+    @Test
+    fun friendSnapshotAvoidsFallbackRequest() = runTest {
+        val resolver = BoopNotificationResolver()
+        var fetchCount = 0
+
+        val result = resolver.resolve(
+            notifications = listOf(boop("cached")),
+            friends = mapOf(
+                "usr_sender" to NotificationUserPresentation(
+                    imageUrl = "https://example.com/friend.png",
+                    displayName = "Cached Friend",
+                )
+            ),
+        ) {
+            fetchCount++
+            error("friend cache hit should not use the network")
+        }
+
+        assertEquals(0, fetchCount)
+        assertEquals("https://example.com/friend.png", result.single().imageUrl)
+        assertEquals("Cached Friend", result.single().title)
+    }
+
+    @Test
+    fun fallbackCancellationIsPropagated() = runTest {
+        val resolver = BoopNotificationResolver()
+
+        assertFailsWith<CancellationException> {
+            resolver.resolve(listOf(boop("cancelled")), friends = emptyMap()) {
+                throw CancellationException("cancel refresh")
+            }
+        }
+    }
+
+    private fun boop(id: String) = NotificationItemData(
+        id = id,
+        imageUrl = "",
+        title = null,
+        message = "sent you a boop",
+        createdAt = "2026-07-30T00:00:00Z",
+        senderUserId = "usr_sender",
+        link = "user:usr_sender",
+        type = "boop",
+        actions = emptyList(),
+    )
+
+    private fun notification(responses: List<ResponseData>) = NotificationData(
+        canDelete = true,
+        category = "social",
+        createdAt = "2026-07-30T00:00:00Z",
+        data = NotificationData.Data(announcementTitle = null, groupName = null),
+        expiresAt = "2026-08-30T00:00:00Z",
+        expiryAfterSeen = null,
+        id = "notification",
+        ignoreDND = false,
+        imageUrl = null,
+        isSystem = false,
+        link = "user:usr_sender",
+        linkText = null,
+        linkTextKey = null,
+        message = "sent you a boop",
+        messageKey = null,
+        receiverUserId = "usr_receiver",
+        relatedNotificationsId = null,
+        requireSeen = false,
+        responses = responses,
+        seen = false,
+        senderUserId = "usr_sender",
+        senderUsername = "Sender",
+        title = null,
+        titleKey = null,
+        type = "boop",
+        updatedAt = "2026-07-30T00:00:00Z",
+        version = 2,
+    )
+}

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/data/BoopNotificationResolverTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/data/BoopNotificationResolverTest.kt
@@ -13,6 +13,7 @@ class BoopNotificationResolverTest {
     fun realBoopReplyTargetsUsersApi() {
         val item = NotificationItemData(
             notification(
+                link = null,
                 responses = listOf(
                     ResponseData(
                         responseData = "",
@@ -26,10 +27,34 @@ class BoopNotificationResolverTest {
         )
 
         assertEquals("reply", item.actions.single().icon)
+        assertEquals("usr_sender", item.senderId)
         assertEquals(
             NotificationResponseTarget.BOOP_USER_API,
             item.responseTarget(item.actions.single()),
         )
+    }
+
+    @Test
+    fun senderUserIdEnrichesBoopWithNonUserLink() = runTest {
+        val resolver = BoopNotificationResolver()
+        val item = boop(id = "generic-link", link = "world:wrld_example")
+
+        val result = resolver.resolve(
+            notifications = listOf(item),
+            friends = mapOf(
+                "usr_sender" to NotificationUserPresentation(
+                    imageUrl = "https://example.com/sender.png",
+                    displayName = "Sender",
+                )
+            ),
+        ) {
+            error("sender in friend snapshot should not use the network")
+        }
+
+        assertEquals("usr_sender", item.senderId)
+        assertEquals(null, item.linkedUserId)
+        assertEquals("https://example.com/sender.png", result.single().imageUrl)
+        assertEquals("Sender", result.single().title)
     }
 
     @Test
@@ -86,19 +111,25 @@ class BoopNotificationResolverTest {
         }
     }
 
-    private fun boop(id: String) = NotificationItemData(
+    private fun boop(
+        id: String,
+        link: String? = null,
+    ) = NotificationItemData(
         id = id,
         imageUrl = "",
         title = null,
         message = "sent you a boop",
         createdAt = "2026-07-30T00:00:00Z",
         senderUserId = "usr_sender",
-        link = "user:usr_sender",
+        link = link,
         type = "boop",
         actions = emptyList(),
     )
 
-    private fun notification(responses: List<ResponseData>) = NotificationData(
+    private fun notification(
+        link: String?,
+        responses: List<ResponseData>,
+    ) = NotificationData(
         canDelete = true,
         category = "social",
         createdAt = "2026-07-30T00:00:00Z",
@@ -109,7 +140,7 @@ class BoopNotificationResolverTest {
         ignoreDND = false,
         imageUrl = null,
         isSystem = false,
-        link = "user:usr_sender",
+        link = link,
         linkText = null,
         linkTextKey = null,
         message = "sent you a boop",


### PR DESCRIPTION
## 变更说明

- Boop 通知使用 `senderUserId` 对应的用户资料补全头像，并支持点击头像进入发送者资料。
- 回复按钮按 VRChat V2 的 `type=boop`、`icon=reply` 载荷调用 Boop API，回复对象取自 `senderUserId`。
- 通知补全优先读取好友快照；仅对去重后的缓存缺失用户执行最多 4 路并发查询，并缓存成功结果。
- 通知 `link` 仅用于 `link` 类型动作的导航，不再承担发送者身份。

## 验证

- `./gradlew :composeApp:desktopTest`
- `./gradlew :composeApp:assembleDebug`

## 代码逻辑图

```mermaid
flowchart TD
    A[HomeScreenModel.refreshNotifications] --> B[NotificationApi.fetchNotifications]
    B --> C[NotificationItemData]
    C --> P[NotificationItemData.senderId from senderUserId]
    P --> D[BoopNotificationResolver.resolve]
    E[FriendService.friendMap snapshot] --> D
    D -->|distinct cache misses, max 4 concurrent| F[UsersApi.fetchUser]
    F --> G[BoopNotificationResolver fallbackCache]
    D --> H[HomeScreenModel notifications state]
    H --> I[NotificationDialog]
    I -->|avatar click uses senderId| U[UserProfileScreen]
    I -->|link action uses linkedUserId| U
    I -->|response action| J[HomeScreenModel.responseAllNotification]
    J --> K{NotificationItemData.responseTarget}
    K -->|boop reply uses senderId| L[UsersApi.boop]
    K -->|other response| M{friendRequest}
    M -->|yes| N[NotificationApi.acceptFriendRequest or deleteNotification]
    M -->|no| O[NotificationApi.responseNotification]
```