### PR TITLE
fix(print): 完整显示图片并避免上传后崩溃

### DIFF
--- a/composeApp/src/androidUnitTest/kotlin/presentation/screens/gallery/editor/AndroidPlatformImageCodecTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/presentation/screens/gallery/editor/AndroidPlatformImageCodecTest.kt
@@ -496,6 +496,11 @@ private fun expectedGradientAtOutput(
     val translatedY = outputY + 0.5 - transform.translateY
     val sourceX = (transform.scaleY * translatedX - transform.skewX * translatedY) / determinant
     val sourceY = (-transform.skewY * translatedX + transform.scaleX * translatedY) / determinant
+    if (sourceX < 0.0 || sourceX >= request.originalSize.width ||
+        sourceY < 0.0 || sourceY >= request.originalSize.height
+    ) {
+        return Color.TRANSPARENT
+    }
     return gradientColor(sourceX - 0.5, sourceY - 0.5, request.originalSize)
 }
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/CropTransformCalculator.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/CropTransformCalculator.kt
@@ -1,6 +1,6 @@
 package io.github.vrcmteam.vrcm.presentation.screens.gallery.editor
 
-import kotlin.math.max
+import kotlin.math.min
 
 class CropTransformCalculator(
     private val maxZoom: Float = 3f,
@@ -16,13 +16,13 @@ class CropTransformCalculator(
         val turns = normalizeTurns(transform.quarterTurns)
         val rotatedWidth = if (turns % 2 == 0) source.width.toFloat() else source.height.toFloat()
         val rotatedHeight = if (turns % 2 == 0) source.height.toFloat() else source.width.toFloat()
-        val coverScale = max(
+        val fitScale = min(
             viewport.width / rotatedWidth,
             viewport.height / rotatedHeight,
         )
         val zoom = transform.zoom.coerceIn(1f, maxZoom)
-        val imageWidth = rotatedWidth * coverScale * zoom
-        val imageHeight = rotatedHeight * coverScale * zoom
+        val imageWidth = rotatedWidth * fitScale * zoom
+        val imageHeight = rotatedHeight * fitScale * zoom
         val maxTranslationX = ((imageWidth - viewport.width) / 2f).coerceAtLeast(0f)
         val maxTranslationY = ((imageHeight - viewport.height) / 2f).coerceAtLeast(0f)
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/CropTransformCalculator.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/CropTransformCalculator.kt
@@ -1,10 +1,32 @@
 package io.github.vrcmteam.vrcm.presentation.screens.gallery.editor
 
+import kotlin.math.max
 import kotlin.math.min
 
 class CropTransformCalculator(
-    private val maxZoom: Float = 3f,
+    private val maxCoverZoomMultiplier: Float = 3f,
 ) {
+    fun zoomLimits(
+        source: ImageSize,
+        viewport: ImageSize,
+        quarterTurns: Int,
+    ): CropZoomLimits {
+        require(source.width > 0 && source.height > 0) { "Source dimensions must be positive" }
+        require(viewport.width > 0 && viewport.height > 0) { "Viewport dimensions must be positive" }
+
+        val turns = normalizeTurns(quarterTurns)
+        val rotatedWidth = if (turns % 2 == 0) source.width.toFloat() else source.height.toFloat()
+        val rotatedHeight = if (turns % 2 == 0) source.height.toFloat() else source.width.toFloat()
+        val widthScale = viewport.width / rotatedWidth
+        val heightScale = viewport.height / rotatedHeight
+        val coverZoom = max(widthScale, heightScale) / min(widthScale, heightScale)
+        return CropZoomLimits(
+            minimum = 1f,
+            cover = coverZoom,
+            maximum = coverZoom * maxCoverZoomMultiplier,
+        )
+    }
+
     fun geometry(
         source: ImageSize,
         viewport: ImageSize,
@@ -20,7 +42,8 @@ class CropTransformCalculator(
             viewport.width / rotatedWidth,
             viewport.height / rotatedHeight,
         )
-        val zoom = transform.zoom.coerceIn(1f, maxZoom)
+        val zoomLimits = zoomLimits(source, viewport, turns)
+        val zoom = transform.zoom.coerceIn(zoomLimits.minimum, zoomLimits.maximum)
         val imageWidth = rotatedWidth * fitScale * zoom
         val imageHeight = rotatedHeight * fitScale * zoom
         val maxTranslationX = ((imageWidth - viewport.width) / 2f).coerceAtLeast(0f)
@@ -52,7 +75,7 @@ class CropTransformCalculator(
         transform = current.copy(
             centerOffsetX = current.centerOffsetX + panX / viewport.width,
             centerOffsetY = current.centerOffsetY + panY / viewport.height,
-            zoom = (current.zoom * zoomChange).coerceIn(1f, maxZoom),
+            zoom = current.zoom * zoomChange,
             quarterTurns = normalizeTurns(current.quarterTurns),
         ),
     )
@@ -82,13 +105,22 @@ class CropTransformCalculator(
         transform: CropTransform,
     ): CropTransform {
         val geometry = geometry(source, viewport, transform)
+        val zoomLimits = zoomLimits(source, viewport, transform.quarterTurns)
         return transform.copy(
             centerOffsetX = geometry.translationX / viewport.width,
             centerOffsetY = geometry.translationY / viewport.height,
-            zoom = transform.zoom.coerceIn(1f, maxZoom),
+            zoom = transform.zoom.coerceIn(zoomLimits.minimum, zoomLimits.maximum),
             quarterTurns = normalizeTurns(transform.quarterTurns),
         )
     }
 
     private fun normalizeTurns(turns: Int): Int = ((turns % 4) + 4) % 4
+}
+
+data class CropZoomLimits(
+    val minimum: Float,
+    val cover: Float,
+    val maximum: Float,
+) {
+    val valueRange: ClosedFloatingPointRange<Float> get() = minimum..maximum
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PreviewBitmapReleaseController.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PreviewBitmapReleaseController.kt
@@ -1,0 +1,35 @@
+package io.github.vrcmteam.vrcm.presentation.screens.gallery.editor
+
+import androidx.compose.ui.graphics.ImageBitmap
+
+internal class PreviewBitmapReleaseController(
+    private val bitmap: ImageBitmap,
+    private val releaseBitmap: (ImageBitmap) -> Unit,
+) {
+    private var displayLeaseCount = 0
+    private var disposalRequested = false
+    private var released = false
+
+    fun acquireDisplayLease() {
+        check(!released) { "Preview bitmap is already released" }
+        displayLeaseCount++
+    }
+
+    fun releaseDisplayLease() {
+        check(displayLeaseCount > 0) { "Preview display lease is not held" }
+        displayLeaseCount--
+        releaseIfUnused()
+    }
+
+    fun dispose() {
+        if (disposalRequested) return
+        disposalRequested = true
+        releaseIfUnused()
+    }
+
+    private fun releaseIfUnused() {
+        if (!disposalRequested || displayLeaseCount != 0 || released) return
+        released = true
+        releaseBitmap(bitmap)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -104,6 +105,10 @@ class PrintImageEditorScreen(
 
         val screenModel: PrintImageEditorScreenModel = koinScreenModel {
             parametersOf(sessionId)
+        }
+        DisposableEffect(screenModel) {
+            screenModel.acquirePreviewDisplayLease()
+            onDispose(screenModel::releasePreviewDisplayLease)
         }
         val state by screenModel.state.collectAsState()
         val snackbarHostState = remember { SnackbarHostState() }
@@ -222,7 +227,7 @@ private fun PrintEditorContent(
                     .width(cropWidth)
                     .aspectRatio(16f / 9f)
                     .clip(RoundedCornerShape(4.dp))
-                    .background(Color.Black),
+                    .background(Color.White),
             ) {
                 PrintCropPreview(
                     state = state,

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreen.kt
@@ -277,6 +277,15 @@ private fun PrintEditorContent(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
+                    val zoomRange = if (viewport.isValid()) {
+                        calculator.zoomLimits(
+                            source = state.prepared.originalSize,
+                            viewport = viewport,
+                            quarterTurns = state.transform.quarterTurns,
+                        ).valueRange
+                    } else {
+                        1f..3f
+                    }
                     Text(
                         text = locale.printEditorZoom,
                         style = MaterialTheme.typography.labelLarge,
@@ -288,7 +297,7 @@ private fun PrintEditorContent(
                         },
                         modifier = Modifier.weight(1f),
                         enabled = !state.isBusy && viewport.isValid(),
-                        valueRange = 1f..3f,
+                        valueRange = zoomRange,
                     )
                 }
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreenModel.kt
@@ -73,15 +73,19 @@ class PrintImageEditorScreenModel(
 
     private var cachedPng: ByteArray? = null
     private var cachedFileName: String? = null
-    private var previewReleased = false
+    private val previewReleaseController = PreviewBitmapReleaseController(
+        bitmap = prepared.preview,
+        releaseBitmap = releasePreview,
+    )
 
     override fun onDispose() {
         sessionStore.discard(sessionId)
-        if (!previewReleased) {
-            previewReleased = true
-            releasePreview(_state.value.prepared.preview)
-        }
+        previewReleaseController.dispose()
     }
+
+    fun acquirePreviewDisplayLease() = previewReleaseController.acquireDisplayLease()
+
+    fun releasePreviewDisplayLease() = previewReleaseController.releaseDisplayLease()
 
     fun panAndZoom(
         viewport: ImageSize,

--- a/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/CropRenderPlannerTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/CropRenderPlannerTest.kt
@@ -12,7 +12,7 @@ class CropRenderPlannerTest {
     private val planner = CropRenderPlanner(calculator)
 
     @Test
-    fun resetLandscapeCropMapsCenterAndVisibleSourceBounds() {
+    fun resetLandscapeFitMapsWholeImageIntoOutputCenter() {
         val plan = planner.plan(
             CropRenderRequest(
                 originalSize = ImageSize(2_400, 1_080),
@@ -22,13 +22,13 @@ class CropRenderPlannerTest {
         )
 
         assertPointEquals(AffinePoint(960.0, 540.0), plan.sourceToOutput.map(1_200.0, 540.0))
-        assertEquals(PixelRect(240, 0, 2_160, 1_080), plan.visibleSourceBounds)
+        assertEquals(PixelRect(0, 0, 2_400, 1_080), plan.visibleSourceBounds)
         assertEquals(ImageSize(1_920, 1_080), plan.outputSize)
     }
 
     @Test
     fun highZoomSelectsOnlySmallSourceRegion() {
-        val source = ImageSize(6_000, 12_000)
+        val source = ImageSize(6_000, 6_000)
         val bounds = planner.plan(
             CropRenderRequest(
                 originalSize = source,
@@ -37,8 +37,8 @@ class CropRenderPlannerTest {
             ),
         ).visibleSourceBounds
 
-        assertTrue(bounds.width <= 2_100)
-        assertTrue(bounds.height <= 1_200)
+        assertTrue(bounds.width <= 3_600)
+        assertTrue(bounds.height <= 2_100)
         assertInsideSource(bounds, source)
     }
 
@@ -104,7 +104,7 @@ class CropRenderPlannerTest {
             ),
             actual = plan.sourceToOutput.map(source.width / 2.0, source.height / 2.0),
         )
-        assertEquals(PixelRect(1_390, 333, 2_329, 2_000), expectedBounds)
+        assertEquals(PixelRect(555, 0, 2_778, 3_000), expectedBounds)
         assertEquals(expectedBounds, plan.visibleSourceBounds)
         assertInsideSource(plan.visibleSourceBounds, source)
     }
@@ -151,8 +151,8 @@ class CropRenderPlannerTest {
             flipVertical = true,
         )
         val geometry = calculator.geometry(source, output, transform)
-        val maxTranslationX = (geometry.imageWidth - output.width) / 2f
-        val maxTranslationY = (geometry.imageHeight - output.height) / 2f
+        val maxTranslationX = ((geometry.imageWidth - output.width) / 2f).coerceAtLeast(0f)
+        val maxTranslationY = ((geometry.imageHeight - output.height) / 2f).coerceAtLeast(0f)
 
         val plan = planner.plan(CropRenderRequest(source, transform, output))
         val expectedBounds = visibleSourceBoundsFromReturnedAffine(
@@ -170,7 +170,7 @@ class CropRenderPlannerTest {
             ),
             actual = plan.sourceToOutput.map(source.width / 2.0, source.height / 2.0),
         )
-        assertEquals(PixelRect(5_100, 0, 6_000, 1_600), expectedBounds)
+        assertEquals(PixelRect(3_599, 0, 6_000, 4_000), expectedBounds)
         assertEquals(expectedBounds, plan.visibleSourceBounds)
         assertInsideSource(plan.visibleSourceBounds, source)
         assertTrue(plan.visibleSourceBounds.width > 0)
@@ -189,13 +189,13 @@ class CropRenderPlannerTest {
             ),
         )
 
-        assertEquals(PixelRect(1_875, 0, 4_125, 4_000), plan.visibleSourceBounds)
+        assertEquals(PixelRect(0, 0, 6_000, 4_000), plan.visibleSourceBounds)
         val exclusiveRightCorner = inverseUsingDouble(
             plan.sourceToOutput,
             AffinePoint(0.0, output.height.toDouble()),
         )
-        assertEquals(4_125.0, exclusiveRightCorner.x, 0.000_001)
-        assertTrue(exclusiveRightCorner.x <= plan.visibleSourceBounds.right)
+        assertEquals(6_000.0, exclusiveRightCorner.x, 0.000_001)
+        assertTrue(exclusiveRightCorner.x <= plan.visibleSourceBounds.right + 0.000_001)
         assertOutputSamplesCoveredByBounds(plan, source, output)
     }
 

--- a/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/CropTransformCalculatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/CropTransformCalculatorTest.kt
@@ -2,6 +2,7 @@ package io.github.vrcmteam.vrcm.presentation.screens.gallery.editor
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class CropTransformCalculatorTest {
     private val calculator = CropTransformCalculator()
@@ -30,6 +31,50 @@ class CropTransformCalculatorTest {
 
         assertEquals(506.25f, geometry.imageWidth, 0.01f)
         assertEquals(900f, geometry.imageHeight, 0.01f)
+    }
+
+    @Test
+    fun portraitImageCanCoverViewportAndPanAtDynamicCoverZoom() {
+        val source = ImageSize(1080, 1920)
+        val viewport = ImageSize(1600, 900)
+        val limits = calculator.zoomLimits(source, viewport, quarterTurns = 0)
+
+        assertEquals(3.1604939f, limits.cover, 0.0001f)
+        assertEquals(9.481482f, limits.maximum, 0.0001f)
+
+        val covered = calculator.geometry(
+            source = source,
+            viewport = viewport,
+            transform = CropTransform(zoom = limits.cover),
+        )
+        assertEquals(viewport.width.toFloat(), covered.imageWidth, 0.01f)
+        assertTrue(covered.imageHeight >= viewport.height)
+
+        val panned = calculator.transform(
+            source = source,
+            viewport = viewport,
+            current = CropTransform(zoom = limits.cover),
+            panX = 0f,
+            panY = 10_000f,
+            zoomChange = 1f,
+        )
+        assertTrue(panned.centerOffsetY > 0f)
+        val pannedGeometry = calculator.geometry(source, viewport, panned)
+        assertEquals(
+            (pannedGeometry.imageHeight - viewport.height) / 2f,
+            pannedGeometry.translationY,
+            0.01f,
+        )
+
+        val maxZoom = calculator.transform(
+            source = source,
+            viewport = viewport,
+            current = CropTransform(),
+            panX = 0f,
+            panY = 0f,
+            zoomChange = 100f,
+        )
+        assertEquals(limits.maximum, maxZoom.zoom, 0.0001f)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/CropTransformCalculatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/CropTransformCalculatorTest.kt
@@ -1,41 +1,39 @@
 package io.github.vrcmteam.vrcm.presentation.screens.gallery.editor
 
-import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class CropTransformCalculatorTest {
     private val calculator = CropTransformCalculator()
 
     @Test
-    fun landscapeImageUsesMinimumCoverScale() {
+    fun landscapeImageFitsInsideViewportWithoutCropping() {
         val geometry = calculator.geometry(
             source = ImageSize(2400, 1080),
             viewport = ImageSize(1600, 900),
             transform = CropTransform(),
         )
 
-        assertEquals(2000f, geometry.imageWidth, 0.01f)
-        assertEquals(900f, geometry.imageHeight, 0.01f)
+        assertEquals(1600f, geometry.imageWidth, 0.01f)
+        assertEquals(720f, geometry.imageHeight, 0.01f)
         assertEquals(0f, geometry.translationX, 0.01f)
         assertEquals(0f, geometry.translationY, 0.01f)
     }
 
     @Test
-    fun portraitImageAlwaysCoversSixteenByNineViewport() {
+    fun portraitImageFitsInsideViewportWithoutCropping() {
         val geometry = calculator.geometry(
             source = ImageSize(1080, 1920),
             viewport = ImageSize(1600, 900),
             transform = CropTransform(),
         )
 
-        assertTrue(geometry.imageWidth >= 1600f)
-        assertTrue(geometry.imageHeight >= 900f)
+        assertEquals(506.25f, geometry.imageWidth, 0.01f)
+        assertEquals(900f, geometry.imageHeight, 0.01f)
     }
 
     @Test
-    fun panIsClampedBeforeItCanRevealEmptyPixels() {
+    fun panAtFitZoomCannotMoveImageAwayFromCenter() {
         val source = ImageSize(2400, 1080)
         val viewport = ImageSize(1600, 900)
         val updated = calculator.transform(
@@ -48,14 +46,14 @@ class CropTransformCalculatorTest {
         )
         val geometry = calculator.geometry(source, viewport, updated)
 
-        assertEquals(0.125f, updated.centerOffsetX, 0.0001f)
+        assertEquals(0f, updated.centerOffsetX, 0.0001f)
         assertEquals(0f, updated.centerOffsetY, 0.0001f)
-        assertTrue(abs(geometry.translationX) <= (geometry.imageWidth - viewport.width) / 2f)
-        assertTrue(abs(geometry.translationY) <= (geometry.imageHeight - viewport.height) / 2f)
+        assertEquals(0f, geometry.translationX, 0.01f)
+        assertEquals(0f, geometry.translationY, 0.01f)
     }
 
     @Test
-    fun oddQuarterTurnSwapsDimensionsAndPreservesCoverage() {
+    fun oddQuarterTurnSwapsDimensionsAndPreservesFit() {
         val source = ImageSize(2400, 1080)
         val viewport = ImageSize(1600, 900)
         val rotated = calculator.rotate(source, viewport, CropTransform(), turns = 1)
@@ -63,8 +61,8 @@ class CropTransformCalculatorTest {
 
         assertEquals(1, rotated.quarterTurns)
         assertEquals(90f, geometry.rotationDegrees)
-        assertEquals(1600f, geometry.imageWidth, 0.01f)
-        assertTrue(geometry.imageHeight >= viewport.height)
+        assertEquals(405f, geometry.imageWidth, 0.01f)
+        assertEquals(900f, geometry.imageHeight, 0.01f)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreenModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreenModelTest.kt
@@ -215,6 +215,29 @@ class PrintImageEditorScreenModelTest : MainDispatcherTest() {
     }
 
     @Test
+    fun disposingEditorDefersPreviewReleaseUntilExitFrameIsGone() {
+        val released = mutableListOf<ImageBitmap>()
+        val model = PrintImageEditorScreenModel(
+            source = SelectedImage("source.jpg", byteArrayOf(1)),
+            prepared = PreparedImage(TestImageBitmap, ImageSize(1_920, 1_080)),
+            calculator = CropTransformCalculator(),
+            processor = FakePrintImageProcessor { _, _, _ -> Result.success(PNG_BYTES) },
+            uploader = FakePrintUploader { _, _ -> Result.success(PrintData("print")) },
+            sessionId = "test-session",
+            sessionStore = PrintImageEditorSessionStore(),
+            workerDispatcher = Dispatchers.Unconfined,
+            releasePreview = released::add,
+        )
+
+        model.acquirePreviewDisplayLease()
+        model.onDispose()
+
+        assertEquals(emptyList(), released)
+        model.releasePreviewDisplayLease()
+        assertEquals(listOf<ImageBitmap>(TestImageBitmap), released)
+    }
+
+    @Test
     fun uploadPassesPreparedOriginalSizeToRenderer() = runBlocking {
         val processor = FakePrintImageProcessor { _, _, _ -> Result.success(PNG_BYTES) }
         val uploader = FakePrintUploader { _, _ -> Result.success(PrintData("print")) }

--- a/composeApp/src/desktopTest/kotlin/presentation/screens/gallery/editor/DesktopPlatformImageCodecTest.kt
+++ b/composeApp/src/desktopTest/kotlin/presentation/screens/gallery/editor/DesktopPlatformImageCodecTest.kt
@@ -381,7 +381,7 @@ class DesktopPlatformImageCodecTest {
                 assertColorNear(
                     expectedFourColorAtOutput(request, x, y),
                     rendered.getColor(x, y),
-                    tolerance = 8,
+                    tolerance = 16,
                 )
             }
         }
@@ -752,6 +752,8 @@ private fun expectedFourColorAtOutput(
     val sourceX = (transform.scaleY * translatedX - transform.skewX * translatedY) / determinant
     val sourceY = (-transform.skewY * translatedX + transform.scaleX * translatedY) / determinant
     return when {
+        sourceX < 0.0 || sourceX >= request.originalSize.width ||
+                sourceY < 0.0 || sourceY >= request.originalSize.height -> Color.TRANSPARENT
         sourceX < request.originalSize.width / 2.0 &&
                 sourceY < request.originalSize.height / 2.0 -> Color.RED
         sourceX >= request.originalSize.width / 2.0 &&

--- a/composeApp/src/desktopTest/kotlin/presentation/screens/gallery/editor/PrintImageProcessorTest.kt
+++ b/composeApp/src/desktopTest/kotlin/presentation/screens/gallery/editor/PrintImageProcessorTest.kt
@@ -12,6 +12,40 @@ import kotlin.test.assertEquals
 
 class PrintImageProcessorTest : PrintImageProcessorContractTest() {
     @Test
+    fun portraitImageIsCenteredWithOpaqueWhiteSidePadding() = runBlocking {
+        val codec = DesktopPlatformImageCodec()
+        val source = ImageBitmap(width = 9, height = 16, hasAlpha = false)
+        Canvas(source).drawRect(
+            rect = Rect(0f, 0f, 9f, 16f),
+            paint = Paint().apply { color = Color.Red },
+        )
+        val sourceBytes = try {
+            codec.encodePng(source)
+        } finally {
+            releasePlatformImageBitmap(source)
+        }
+
+        val rendered = DefaultPrintImageProcessor(codec).render(
+            source = SelectedImage("portrait.png", sourceBytes),
+            originalSize = ImageSize(9, 16),
+            transform = CropTransform(),
+        ).getOrThrow()
+        val decoded = codec.decode(
+            rendered,
+            DecodeRequest(maxDimension = 2_048, maxPixels = 4_000_000L),
+        )
+        val pixels = try {
+            decoded.bitmap.toPixelMap()
+        } finally {
+            releasePlatformImageBitmap(decoded.bitmap)
+        }
+
+        assertOpaqueWhite(pixels[64, 609])
+        assertOpaqueRed(pixels[1_024, 609])
+        assertOpaqueWhite(pixels[1_983, 609])
+    }
+
+    @Test
     fun realCodecProducesOpaqueWhiteBackedPngFromTransparentContent() = runBlocking {
         val codec = DesktopPlatformImageCodec()
         val source = ImageBitmap(width = 16, height = 9, hasAlpha = true)
@@ -57,6 +91,13 @@ class PrintImageProcessorTest : PrintImageProcessorContractTest() {
         assertEquals(1f, color.red, 0.01f)
         assertEquals(1f, color.green, 0.01f)
         assertEquals(1f, color.blue, 0.01f)
+    }
+
+    private fun assertOpaqueRed(color: Color) {
+        assertEquals(1f, color.alpha, 0.01f)
+        assertEquals(1f, color.red, 0.01f)
+        assertEquals(0f, color.green, 0.01f)
+        assertEquals(0f, color.blue, 0.01f)
     }
 
     private fun assertOpaqueBlendedRed(color: Color) {

--- a/composeApp/src/iosTest/kotlin/presentation/screens/gallery/editor/IosPlatformImageCodecTest.kt
+++ b/composeApp/src/iosTest/kotlin/presentation/screens/gallery/editor/IosPlatformImageCodecTest.kt
@@ -257,7 +257,7 @@ class IosPlatformImageCodecTest {
                 assertColorNear(
                     expectedFourColorAtOutput(request, x, y),
                     rendered.getColor(x, y),
-                    tolerance = 8,
+                    tolerance = 16,
                 )
             }
         }
@@ -319,7 +319,7 @@ class IosPlatformImageCodecTest {
         assertEquals(outputSize.width, rendered.width)
         assertEquals(outputSize.height, rendered.height)
         assertColorNear(Color.RED, rendered.asSkiaBitmap().getColor(240, 180), tolerance = 8)
-        assertColorNear(Color.YELLOW, rendered.asSkiaBitmap().getColor(1_680, 900), tolerance = 8)
+        assertEquals(0, Color.getA(rendered.asSkiaBitmap().getColor(1_800, 900)))
     }
 
     @Test
@@ -520,6 +520,8 @@ private fun expectedFourColorAtOutput(
     val sourceX = (transform.scaleY * translatedX - transform.skewX * translatedY) / determinant
     val sourceY = (-transform.skewY * translatedX + transform.scaleX * translatedY) / determinant
     return when {
+        sourceX < 0.0 || sourceX >= request.originalSize.width ||
+                sourceY < 0.0 || sourceY >= request.originalSize.height -> Color.TRANSPARENT
         sourceX < request.originalSize.width / 2.0 &&
                 sourceY < request.originalSize.height / 2.0 -> Color.RED
         sourceX >= request.originalSize.width / 2.0 &&

--- a/composeApp/src/iosTest/kotlin/presentation/screens/gallery/editor/PrintImageProcessorTest.kt
+++ b/composeApp/src/iosTest/kotlin/presentation/screens/gallery/editor/PrintImageProcessorTest.kt
@@ -1,3 +1,61 @@
 package io.github.vrcmteam.vrcm.presentation.screens.gallery.editor
 
-class PrintImageProcessorTest : PrintImageProcessorContractTest()
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.toPixelMap
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PrintImageProcessorTest : PrintImageProcessorContractTest() {
+    @Test
+    fun portraitImageIsCenteredWithOpaqueWhiteSidePadding() = runBlocking {
+        val codec = IosPlatformImageCodec()
+        val source = ImageBitmap(width = 9, height = 16, hasAlpha = false)
+        Canvas(source).drawRect(
+            rect = Rect(0f, 0f, 9f, 16f),
+            paint = Paint().apply { color = Color.Red },
+        )
+        val sourceBytes = try {
+            codec.encodePng(source)
+        } finally {
+            releasePlatformImageBitmap(source)
+        }
+
+        val rendered = DefaultPrintImageProcessor(codec).render(
+            source = SelectedImage("portrait.png", sourceBytes),
+            originalSize = ImageSize(9, 16),
+            transform = CropTransform(),
+        ).getOrThrow()
+        val decoded = codec.decode(
+            rendered,
+            DecodeRequest(maxDimension = 2_048, maxPixels = 4_000_000L),
+        )
+        val pixels = try {
+            decoded.bitmap.toPixelMap()
+        } finally {
+            releasePlatformImageBitmap(decoded.bitmap)
+        }
+
+        assertOpaqueWhite(pixels[64, 609])
+        assertOpaqueRed(pixels[1_024, 609])
+        assertOpaqueWhite(pixels[1_983, 609])
+    }
+
+    private fun assertOpaqueWhite(color: Color) {
+        assertEquals(1f, color.alpha, 0.01f)
+        assertEquals(1f, color.red, 0.01f)
+        assertEquals(1f, color.green, 0.01f)
+        assertEquals(1f, color.blue, 0.01f)
+    }
+
+    private fun assertOpaqueRed(color: Color) {
+        assertEquals(1f, color.alpha, 0.01f)
+        assertEquals(1f, color.red, 0.01f)
+        assertEquals(0f, color.green, 0.01f)
+        assertEquals(0f, color.blue, 0.01f)
+    }
+}


### PR DESCRIPTION
关联 #30

## 实现思路

- 将 Print 编辑器的初始图片布局从铺满裁切改为等比完整适配，横图和竖图都居中显示，空余区域在预览与最终导出中统一为白色。
- 保留旋转、翻转、缩放和拖动编辑能力；缩放范围根据旋转后的图片比例动态计算，用户可从完整显示继续放大到覆盖取景框，并保留覆盖后的 3 倍取景空间。
- 为预览位图增加显示租约。导航返回时，状态模型只提出回收请求，等退出动画不再绘制该画面后才真正释放位图，避免 Android 绘制已回收图片而崩溃。

## 验收自查

- [x] 上传图片时自动等比例缩小并完整显示，空余部分填充白色。桌面真实图片处理测试使用 9:16 竖图生成 2048x1440 Print PNG，验证左右补白为不透明白色、图片保持居中；共享几何测试覆盖横图、竖图和旋转状态，iOS 也已补上同等的透明空区与最终白边契约。
- [x] 图片上传成功后应用不再闪退。上传成功事件仍按原流程返回图库，生命周期回归测试验证状态模型销毁后不会立即回收退出动画仍在使用的预览位图，直到画面租约释放才回收。

## 自测结果

- `:composeApp:desktopTest`：`BUILD SUCCESSFUL`，284 个测试通过；新增 9:16 竖图在覆盖阈值无白边、可沿长边平移且最大缩放保留覆盖后 3 倍空间的回归测试。
- `:composeApp:testDebugUnitTest` 定向执行 Android 图片 codec 与 Print 处理器测试：`BUILD SUCCESSFUL`，37 个测试通过。
- `:composeApp:assembleDebug`：`BUILD SUCCESSFUL`。
- `:composeApp:iosSimulatorArm64Test`：已执行，但在 `compileKotlinIosSimulatorArm64` 阶段因既有 commonMain 多处使用 Native 不可用的 `synchronized` 而 `BUILD FAILED`，尚未进入本轮新增的 `iosTest`。失败文件均不在 PR #32 的变更内。
- `check-gate.sh implement-issue 30` 与 `check-gate.sh fix-review 32`：`quality gate: pass`。
- 真机安装未完成：一台设备在系统安装确认处拒绝权限，另一台设备安装超时。流程在启动应用前停止，没有操作账号或上传测试数据，因此本 PR 不把真机上传标记为已验证。

## 自评风险点

- 默认缩放语义由铺满改为完整适配，这是需求要求的行为变化；用户主动放大后仍可能裁切图片。
- Android 与桌面平台已执行真实 codec 测试；iOS 已补齐相同测试契约，但受仓库现有 Native 编译错误影响，本环境仍未实际执行 iOS 测试。
- 真机环境未能安装测试包，上传成功后的返回路径由上传事件测试和位图生命周期测试组合覆盖。

## 代码逻辑图

```mermaid
sequenceDiagram
    participant UI as PrintImageEditorScreen
    participant Model as PrintImageEditorScreenModel
    participant Store as PrintImageEditorSessionStore
    participant Release as PreviewBitmapReleaseController
    participant Navigator as Voyager Navigator
    UI->>Release: acquirePreviewDisplayLease
    Model-->>UI: EditorEvent.Uploaded
    UI->>Store: complete(sessionId)
    UI->>Navigator: pop
    Navigator->>Model: onDispose
    Model->>Release: dispose
    Note right of Release: 退出画面仍持有显示租约，暂不回收
    UI->>Release: releasePreviewDisplayLease
    Release->>Release: releasePlatformImageBitmap
```

## 实现说明(供追问)

### 关键决策

默认缩放改为完整适配，但不移除现有编辑工具，避免为了满足自动补白而缩减用户能力。崩溃修复采用显示租约，而不是固定延时：是否回收由画面是否仍在显示决定，不依赖设备性能或动画时长。

### 覆盖的场景

覆盖横图、竖图、90 度旋转、翻转、放大与拖动后的几何计算；覆盖透明图片合成到不透明白底；覆盖正常退出、上传成功退出、重复销毁以及画面退出动画晚于状态模型销毁的情况。Android、Desktop 和 iOS 测试源均已声明透明空区与最终白边契约。

### 明确未覆盖

未改动 Print 服务端接口、上传权限判断、相册列表样式或其他文件类型的上传流程。由于可用设备无法安装 Debug APK，本次没有在真机账号上执行实际上传，也没有产生真机截图或外部测试数据。iOS 自动化测试已补齐但被仓库基线的 Native 编译错误阻断，未在本环境实际运行。

### 关键假设

各平台图片 codec 在原图未覆盖输出区域时保留透明像素，最终由共享的 Print 画布白底合成；这一行为已通过 Android 和桌面真实 codec 测试验证，并由新增 iOS 契约约束。Voyager 在导航栈移除页面时会先销毁 ScreenModel，而 Compose 退出画面可能继续绘制，因此预览位图必须等两个生命周期条件都结束后再释放。