### PR TITLE
修复切后台后请求超时及好友位置过期

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -83,6 +83,7 @@ kotlin {
             implementation(compose.materialIconsExtended)
 //            implementation(compose.materialIconsExtended)
             implementation(compose.components.resources)
+            implementation(libs.androidx.lifecycle.runtime.compose)
 //            implementation(compose.components.uiToolingPreview)
 
             implementation(libs.multiplatform.settings)

--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.backhandler.BackHandler
@@ -35,14 +37,27 @@ import io.github.vrcmteam.vrcm.presentation.screens.group.GroupProfileScreen
 import io.github.vrcmteam.vrcm.presentation.screens.home.HomeScreen
 import io.github.vrcmteam.vrcm.presentation.screens.user.UserProfileScreen
 import io.github.vrcmteam.vrcm.presentation.screens.world.WorldProfileScreen
+import io.github.vrcmteam.vrcm.presentation.screens.home.pager.FriendLocationPagerModel
 import io.github.vrcmteam.vrcm.presentation.settings.SettingsProvider
+import io.github.vrcmteam.vrcm.network.websocket.WebSocketApi
 import org.koin.compose.KoinContext
+import org.koin.compose.koinInject
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun App() {
     val backNavigationPolicy = remember { BackNavigationPolicy() }
     KoinContext {
+        val webSocketApi = koinInject<WebSocketApi>()
+        val friendLocationPagerModel = koinInject<FriendLocationPagerModel>()
+        LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
+            friendLocationPagerModel.onBackground()
+            webSocketApi.onBackground()
+        }
+        LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+            webSocketApi.onForeground()
+            friendLocationPagerModel.onForeground()
+        }
         SettingsProvider {
             Navigator(
                 screen = StartupAnimeScreen,

--- a/composeApp/src/commonMain/kotlin/network/websocket/WebSocketApi.kt
+++ b/composeApp/src/commonMain/kotlin/network/websocket/WebSocketApi.kt
@@ -14,6 +14,9 @@ import io.ktor.client.request.*
 import io.ktor.client.call.*
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.*
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 import org.koin.core.logger.Logger
 
 class WebSocketApi(
@@ -22,20 +25,37 @@ class WebSocketApi(
 ) {
 
     private var currentJob: Job? = null
-    private var scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val connectionLock = SynchronizedObject()
+    private val isForeground = atomic(true)
 
     init {
         scope.launch {
             SharedFlowCentre.authed.collect { session ->
-                currentJob?.cancelAndJoin()
-                currentJob = launch { startWebSocket(session.token) }
+                if (isForeground.value) replaceConnection(session.token)
             }
         }
         scope.launch {
             SharedFlowCentre.logout.collect {
-                currentJob?.cancelAndJoin()
-                currentJob = null
+                replaceConnection(null)
             }
+        }
+    }
+
+    fun onBackground() {
+        isForeground.value = false
+        replaceConnection(null)
+    }
+
+    fun onForeground() {
+        if (isForeground.getAndSet(true)) return
+        replaceConnection(SharedFlowCentre.currentSession.value?.token)
+    }
+
+    private fun replaceConnection(sessionToken: AccountSessionToken?) = synchronized(connectionLock) {
+        currentJob?.cancel()
+        currentJob = sessionToken?.let { token ->
+            scope.launch { startWebSocket(token) }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendLocationPagerModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendLocationPagerModel.kt
@@ -25,13 +25,19 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 
 internal class FriendUpdateSessionGate(
     initialSessionToken: AccountSessionToken? = null,
@@ -110,6 +116,11 @@ class FriendLocationPagerModel(
     private val accountTracker = AccountGenerationTracker(initialSession?.account?.userId)
     private val updateMutex = Mutex()
     private val refreshMutex = Mutex()
+    private val instanceFetchSemaphore = Semaphore(4)
+    private val instanceJobsLock = SynchronizedObject()
+    private val instanceJobs = mutableMapOf<String, Job>()
+    private val foregroundGeneration = atomic(0L)
+    private val isForeground = atomic(true)
     private val preloadTask = AccountBoundTask(
         scope = modelScope,
         isCurrent = accountTracker::isCurrent,
@@ -200,6 +211,24 @@ class FriendLocationPagerModel(
         preloadTask.start(token)
     }
 
+    fun onBackground() {
+        isForeground.value = false
+        foregroundGeneration.incrementAndGet()
+        preloadTask.cancel()
+        synchronized(instanceJobsLock) {
+            instanceJobs.values.forEach(Job::cancel)
+            instanceJobs.clear()
+        }
+    }
+
+    fun onForeground() {
+        if (isForeground.getAndSet(true)) return
+        foregroundGeneration.incrementAndGet()
+        val token = accountTracker.currentToken() ?: return
+        isRefreshing = true
+        preloadTask.start(token)
+    }
+
     fun findFriendLocation(userId: String, location: String): FriendLocation? =
         friendLocationsByUser.value[userId]?.takeIf { it.location == location }
 
@@ -264,7 +293,7 @@ class FriendLocationPagerModel(
                             includedIds.addAll(friends.map(FriendData::id))
                         }
                     }
-                    syncFriendLocations(token)
+                    syncFriendLocations(token, fetchInstanceDetails = false)
                 }
             }
             updateMutex.withLock {
@@ -276,13 +305,16 @@ class FriendLocationPagerModel(
         } finally {
             if (accountTracker.isCurrent(token)) {
                 if (!completed) updateMutex.withLock { presenceStore.cancelRefresh() }
-                syncFriendLocations(token)
+                syncFriendLocations(token, fetchInstanceDetails = completed)
                 isRefreshing = false
             }
         }
     }
 
-    private suspend fun syncFriendLocations(token: AccountGenerationToken? = null) = updateMutex.withLock {
+    private suspend fun syncFriendLocations(
+        token: AccountGenerationToken? = null,
+        fetchInstanceDetails: Boolean = true,
+    ) = updateMutex.withLock {
         if (token != null && !accountTracker.isCurrent(token)) return@withLock
         runCatching {
             val snapshot = presenceStore.snapshot()
@@ -315,7 +347,7 @@ class FriendLocationPagerModel(
                     )
                 }
             }
-            syncInstanceLocations(instances)
+            syncInstanceLocations(instances, fetchInstanceDetails)
             publishFriendLocationIndex()
         }.onApiFailure("FriendLocation") {
             SharedFlowCentre.toastText.emit(ToastText.Error(it))
@@ -331,7 +363,10 @@ class FriendLocationPagerModel(
         publishedState.publishIndex()
     }
 
-    private fun syncInstanceLocations(groups: Map<String, FriendLocationGroup>) {
+    private fun syncInstanceLocations(
+        groups: Map<String, FriendLocationGroup>,
+        fetchInstanceDetails: Boolean,
+    ) {
         if (groups.isEmpty()) {
             friendLocationMap.remove(LocationType.Instance)
             return
@@ -347,12 +382,14 @@ class FriendLocationPagerModel(
                 location.friends.keys != group.friends.mapTo(mutableSetOf(), FriendData::id) ||
                     location.travelingIds.value != group.travelingIds
             syncFriends(location, group)
-            fetchInstants(
-                location = locationId,
-                oldInstants = location.instants.value,
-                forceRefresh = presenceChanged && group.friends.isNotEmpty(),
-            ) {
-                location.instants.value = it
+            if (fetchInstanceDetails) {
+                fetchInstants(
+                    location = locationId,
+                    oldInstants = location.instants.value,
+                    forceRefresh = presenceChanged && group.friends.isNotEmpty(),
+                ) {
+                    location.instants.value = it
+                }
             }
         }
     }
@@ -365,12 +402,17 @@ class FriendLocationPagerModel(
     ) {
         // 已加载过实例信息则跳过网络请求
         if (!forceRefresh && oldInstants.worldId.isNotEmpty()) return
-        modelScope.launch(Dispatchers.IO) {
-            authService.reTryAuthCatching {
-                instancesApi.instanceByLocation(location)
-            }.onFailure {
-                SharedFlowCentre.toastText.emit(ToastText.Error(it.message.toString()))
-            }.onSuccess { instance ->
+        if (!isForeground.value) return
+        val generation = foregroundGeneration.value
+        val job = synchronized(instanceJobsLock) {
+            if (instanceJobs[location]?.isActive == true) return
+            modelScope.launch(Dispatchers.IO, start = kotlinx.coroutines.CoroutineStart.LAZY) {
+                try {
+                    instanceFetchSemaphore.withPermit {
+                        val instance = authService.reTryAuthCatching {
+                            instancesApi.instanceByLocation(location)
+                        }.getOrNull() ?: return@withPermit
+                        if (!isCurrentForegroundGeneration(generation)) return@withPermit
                 val instantsVo = HomeInstanceVo(instance)
                 updateInstants(instantsVo)
                 // owner不会变所以不用更新
@@ -382,9 +424,21 @@ class FriendLocationPagerModel(
                     updateInstants(instantsVo)
                     fetchAndSetOwner(instance.ownerId, instantsVo)
                 }
-            }
+                    }
+                } finally {
+                    synchronized(instanceJobsLock) {
+                        if (instanceJobs[location] == coroutineContext[Job]) {
+                            instanceJobs.remove(location)
+                        }
+                    }
+                }
+            }.also { instanceJobs[location] = it }
         }
+        job.start()
     }
+
+    private fun isCurrentForegroundGeneration(generation: Long): Boolean =
+        isForeground.value && foregroundGeneration.value == generation
 
     /**
      * 获取房间实例的拥有者名称

--- a/composeApp/src/commonMain/kotlin/service/AccountBoundTask.kt
+++ b/composeApp/src/commonMain/kotlin/service/AccountBoundTask.kt
@@ -31,6 +31,14 @@ internal class AccountBoundTask<T>(
         }.also { it.start() }
     }
 
+    fun cancel() {
+        synchronized(lock) {
+            token = null
+            job?.cancel()
+            job = null
+        }
+    }
+
     suspend fun cancelAndJoin() {
         val runningJob = synchronized(lock) {
             token = null

--- a/composeApp/src/commonTest/kotlin/service/AccountBoundTaskTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/AccountBoundTaskTest.kt
@@ -3,7 +3,9 @@ package io.github.vrcmteam.vrcm.service
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.runCurrent
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -41,6 +43,27 @@ class AccountBoundTaskTest {
         accountBStarted.await()
         assertFalse(tracker.isCurrent(accountA))
         assertTrue(tracker.isCurrent(accountB))
+        task.cancelAndJoin()
+    }
+
+    @Test
+    fun cancelledTaskCanRestartForTheSameAccountOnForeground() = runTest {
+        val tracker = AccountGenerationTracker("usr_a")
+        val token = tracker.currentToken()!!
+        var starts = 0
+        val task = AccountBoundTask(
+            scope = this,
+            isCurrent = tracker::isCurrent,
+            runTask = { starts++ },
+        )
+
+        task.start(token)
+        runCurrent()
+        task.cancel()
+        task.start(token)
+        runCurrent()
+
+        assertEquals(2, starts)
         task.cancelAndJoin()
     }
 }


### PR DESCRIPTION
增加 Android 和 iOS 共用的前后台生命周期处理。应用进入后台时取消好友刷新、房间详情请求并停止 WebSocket，回到前台后重建连接并重新拉取好友快照，避免丢失后台期间的好友事件。

对好友位置恢复流程增加请求代次校验、房间请求去重和最多 4 个并发限制，并将房间详情加载推迟到好友分页完成后，减少恢复瞬间的请求扇出。补充相同账号任务取消后重新启动的测试。

验证：:composeApp:compileDebugKotlinAndroid 通过；:composeApp:compileKotlinIosSimulatorArm64 通过。