### PR TITLE
修复正式发布前的凭据安全、Cookie 隔离与桌面持久化问题

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -61,6 +61,7 @@ kotlin {
             implementation(compose.desktop.currentOs)
 
             implementation(libs.ktor.client.okhttp)
+            implementation(libs.jna.platform)
         }
 
         val desktopTest by getting

--- a/composeApp/src/androidMain/kotlin/di/modules/PlatformModule.android.kt
+++ b/composeApp/src/androidMain/kotlin/di/modules/PlatformModule.android.kt
@@ -6,6 +6,9 @@ import io.github.vrcmteam.vrcm.AndroidAppPlatform
 import io.github.vrcmteam.vrcm.AppPlatform
 import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.AndroidPlatformImageCodec
 import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PlatformImageCodec
+import io.github.vrcmteam.vrcm.storage.AndroidSecureStorage
+import io.github.vrcmteam.vrcm.storage.DaoKeys
+import io.github.vrcmteam.vrcm.storage.SecureStorage
 import org.koin.android.logger.AndroidLogger
 import org.koin.core.logger.Logger
 import org.koin.core.module.Module
@@ -18,4 +21,5 @@ actual val platformModule: Module = module {
     singleOf(SharedPreferencesSettings::Factory) bind Settings.Factory::class
     singleOf(::AndroidAppPlatform) bind AppPlatform::class
     singleOf(::AndroidPlatformImageCodec) bind PlatformImageCodec::class
+    single<SecureStorage> { AndroidSecureStorage(get(), DaoKeys.Account.NAME) }
 }

--- a/composeApp/src/androidMain/kotlin/storage/AndroidSecureStorage.kt
+++ b/composeApp/src/androidMain/kotlin/storage/AndroidSecureStorage.kt
@@ -1,0 +1,71 @@
+package io.github.vrcmteam.vrcm.storage
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+class AndroidSecureStorage(
+    context: Context,
+    name: String,
+) : SecureStorage {
+    private val preferences = context.getSharedPreferences("$name.secure", Context.MODE_PRIVATE)
+    private val keyAlias = "io.github.vrcmteam.vrcm.$name"
+
+    override fun get(key: String): String? = preferences.getString(key, null)?.let(::decrypt)
+
+    override fun put(key: String, value: String) {
+        check(preferences.edit().putString(key, encrypt(value)).commit()) {
+            "Failed to persist encrypted credential"
+        }
+    }
+
+    override fun remove(key: String) {
+        preferences.edit().remove(key).commit()
+    }
+
+    override fun clear() {
+        preferences.edit().clear().commit()
+    }
+
+    private fun encrypt(value: String): String {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey())
+        return "${encode(cipher.iv)}:${encode(cipher.doFinal(value.encodeToByteArray()))}"
+    }
+
+    private fun decrypt(value: String): String? = runCatching {
+        val (iv, ciphertext) = value.split(':', limit = 2)
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.DECRYPT_MODE, secretKey(), GCMParameterSpec(128, decode(iv)))
+        cipher.doFinal(decode(ciphertext)).decodeToString()
+    }.getOrNull()
+
+    private fun secretKey(): SecretKey {
+        val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+        (keyStore.getKey(keyAlias, null) as? SecretKey)?.let { return it }
+        return KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore").run {
+            init(
+                KeyGenParameterSpec.Builder(
+                    keyAlias,
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+                ).setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .build()
+            )
+            generateKey()
+        }
+    }
+
+    private fun encode(bytes: ByteArray) = Base64.encodeToString(bytes, Base64.NO_WRAP)
+    private fun decode(value: String) = Base64.decode(value, Base64.NO_WRAP)
+
+    private companion object {
+        const val TRANSFORMATION = "AES/GCM/NoPadding"
+    }
+}

--- a/composeApp/src/androidMain/res/xml/backup_rules.xml
+++ b/composeApp/src/androidMain/res/xml/backup_rules.xml
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older that API 31
-   See https://developer.android.com/about/versions/12/backup-restore
--->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <exclude domain="sharedpref" path="vrcm.account.xml"/>
+    <exclude domain="sharedpref" path="vrcm.account.secure.xml"/>
 </full-backup-content>

--- a/composeApp/src/androidMain/res/xml/data_extraction_rules.xml
+++ b/composeApp/src/androidMain/res/xml/data_extraction_rules.xml
@@ -1,20 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
--->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude domain="sharedpref" path="vrcm.account.xml"/>
+        <exclude domain="sharedpref" path="vrcm.account.secure.xml"/>
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="sharedpref" path="vrcm.account.xml"/>
+        <exclude domain="sharedpref" path="vrcm.account.secure.xml"/>
     </device-transfer>
-    -->
 </data-extraction-rules>

--- a/composeApp/src/commonMain/kotlin/di/modules/StorageModule.kt
+++ b/composeApp/src/commonMain/kotlin/di/modules/StorageModule.kt
@@ -10,6 +10,7 @@ import io.github.vrcmteam.vrcm.storage.FriendListCacheDao
 import io.github.vrcmteam.vrcm.storage.FriendNetworkCacheDao
 import io.github.vrcmteam.vrcm.storage.GroupProfileCacheDao
 import io.github.vrcmteam.vrcm.storage.SettingsDao
+import io.github.vrcmteam.vrcm.storage.SecureStorage
 import io.github.vrcmteam.vrcm.storage.UserProfileCacheDao
 import io.github.vrcmteam.vrcm.storage.WorldProfileCacheDao
 import io.ktor.client.plugins.cookies.*
@@ -21,7 +22,7 @@ import org.koin.dsl.module
 
 internal val storageModule: Module = module {
     factory<Settings> { (name: String) -> get<Settings.Factory>().create(name) }
-    single { AccountDao(get { parametersOf(DaoKeys.Account.NAME) }) }
+    single { AccountDao(get { parametersOf(DaoKeys.Account.NAME) }, get<SecureStorage>()) }
     single { SettingsDao(get { parametersOf(DaoKeys.Settings.NAME) }) }
     single { FavoriteLocalDao(get { parametersOf(DaoKeys.FavoriteLocal.NAME) }) }
     single { FriendListCacheDao(get { parametersOf(DaoKeys.FriendListCache.NAME) }) }

--- a/composeApp/src/commonMain/kotlin/di/supports/PersistentCookiesStorage.kt
+++ b/composeApp/src/commonMain/kotlin/di/supports/PersistentCookiesStorage.kt
@@ -1,7 +1,10 @@
 package io.github.vrcmteam.vrcm.di.supports
 
 import io.ktor.client.plugins.cookies.*
+import io.github.vrcmteam.vrcm.network.api.attributes.VRC_API_HOST
 import io.ktor.http.*
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 import org.koin.core.logger.Logger
 
 /**
@@ -13,27 +16,32 @@ class PersistentCookiesStorage(
 ) : CookiesStorage {
 
     private val cookieCache: MutableMap<String, Cookie> = mutableMapOf()
+    private val lock = SynchronizedObject()
 
     override suspend fun get(requestUrl: Url): List<Cookie> {
-        return cookieCache.values.toList()
+        if (requestUrl.protocol != URLProtocol.HTTPS || requestUrl.host != VRC_API_HOST) {
+            return emptyList()
+        }
+        return synchronized(lock) { cookieCache.values.toList() }
     }
 
     override suspend fun addCookie(requestUrl: Url, cookie: Cookie) {
+        if (requestUrl.protocol != URLProtocol.HTTPS || requestUrl.host != VRC_API_HOST) return
         logger.info("requestUrl=$requestUrl")
-        cookieCache[cookie.name] = cookie
+        synchronized(lock) { cookieCache[cookie.name] = cookie }
     }
 
     fun addCookie(key: String, value: String?) =
         value?.takeIf { it.isNotEmpty() }
-            ?.let { cookieCache[key] = parseServerSetCookieHeader("$key=$it") }
+            ?.let { synchronized(lock) { cookieCache[key] = parseServerSetCookieHeader("$key=$it") } }
 
-    fun cookieValue(key: String): String? = cookieCache[key]?.value
+    fun cookieValue(key: String): String? = synchronized(lock) { cookieCache[key]?.value }
 
 
-    override fun close() = cookieCache.clear()
+    override fun close() = synchronized(lock) { cookieCache.clear() }
 
     fun removeCookie(key: String) {
-        cookieCache.remove(key)
+        synchronized(lock) { cookieCache.remove(key) }
     }
 
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreenModel.kt
@@ -11,6 +11,7 @@ import io.github.vrcmteam.vrcm.network.api.attributes.BlueprintType
 import io.github.vrcmteam.vrcm.network.api.attributes.LocationType
 import io.github.vrcmteam.vrcm.network.api.attributes.NotificationType
 import io.github.vrcmteam.vrcm.network.api.attributes.UserStatus
+import io.github.vrcmteam.vrcm.network.api.attributes.UserState
 import io.github.vrcmteam.vrcm.network.api.avatars.AvatarsApi
 import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
 import io.github.vrcmteam.vrcm.network.api.favorite.FavoriteApi
@@ -261,13 +262,25 @@ class UserProfileScreenModel(
                         ?: ownLocation?.location.takeIf { userProfileVO.id == cacheOwnerUserId },
                     locationsByUser = locationsByUser,
                 )
-            }.collect { (_, location) -> _friendLocation.value = location }
+            }.collect { (friend, location) ->
+                _friendLocation.value = location
+                if (friend != null && userProfileVO.id != cacheOwnerUserId) {
+                    _userState.value = _userState.value.withCurrentFriendPresence(friend)
+                }
+            }
         }
     }
 
     private fun restoreCachedProfile(cache: UserProfileCache) {
         cachedUserData = cache.user
-        val profile = UserProfileVo(cache.user).withSelfIdentity()
+        val cachedUser = cache.user.asCachedOffline()
+        val profile = UserProfileVo(cachedUser)
+            .withSelfIdentity()
+            .let { restored ->
+                friendService.friendState.value[cache.user.id]
+                    ?.let(restored::withCurrentFriendPresence)
+                    ?: restored
+            }
         _userState.value = profile
         computeFriendLocation(profile.location)
         _userGroups.value = visibleUserGroups(cache.groups, profile.isSelf)
@@ -719,3 +732,22 @@ private fun UserProfileVo.toFriendData() =
         userIcon = userIcon,
         pronouns = pronouns,
     )
+
+internal fun UserData.asCachedOffline(): UserData = copy(
+    state = UserState.Offline,
+    status = UserStatus.Offline,
+    location = LocationType.Offline.value,
+    instanceId = "",
+    worldId = "",
+    travelingToInstance = null,
+    travelingToLocation = null,
+    travelingToWorld = null,
+)
+
+internal fun UserProfileVo.withCurrentFriendPresence(friend: FriendData): UserProfileVo = copy(
+    status = friend.status,
+    statusDescription = friend.statusDescription,
+    location = friend.location,
+    lastLogin = friend.lastLogin,
+    lastPlatform = friend.lastPlatform,
+)

--- a/composeApp/src/commonMain/kotlin/storage/AccountDao.kt
+++ b/composeApp/src/commonMain/kotlin/storage/AccountDao.kt
@@ -14,6 +14,7 @@ import okio.ByteString.Companion.decodeBase64
 
 class AccountDao(
     private val accountSettings: Settings,
+    private val secureStorage: SecureStorage,
 ) {
 
     fun saveAccountInfo(accountDto: AccountDto) {
@@ -21,11 +22,20 @@ class AccountDao(
             .filter { it.startsWith(CURRENT_KEY) }
             .forEach { accountSettings[it] = false }
         accountSettings["${USERNAME_KEY}|${accountDto.userId}"] = accountDto.username
-        accountDto.password?.let { accountSettings["${PASSWORD_KEY}|${accountDto.userId}"] = it.encodeBase64() }
+        accountDto.password?.let {
+            secureStorage.put(secretKey(PASSWORD_KEY, accountDto.userId), it)
+            accountSettings.remove("${PASSWORD_KEY}|${accountDto.userId}")
+        }
         accountDto.iconUrl?.let { accountSettings["${ICON_URL_KEY}|${accountDto.userId}"] = it }
         accountSettings["${CURRENT_KEY}|${accountDto.userId}"] = true
-        accountDto.authCookie?.let { accountSettings["${AUTH_KEY}|${accountDto.userId}"] = it }
-        accountDto.twoFactorAuthCookie?.let { accountSettings["${TWO_FACTOR_AUTH_KEY}|${accountDto.userId}"] = it }
+        accountDto.authCookie?.let {
+            secureStorage.put(secretKey(AUTH_KEY, accountDto.userId), it)
+            accountSettings.remove("${AUTH_KEY}|${accountDto.userId}")
+        }
+        accountDto.twoFactorAuthCookie?.let {
+            secureStorage.put(secretKey(TWO_FACTOR_AUTH_KEY, accountDto.userId), it)
+            accountSettings.remove("${TWO_FACTOR_AUTH_KEY}|${accountDto.userId}")
+        }
     }
 
     fun accountDtoList(): List<AccountDto> =
@@ -39,11 +49,17 @@ class AccountDao(
                 AccountDto(
                     userId = userId,
                     username = accountSettings.getStringOrNull("${USERNAME_KEY}|${userId}").orEmpty(),
-                    password = accountSettings.getStringOrNull("${PASSWORD_KEY}|${userId}")?.decodeBase64()?.utf8(),
+                    password = readSecret(PASSWORD_KEY, userId) {
+                        accountSettings.getStringOrNull("${PASSWORD_KEY}|${userId}")?.decodeBase64()?.utf8()
+                    },
                     iconUrl = accountSettings.getStringOrNull("${ICON_URL_KEY}|${userId}"),
                     current = accountSettings.getBoolean("${CURRENT_KEY}|${userId}", false),
-                    authCookie = accountSettings.getStringOrNull("${AUTH_KEY}|${userId}"),
-                    twoFactorAuthCookie = accountSettings.getStringOrNull("${TWO_FACTOR_AUTH_KEY}|${userId}")
+                    authCookie = readSecret(AUTH_KEY, userId) {
+                        accountSettings.getStringOrNull("${AUTH_KEY}|${userId}")
+                    },
+                    twoFactorAuthCookie = readSecret(TWO_FACTOR_AUTH_KEY, userId) {
+                        accountSettings.getStringOrNull("${TWO_FACTOR_AUTH_KEY}|${userId}")
+                    }
                 )
             }
 
@@ -62,12 +78,14 @@ class AccountDao(
 
     fun clearAccount() {
         accountSettings.clear()
+        secureStorage.clear()
     }
 
     fun logout(userId: String) {
         accountSettings.keys
             .firstOrNull { it == "${AUTH_KEY}|${userId}" }
             ?.let(accountSettings::remove)
+        secureStorage.remove(secretKey(AUTH_KEY, userId))
     }
 
     fun removeAccount(userId: String) {
@@ -76,6 +94,19 @@ class AccountDao(
             .forEach {
                 accountSettings.remove(it)
             }
+        listOf(PASSWORD_KEY, AUTH_KEY, TWO_FACTOR_AUTH_KEY).forEach { type ->
+            secureStorage.remove(secretKey(type, userId))
+        }
+    }
+
+    private fun secretKey(type: String, userId: String) = "$userId|${type.substringAfterLast('.')}"
+
+    private fun readSecret(type: String, userId: String, legacy: () -> String?): String? {
+        secureStorage.get(secretKey(type, userId))?.let { return it }
+        val oldValue = legacy() ?: return null
+        secureStorage.put(secretKey(type, userId), oldValue)
+        accountSettings.remove("$type|$userId")
+        return oldValue
     }
 
 }

--- a/composeApp/src/commonMain/kotlin/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/storage/SecureStorage.kt
@@ -1,0 +1,17 @@
+package io.github.vrcmteam.vrcm.storage
+
+interface SecureStorage {
+    fun get(key: String): String?
+    fun put(key: String, value: String)
+    fun remove(key: String)
+    fun clear()
+}
+
+internal class InMemorySecureStorage : SecureStorage {
+    private val values = mutableMapOf<String, String>()
+
+    override fun get(key: String): String? = values[key]
+    override fun put(key: String, value: String) { values[key] = value }
+    override fun remove(key: String) { values.remove(key) }
+    override fun clear() { values.clear() }
+}

--- a/composeApp/src/commonTest/kotlin/di/supports/PersistentCookiesStorageTest.kt
+++ b/composeApp/src/commonTest/kotlin/di/supports/PersistentCookiesStorageTest.kt
@@ -1,0 +1,31 @@
+package io.github.vrcmteam.vrcm.di.supports
+
+import io.github.vrcmteam.vrcm.network.api.attributes.AUTH_COOKIE
+import io.ktor.http.Cookie
+import io.ktor.http.Url
+import kotlinx.coroutines.test.runTest
+import org.koin.core.logger.EmptyLogger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PersistentCookiesStorageTest {
+    @Test
+    fun vrChatCookiesAreOnlyReturnedToVrChatApiOverHttps() = runTest {
+        val storage = PersistentCookiesStorage(EmptyLogger())
+        storage.addCookie(Url("https://api.vrchat.cloud/api/1/auth/user"), Cookie(AUTH_COOKIE, "secret"))
+
+        assertEquals(1, storage.get(Url("https://api.vrchat.cloud/api/1/auth/user")).size)
+        assertTrue(storage.get(Url("https://api.github.com/repos/vrcm-team/VRCM/releases/latest")).isEmpty())
+        assertTrue(storage.get(Url("http://api.vrchat.cloud/api/1/auth/user")).isEmpty())
+    }
+
+    @Test
+    fun cookiesFromOtherHostsAreRejected() = runTest {
+        val storage = PersistentCookiesStorage(EmptyLogger())
+
+        storage.addCookie(Url("https://example.com"), Cookie(AUTH_COOKIE, "foreign"))
+
+        assertTrue(storage.get(Url("https://api.vrchat.cloud/api/1/auth/user")).isEmpty())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/LateSessionConsumerIntegrationTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/LateSessionConsumerIntegrationTest.kt
@@ -20,6 +20,7 @@ import io.github.vrcmteam.vrcm.service.FriendService
 import io.github.vrcmteam.vrcm.service.data.AccountDto
 import io.github.vrcmteam.vrcm.storage.AccountCacheManager
 import io.github.vrcmteam.vrcm.storage.AccountDao
+import io.github.vrcmteam.vrcm.storage.InMemorySecureStorage
 import io.github.vrcmteam.vrcm.storage.FriendListCacheDao
 import io.github.vrcmteam.vrcm.storage.UserProfileCacheDao
 import io.github.vrcmteam.vrcm.testing.MainDispatcherTest
@@ -56,7 +57,7 @@ class LateSessionConsumerIntegrationTest : MainDispatcherTest() {
 
         val json = Json { ignoreUnknownKeys = true }
         val client = testClient(json)
-        val accountDao = AccountDao(MapSettings()).also { it.saveAccountInfo(account) }
+        val accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also { it.saveAccountInfo(account) }
         val friendListCacheDao = FriendListCacheDao(MapSettings())
         val cacheManager = AccountCacheManager(
             friendListCacheDao = friendListCacheDao,

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/SearchListPagerModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/SearchListPagerModelTest.kt
@@ -12,6 +12,7 @@ import io.github.vrcmteam.vrcm.presentation.screens.home.data.WorldSearchOptions
 import io.github.vrcmteam.vrcm.service.AuthService
 import io.github.vrcmteam.vrcm.service.data.AccountDto
 import io.github.vrcmteam.vrcm.storage.AccountDao
+import io.github.vrcmteam.vrcm.storage.InMemorySecureStorage
 import io.github.vrcmteam.vrcm.storage.AccountCacheManager
 import io.github.vrcmteam.vrcm.storage.FriendListCacheDao
 import io.github.vrcmteam.vrcm.storage.UserProfileCacheDao
@@ -502,7 +503,7 @@ private fun createFixture(
             json(Json { ignoreUnknownKeys = true })
         }
     }
-    val accountDao = AccountDao(MapSettings()).also { dao ->
+    val accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also { dao ->
         account?.let(dao::saveAccountInfo)
     }
     val authService = AuthService(

--- a/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
@@ -9,7 +9,9 @@ import io.github.vrcmteam.vrcm.service.data.AccountDto
 import io.github.vrcmteam.vrcm.storage.AccountCacheManager
 import io.github.vrcmteam.vrcm.storage.AccountDao
 import io.github.vrcmteam.vrcm.storage.FriendListCacheDao
+import io.github.vrcmteam.vrcm.storage.InMemorySecureStorage
 import io.github.vrcmteam.vrcm.storage.UserProfileCacheDao
+import io.github.vrcmteam.vrcm.testing.MainDispatcherTest
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.MockRequestHandler
@@ -17,6 +19,7 @@ import io.ktor.client.engine.mock.MockRequestHandleScope
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.plugins.defaultRequest
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
@@ -34,7 +37,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-class AuthServiceTest {
+class AuthServiceTest : MainDispatcherTest() {
     @AfterTest
     fun clearSession() = runTest { SharedFlowCentre.emitLogout() }
 
@@ -114,10 +117,11 @@ class AuthServiceTest {
         val cookies = PersistentCookiesStorage(EmptyLogger())
         val client = HttpClient(MockEngine) {
             engine { addHandler(handler) }
+            defaultRequest { url("https://api.vrchat.cloud/api/1/") }
             install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
             install(HttpCookies) { storage = cookies }
         }
-        val accountDao = AccountDao(MapSettings()).also { it.saveAccountInfo(cachedAccount()) }
+        val accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also { it.saveAccountInfo(cachedAccount()) }
         val service = AuthService(
             authApi = AuthApi(client),
             accountDao = accountDao,

--- a/composeApp/src/commonTest/kotlin/storage/AccountDaoSecureStorageTest.kt
+++ b/composeApp/src/commonTest/kotlin/storage/AccountDaoSecureStorageTest.kt
@@ -1,0 +1,58 @@
+package io.github.vrcmteam.vrcm.storage
+
+import com.russhwolf.settings.MapSettings
+import io.github.vrcmteam.vrcm.service.data.AccountDto
+import io.github.vrcmteam.vrcm.storage.DaoKeys.Account.AUTH_KEY
+import io.github.vrcmteam.vrcm.storage.DaoKeys.Account.PASSWORD_KEY
+import io.github.vrcmteam.vrcm.storage.DaoKeys.Account.TWO_FACTOR_AUTH_KEY
+import io.ktor.util.encodeBase64
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class AccountDaoSecureStorageTest {
+    @Test
+    fun secretsAreNotWrittenToRegularSettings() {
+        val settings = MapSettings()
+        val secureStorage = InMemorySecureStorage()
+        val dao = AccountDao(settings, secureStorage)
+
+        dao.saveAccountInfo(account())
+
+        assertFalse(settings.keys.any { it.startsWith(PASSWORD_KEY) })
+        assertFalse(settings.keys.any { it.startsWith(AUTH_KEY) })
+        assertFalse(settings.keys.any { it.startsWith(TWO_FACTOR_AUTH_KEY) })
+        assertEquals(account(), dao.currentAccountDtoOrNull())
+    }
+
+    @Test
+    fun legacySecretsAreMigratedWithoutSigningTheUserOut() {
+        val settings = MapSettings().apply {
+            putString("${DaoKeys.Account.USERNAME_KEY}|usr_a", "alice")
+            putBoolean("${DaoKeys.CURRENT_KEY}|usr_a", true)
+            putString("$PASSWORD_KEY|usr_a", "password".encodeBase64())
+            putString("$AUTH_KEY|usr_a", "auth-cookie")
+            putString("$TWO_FACTOR_AUTH_KEY|usr_a", "2fa-cookie")
+        }
+        val dao = AccountDao(settings, InMemorySecureStorage())
+
+        val restored = dao.currentAccountDtoOrNull()
+
+        assertEquals("password", restored?.password)
+        assertEquals("auth-cookie", restored?.authCookie)
+        assertEquals("2fa-cookie", restored?.twoFactorAuthCookie)
+        assertNull(settings.getStringOrNull("$PASSWORD_KEY|usr_a"))
+        assertNull(settings.getStringOrNull("$AUTH_KEY|usr_a"))
+        assertNull(settings.getStringOrNull("$TWO_FACTOR_AUTH_KEY|usr_a"))
+    }
+
+    private fun account() = AccountDto(
+        userId = "usr_a",
+        username = "alice",
+        password = "password",
+        current = true,
+        authCookie = "auth-cookie",
+        twoFactorAuthCookie = "2fa-cookie",
+    )
+}

--- a/composeApp/src/desktopMain/kotlin/di/modules/PlatformModule.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/di/modules/PlatformModule.desktop.kt
@@ -84,7 +84,10 @@ actual val platformModule: Module = module {
     single<Settings.Factory> {
         object : Settings.Factory {
             override fun create(name: String?): Settings {
-                val file = FileSystem.SYSTEM_TEMPORARY_DIRECTORY.resolve("$name-settings.properties").toFile()
+                val directory = desktopSettingsDirectory().apply { mkdirs() }
+                val file = directory.resolve("$name-settings.properties")
+                val legacyFile = FileSystem.SYSTEM_TEMPORARY_DIRECTORY.resolve("$name-settings.properties").toFile()
+                migrateLegacySettingsFile(legacyFile, file)
                 if (!file.exists()) {
                     file.createNewFile()
                 }

--- a/composeApp/src/desktopMain/kotlin/di/modules/PlatformModule.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/di/modules/PlatformModule.desktop.kt
@@ -7,6 +7,9 @@ import io.github.vrcmteam.vrcm.AppPlatform
 import io.github.vrcmteam.vrcm.DesktopAppPlatform
 import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.DesktopPlatformImageCodec
 import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PlatformImageCodec
+import io.github.vrcmteam.vrcm.storage.DaoKeys
+import io.github.vrcmteam.vrcm.storage.DesktopSecureStorage
+import io.github.vrcmteam.vrcm.storage.SecureStorage
 import okio.FileSystem
 import org.koin.core.logger.Logger
 import org.koin.core.logger.PrintLogger
@@ -22,6 +25,28 @@ import java.nio.file.StandardCopyOption
 import java.util.*
 
 internal const val MAX_SETTINGS_FILE_SIZE = 64L * 1024L * 1024L
+
+internal fun desktopSettingsDirectory(
+    environment: Map<String, String> = System.getenv(),
+    osName: String = System.getProperty("os.name"),
+    userHome: String = System.getProperty("user.home"),
+): File = when {
+    osName.startsWith("Windows", ignoreCase = true) ->
+        File(environment["APPDATA"] ?: File(userHome, "AppData/Roaming").path, "VRCM")
+    osName.startsWith("Mac", ignoreCase = true) ->
+        File(userHome, "Library/Application Support/VRCM")
+    else -> File(environment["XDG_CONFIG_HOME"] ?: File(userHome, ".config").path, "vrcm")
+}
+
+internal fun migrateLegacySettingsFile(legacyFile: File, targetFile: File) {
+    if (targetFile.exists() || !legacyFile.isFile) return
+    targetFile.parentFile.mkdirs()
+    try {
+        Files.move(legacyFile.toPath(), targetFile.toPath(), StandardCopyOption.ATOMIC_MOVE)
+    } catch (_: AtomicMoveNotSupportedException) {
+        Files.move(legacyFile.toPath(), targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+    }
+}
 
 internal fun loadSettingsProperties(file: File): Properties {
     if (file.exists() && file.length() > MAX_SETTINGS_FILE_SIZE) {
@@ -59,7 +84,6 @@ actual val platformModule: Module = module {
     single<Settings.Factory> {
         object : Settings.Factory {
             override fun create(name: String?): Settings {
-                // TODO：保存到非临时文件夹避免误删
                 val file = FileSystem.SYSTEM_TEMPORARY_DIRECTORY.resolve("$name-settings.properties").toFile()
                 if (!file.exists()) {
                     file.createNewFile()
@@ -73,4 +97,5 @@ actual val platformModule: Module = module {
     }
     singleOf<AppPlatform>(::DesktopAppPlatform)
     singleOf(::DesktopPlatformImageCodec) bind PlatformImageCodec::class
+    single<SecureStorage> { DesktopSecureStorage(desktopSettingsDirectory(), DaoKeys.Account.NAME) }
 }

--- a/composeApp/src/desktopMain/kotlin/storage/DesktopSecureStorage.kt
+++ b/composeApp/src/desktopMain/kotlin/storage/DesktopSecureStorage.kt
@@ -1,0 +1,94 @@
+package io.github.vrcmteam.vrcm.storage
+
+import com.sun.jna.platform.win32.Crypt32Util
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.security.SecureRandom
+import java.util.Base64
+import java.util.Properties
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+class DesktopSecureStorage(directory: File, name: String) : SecureStorage {
+    private val secretsFile = directory.resolve("$name-secrets.properties")
+    private val keyFile = directory.resolve("$name-secrets.key")
+    private val isWindows = System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
+    private val lock = Any()
+
+    init { directory.mkdirs() }
+
+    override fun get(key: String): String? = synchronized(lock) {
+        load()[key]?.toString()?.let(::decrypt)
+    }
+
+    override fun put(key: String, value: String) = synchronized(lock) {
+        store(load().apply { setProperty(key, encrypt(value)) })
+    }
+
+    override fun remove(key: String) = synchronized(lock) {
+        val properties = load()
+        if (properties.remove(key) != null) store(properties)
+    }
+
+    override fun clear() = synchronized(lock) {
+        if (secretsFile.exists()) secretsFile.delete()
+    }
+
+    private fun encrypt(value: String): String = if (isWindows) {
+        "dpapi:${encode(Crypt32Util.cryptProtectData(value.toByteArray(StandardCharsets.UTF_8)))}"
+    } else {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey())
+        "aes:${encode(cipher.iv)}:${encode(cipher.doFinal(value.toByteArray(StandardCharsets.UTF_8)))}"
+    }
+
+    private fun decrypt(value: String): String? = runCatching {
+        when {
+            value.startsWith("dpapi:") ->
+                String(Crypt32Util.cryptUnprotectData(decode(value.substringAfter(':'))), StandardCharsets.UTF_8)
+            value.startsWith("aes:") -> {
+                val parts = value.split(':', limit = 3)
+                val cipher = Cipher.getInstance(TRANSFORMATION)
+                cipher.init(Cipher.DECRYPT_MODE, secretKey(), GCMParameterSpec(128, decode(parts[1])))
+                String(cipher.doFinal(decode(parts[2])), StandardCharsets.UTF_8)
+            }
+            else -> null
+        }
+    }.getOrNull()
+
+    private fun secretKey(): SecretKey {
+        if (!keyFile.exists()) {
+            val key = KeyGenerator.getInstance("AES").apply { init(256, SecureRandom()) }.generateKey().encoded
+            Files.write(keyFile.toPath(), key)
+            keyFile.setReadable(false, false)
+            keyFile.setWritable(false, false)
+            keyFile.setReadable(true, true)
+            keyFile.setWritable(true, true)
+        }
+        return SecretKeySpec(Files.readAllBytes(keyFile.toPath()), "AES")
+    }
+
+    private fun load() = Properties().apply {
+        if (secretsFile.isFile) Files.newBufferedReader(secretsFile.toPath(), StandardCharsets.UTF_8).use(::load)
+    }
+
+    private fun store(properties: Properties) {
+        val temporary = Files.createTempFile(secretsFile.parentFile.toPath(), secretsFile.name, ".tmp")
+        try {
+            Files.newBufferedWriter(temporary, StandardCharsets.UTF_8).use { properties.store(it, null) }
+            Files.move(temporary, secretsFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        } finally {
+            Files.deleteIfExists(temporary)
+        }
+    }
+
+    private fun encode(bytes: ByteArray) = Base64.getEncoder().encodeToString(bytes)
+    private fun decode(value: String) = Base64.getDecoder().decode(value)
+
+    private companion object { const val TRANSFORMATION = "AES/GCM/NoPadding" }
+}

--- a/composeApp/src/desktopTest/kotlin/di/modules/PlatformSettingsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/di/modules/PlatformSettingsTest.kt
@@ -10,6 +10,42 @@ import kotlin.test.assertTrue
 
 class PlatformSettingsTest {
     @Test
+    fun settingsDirectoryUsesPlatformApplicationDataLocation() {
+        assertEquals(
+            "C:\\Users\\alice\\AppData\\Roaming\\VRCM",
+            desktopSettingsDirectory(
+                environment = mapOf("APPDATA" to "C:\\Users\\alice\\AppData\\Roaming"),
+                osName = "Windows 11",
+                userHome = "C:\\Users\\alice",
+            ).path,
+        )
+        assertEquals(
+            "/Users/alice/Library/Application Support/VRCM",
+            desktopSettingsDirectory(emptyMap(), "Mac OS X", "/Users/alice").path.replace('\\', '/'),
+        )
+        assertEquals(
+            "/home/alice/.config/vrcm",
+            desktopSettingsDirectory(emptyMap(), "Linux", "/home/alice").path.replace('\\', '/'),
+        )
+    }
+
+    @Test
+    fun legacyTemporarySettingsAreMovedOnce() {
+        val directory = Files.createTempDirectory("vrcm-settings-migration").toFile()
+        try {
+            val legacy = directory.resolve("legacy.properties").apply { writeText("key=value") }
+            val target = directory.resolve("config/settings.properties")
+
+            migrateLegacySettingsFile(legacy, target)
+
+            assertFalse(legacy.exists())
+            assertEquals("key=value", target.readText())
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
+    @Test
     fun settingsRoundTripUsesUtf8() {
         val directory = Files.createTempDirectory("vrcm-settings-test").toFile()
         try {

--- a/composeApp/src/desktopTest/kotlin/storage/DesktopSecureStorageTest.kt
+++ b/composeApp/src/desktopTest/kotlin/storage/DesktopSecureStorageTest.kt
@@ -1,0 +1,28 @@
+package io.github.vrcmteam.vrcm.storage
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class DesktopSecureStorageTest {
+    @Test
+    fun secretsRoundTripWithoutPlaintextOnDisk() {
+        val directory = Files.createTempDirectory("vrcm-secrets-test").toFile()
+        try {
+            val storage = DesktopSecureStorage(directory, "account")
+
+            storage.put("usr_a|password", "highly-sensitive-password")
+
+            assertEquals("highly-sensitive-password", storage.get("usr_a|password"))
+            assertFalse(
+                directory.walkTopDown()
+                    .filter(File::isFile)
+                    .any { it.readBytes().decodeToString().contains("highly-sensitive-password") }
+            )
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+}

--- a/composeApp/src/iosMain/kotlin/di/modules/PlatformModule.ios.kt
+++ b/composeApp/src/iosMain/kotlin/di/modules/PlatformModule.ios.kt
@@ -7,6 +7,9 @@ import io.github.vrcmteam.vrcm.AppPlatform
 import io.github.vrcmteam.vrcm.IosAppPlatform
 import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.IosPlatformImageCodec
 import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PlatformImageCodec
+import io.github.vrcmteam.vrcm.storage.DaoKeys
+import io.github.vrcmteam.vrcm.storage.IosKeychainSecureStorage
+import io.github.vrcmteam.vrcm.storage.SecureStorage
 import org.koin.core.logger.Logger
 import org.koin.core.logger.PrintLogger
 import org.koin.core.module.Module
@@ -21,4 +24,5 @@ actual val platformModule: Module = module {
     singleOf<Settings.Factory>(NSUserDefaultsSettings::Factory)
     singleOf<AppPlatform>(::IosAppPlatform)
     singleOf(::IosPlatformImageCodec) bind PlatformImageCodec::class
+    single<SecureStorage> { IosKeychainSecureStorage(DaoKeys.Account.NAME) }
 }

--- a/composeApp/src/iosMain/kotlin/storage/IosKeychainSecureStorage.kt
+++ b/composeApp/src/iosMain/kotlin/storage/IosKeychainSecureStorage.kt
@@ -1,0 +1,94 @@
+package io.github.vrcmteam.vrcm.storage
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.usePinned
+import kotlinx.cinterop.value
+import platform.CoreFoundation.CFDictionaryRef
+import platform.CoreFoundation.CFTypeRefVar
+import platform.CoreFoundation.kCFBooleanTrue
+import platform.Foundation.NSData
+import platform.Foundation.dataWithBytes
+import platform.Security.SecItemAdd
+import platform.Security.SecItemCopyMatching
+import platform.Security.SecItemDelete
+import platform.Security.SecItemUpdate
+import platform.Security.errSecItemNotFound
+import platform.Security.errSecSuccess
+import platform.Security.kSecAttrAccount
+import platform.Security.kSecAttrService
+import platform.Security.kSecClass
+import platform.Security.kSecClassGenericPassword
+import platform.Security.kSecMatchLimit
+import platform.Security.kSecMatchLimitOne
+import platform.Security.kSecReturnData
+import platform.Security.kSecValueData
+import platform.posix.memcpy
+
+@OptIn(ExperimentalForeignApi::class)
+class IosKeychainSecureStorage(
+    private val service: String,
+) : SecureStorage {
+    override fun get(key: String): String? = memScoped {
+        val result = alloc<CFTypeRefVar>()
+        val status = SecItemCopyMatching(
+            query(key).plus(
+                mapOf(
+                    kSecReturnData to kCFBooleanTrue,
+                    kSecMatchLimit to kSecMatchLimitOne,
+                )
+            ).asDictionary(),
+            result.ptr,
+        )
+        if (status != errSecSuccess) return@memScoped null
+        (result.value as? NSData)?.toByteArray()?.decodeToString()
+    }
+
+    override fun put(key: String, value: String) {
+        val data = value.encodeToByteArray().toNSData()
+        val attributes = mapOf(kSecValueData to data).asDictionary()
+        val updateStatus = SecItemUpdate(query(key).asDictionary(), attributes)
+        val finalStatus = if (updateStatus == errSecItemNotFound) {
+            SecItemAdd(query(key).plus(mapOf<Any?, Any?>(kSecValueData to data)).asDictionary(), null)
+        } else updateStatus
+        check(finalStatus == errSecSuccess) { "Failed to persist credential in Keychain ($finalStatus)" }
+    }
+
+    override fun remove(key: String) {
+        SecItemDelete(query(key).asDictionary())
+    }
+
+    override fun clear() {
+        SecItemDelete(
+            mapOf(
+                kSecClass to kSecClassGenericPassword,
+                kSecAttrService to service,
+            ).asDictionary()
+        )
+    }
+
+    private fun query(key: String): Map<Any?, Any?> = mapOf(
+        kSecClass to kSecClassGenericPassword,
+        kSecAttrService to service,
+        kSecAttrAccount to key,
+    )
+}
+
+@OptIn(ExperimentalForeignApi::class)
+@Suppress("UNCHECKED_CAST")
+private fun Map<*, *>.asDictionary(): CFDictionaryRef = this as CFDictionaryRef
+
+@OptIn(ExperimentalForeignApi::class)
+private fun ByteArray.toNSData(): NSData = if (isEmpty()) {
+    NSData.dataWithBytes(bytes = null, length = 0u)
+} else usePinned { pinned ->
+    NSData.dataWithBytes(bytes = pinned.addressOf(0), length = size.toULong())
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun NSData.toByteArray(): ByteArray = ByteArray(length.toInt()).also { output ->
+    output.usePinned { pinned -> memcpy(pinned.addressOf(0), bytes, length) }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ chrisbanes-haze = "1.3.1"
 landscapist = "2.4.7"
 robolectric = "4.16.1"
 filekit = "0.11.0"
+jna = "5.17.0"
 
 [libraries]
 # kotlinx
@@ -82,6 +83,7 @@ landscapist-coil = { module = "com.github.skydoves:landscapist-coil3", version.r
 landscapist-animation = { module = "com.github.skydoves:landscapist-animation", version.ref = "landscapist" }
 landscapist-placeholder = { module = "com.github.skydoves:landscapist-placeholder", version.ref = "landscapist" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }
 
 # chrisbanes-haze
 chrisbanes-haze = { module = "dev.chrisbanes.haze:haze", version.ref = "chrisbanes-haze" }


### PR DESCRIPTION
## 背景

项目准备发布正式版本时，对账号会话、跨平台存储和发布测试门禁做了专项检查。本 PR 修复了 4 个会直接影响正式发布的问题，同时保持现有登录、多账号切换、自动登录及页面视觉体验不变。

## 修复内容

### 1. 限制 VRChat 登录 Cookie 的发送范围

此前 `PersistentCookiesStorage.get()` 会忽略请求目标，向共用 `HttpClient` 的所有请求返回完整 Cookie。版本检查会访问 `api.github.com`，因此 VRChat 的 `auth` 和 `twoFactorAuth` Cookie 存在被附带到非 VRChat 域名的风险。

本次修改：

- 仅允许 Cookie 发往 `https://api.vrchat.cloud`。
- 拒绝 HTTP 请求和其他主机读取或写入 VRChat Cookie。
- 为内存 Cookie 缓存增加并发访问保护。
- 增加跨域、非 HTTPS 和外部来源 Cookie 的回归测试。

### 2. 使用平台安全存储长期保存密码和会话凭据

长期保存密码是现有产品需求，因此本 PR 保留密码记忆、自动登录和多账号切换逻辑，只替换底层存储方式。普通设置中不再保存可直接还原的 Base64 密码或明文会话 Cookie。

各平台实现：

- Android：Android Keystore 管理 AES 密钥，使用 AES-GCM 加密凭据。
- iOS：使用 Keychain 的 Generic Password 条目。
- Windows：使用绑定当前 Windows 用户的 DPAPI。
- macOS/Linux 桌面端：使用安装环境生成的 AES-GCM 密钥，并限制密钥文件为当前用户可读写。

兼容与体验：

- 旧版本 Base64 密码及明文 Cookie 会在首次读取时自动迁移。
- 只有安全存储确认写入成功后才删除旧值，避免迁移中断造成账号丢失。
- 用户无需重新登录，不改变登录页、多账号选择或自动登录流程。
- 退出登录只移除当前认证 Cookie，仍保留密码以符合现有账号记忆行为。
- 删除账号会同步删除该账号的密码及全部会话凭据。
- Android 云备份和设备迁移明确排除账号元数据及加密凭据文件，其他普通设置仍可备份。

### 3. 将桌面设置迁移出系统临时目录

此前桌面端将所有 Settings 保存到系统临时目录，系统清理后可能丢失账号列表、偏好和缓存。

本次修改将普通设置保存到标准应用数据目录：

- Windows：`%APPDATA%/VRCM`
- macOS：`~/Library/Application Support/VRCM`
- Linux：`$XDG_CONFIG_HOME/vrcm`，未配置时使用 `~/.config/vrcm`

升级时会自动将旧临时目录文件移动到新目录；目标文件已存在时不会覆盖，避免破坏新数据。写入仍沿用临时文件加替换的原子更新策略。

### 4. 修复缓存用户资料的过期在线状态及测试门禁

用户资料缓存可能保留上次在线状态、世界和实例位置。离线启动或网络响应前直接显示这些字段，会让用户看到已经过期的在线位置。相关测试还引用了缺失的扩展函数，导致完整测试源码无法编译。

本次修改：

- 从缓存恢复资料时先清除历史在线、世界、实例和旅行中位置。
- 如果当前好友状态流已有实时快照，再用实时状态、位置、最近登录和平台信息覆盖缓存离线状态。
- 后续好友状态更新会同步更新资料页状态。
- 补齐并恢复相关回归测试，使完整测试门禁重新可用。

## 提交拆分

- `cdb472a` `fix: restrict auth cookies to VRChat API`
- `6829aca` `fix: store account credentials securely`
- `947b326` `fix: persist desktop settings in app data`
- `cf7dcb3` `fix: reconcile cached user presence`

## 验证结果

- [x] `./gradlew :composeApp:allTests`
- [x] 桌面端 322 项测试
- [x] Android Debug 单元测试
- [x] iOS Simulator ARM64 主代码与测试源码编译
- [x] `./gradlew :composeApp:lintRelease`
- [x] `./gradlew :composeApp:assembleRelease`
- [x] `./gradlew :composeApp:createDistributable`
- [x] Android release APK 签名验证

## 风险与审阅重点

建议重点检查以下边界：

1. Android Keystore 和 iOS Keychain 在升级安装后的旧凭据迁移路径。
2. Windows DPAPI 凭据只能由创建它的 Windows 用户解密，这是预期安全属性。
3. macOS/Linux 桌面端密钥文件权限依赖文件系统权限语义。
4. Cookie 主机限制当前精确匹配 `api.vrchat.cloud`；若未来 VRChat API 切换域名，需要同步更新允许列表。

本 PR 不包含视觉样式调整，也不改变用户可见的登录和账号管理操作。