### PR TITLE
fix(gallery): 同步 Print 预览边界与揭示动画

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/ImagePreviewDialog.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/ImagePreviewDialog.kt
@@ -41,7 +41,6 @@ import io.github.vrcmteam.vrcm.service.AuthService
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import kotlin.math.min
@@ -385,7 +384,6 @@ internal fun rememberPrintCropRevealProgress(
                 .collectLatest { targetState ->
                     when (targetState) {
                         EnterExitState.Visible -> {
-                            delay(PrintBoundsTransitionDurationMillis.toLong())
                             progress.animateTo(
                                 targetValue = 1f,
                                 animationSpec = tween(durationMillis = PrintRevealTransitionDurationMillis),

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/PrintDisplayGeometry.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/PrintDisplayGeometry.kt
@@ -20,7 +20,7 @@ import kotlin.math.max
 import kotlin.math.min
 
 internal const val PrintBoundsTransitionDurationMillis = 500
-internal const val PrintRevealTransitionDurationMillis = 500
+internal const val PrintRevealTransitionDurationMillis = PrintBoundsTransitionDurationMillis
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 internal val PrintBoundsTransform = BoundsTransform { _, _ ->

--- a/composeApp/src/desktopTest/kotlin/presentation/screens/gallery/PrintSharedBoundsRenderingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/presentation/screens/gallery/PrintSharedBoundsRenderingTest.kt
@@ -125,7 +125,7 @@ class PrintSharedBoundsRenderingTest {
     }
 
     @Test
-    fun revealProgressAndVisibleBoundsShrinkDuringExit() = runComposeUiTest {
+    fun revealProgressAndVisibleBoundsChangeContinuouslyInBothDirections() = runComposeUiTest {
         mainClock.autoAdvance = false
         var showPreview by mutableStateOf(false)
         var observedProgress = Float.NaN
@@ -186,16 +186,36 @@ class PrintSharedBoundsRenderingTest {
         }
 
         waitForIdle()
+        val collapsedBeforeEnter = onNodeWithTag(RootTag).captureToImage()
         runOnIdle { showPreview = true }
         waitForIdle()
-        mainClock.advanceTimeBy(
-            PrintBoundsTransitionDurationMillis.toLong() +
-                PrintRevealTransitionDurationMillis + 100L
+        mainClock.advanceTimeBy(PrintRevealTransitionDurationMillis / 2L)
+        waitForIdle()
+
+        val enteringMidpointProgress = runOnIdle { observedProgress }
+        assertTrue(
+            enteringMidpointProgress > 0f && enteringMidpointProgress < 1f,
+            "enter midpoint should be partially revealed, but progress was $enteringMidpointProgress",
         )
+        val enteringMidpointImage = onNodeWithTag(RootTag).captureToImage()
+
+        mainClock.advanceTimeBy(PrintRevealTransitionDurationMillis / 2L)
         waitForIdle()
 
         assertEquals(1f, runOnIdle { observedProgress }, ProgressTolerance)
         val fullImage = onNodeWithTag(RootTag).captureToImage()
+
+        val previewBounds = Rect(0f, 0f, PreviewWidth.value, PreviewHeight.value)
+        val sourceCrop = PrintDisplayGeometry.cropRect(
+            bounds = previewBounds,
+            placement = PrintCanvasPlacement.FitCenter,
+        )
+        assertRevealBounds(
+            full = findPrintBounds(fullImage, "fully revealed preview"),
+            midpoint = findPrintBounds(enteringMidpointImage, "enter midpoint"),
+            collapsed = findPrintBounds(collapsedBeforeEnter, "collapsed preview before enter"),
+            midpointProgress = enteringMidpointProgress,
+        )
 
         runOnIdle { showPreview = false }
         waitForIdle()
@@ -207,15 +227,10 @@ class PrintSharedBoundsRenderingTest {
             midpointProgress > 0f && midpointProgress < 1f,
             "exit midpoint should be partially cropped, but progress was $midpointProgress",
         )
-        val previewBounds = Rect(0f, 0f, PreviewWidth.value, PreviewHeight.value)
         val midpointBounds = PrintDisplayGeometry.revealedCropRect(
             bounds = previewBounds,
             placement = PrintCanvasPlacement.FitCenter,
             revealProgress = midpointProgress,
-        )
-        val sourceCrop = PrintDisplayGeometry.cropRect(
-            bounds = previewBounds,
-            placement = PrintCanvasPlacement.FitCenter,
         )
         assertTrue(midpointBounds.left > 0f && midpointBounds.left < sourceCrop.left)
         assertTrue(midpointBounds.top > 0f && midpointBounds.top < sourceCrop.top)


### PR DESCRIPTION
关联 #35

## 实现思路

Print 预览原先先用 500 毫秒完成照片边界移动，等待结束后才再用 500 毫秒展开完整画面。后半段会形成一次独立的尺寸变化，看起来像照片在动画中途突然放大。本次让画面揭示与边界移动从打开第一帧起同步进行，并让两者共用同一时长；关闭时继续沿同一路径反向收拢。

## 验收标准自查

- [x] 点开 Print 相册中的照片时，照片从缩略图连续过渡到完整预览，不再在中途二次放大或闪屏。验证：Desktop Compose 像素测试在打开后 250 毫秒确认可见边界处于缩略图与完整预览之间，并在 500 毫秒确认到达完整预览。
- [x] 关闭预览时，照片继续平滑收拢回缩略图。验证：同一像素测试在关闭后 250 毫秒检查中间边界，在 500 毫秒检查收拢完成。
- [x] 普通图库预览、相册布局、保存与手势缩放行为不变。验证：改动只作用于直接图片地址启用的 Print 裁剪揭示状态及其测试。

## 自测结果

- `:composeApp:desktopTest --tests io.github.vrcmteam.vrcm.presentation.screens.gallery.PrintSharedBoundsRenderingTest --tests io.github.vrcmteam.vrcm.presentation.screens.gallery.PrintDisplayGeometryTest`：`BUILD SUCCESSFUL`。
- `:composeApp:assembleDebug`：`BUILD SUCCESSFUL`。
- `check-gate.sh implement-issue 35`：`quality gate: pass`，最终提交为 `5f3e64b`。
- 完整 `:composeApp:desktopTest` 共执行 322 项，321 项通过；主分支已有的 `PlatformSettingsTest.settingsDirectoryUsesPlatformApplicationDataLocation` 在 Linux 上把 Windows 路径分隔符规范化为 `/`，因此 1 项失败，与本次 Print 改动无关。
- 真机验证未执行：仓库设备选择脚本返回 `device_test is not enabled for vrcm-team_VRCM`，流程在连接设备前停止，没有操作任何设备。

## 自评风险点

风险较低。改动保留现有 500 毫秒时长、裁剪几何、反向取消逻辑和完整 Print 画面，只调整进入揭示的启动时机。主要风险是不同刷新率设备上的主观动画观感；像素级测试锁定了 250 毫秒中间态和 500 毫秒终态，但当前仓库未开放真机通道。

## 代码逻辑图

```mermaid
stateDiagram-v2
    [*] --> Cropped
    Cropped: cropRevealProgress = 0f
    Cropped --> Revealing: targetState = Visible
    Revealing: rememberPrintCropRevealProgress animateTo 1f
    Revealing --> Revealed: 500ms complete
    Revealed: cropRevealProgress = 1f
    Revealing --> Collapsing: targetState = PostExit
    Revealed --> Collapsing: targetState = PostExit
    Collapsing: collectLatest cancels prior animation and animateTo 0f
    Collapsing --> Cropped: 500ms complete
```

## 实现假设清单

- 假设完整 Print 画面仍需保留，问题只要求消除中途突变，不要求移除白色画布的揭示效果。依据：已合并的 #17 明确建立了完整画面揭示及双向收拢，#35 只反馈动画过程突然变大。
- 假设边界移动的 500 毫秒时长保持不变。依据：现有 `PrintBoundsTransform` 和回归测试以该时长为既有行为，#35 未要求调整整体速度。
- 除以上保留既有体验的判断外，本次无未经验证的接口、数据或兼容性假设。

## 实现说明(供追问)

### 关键决策

让画面从打开第一帧起与照片位置、尺寸一起展开，并把揭示时长直接绑定到边界移动时长。没有删除完整 Print 画面揭示，因为那会改变最终预览内容，超出本 issue 对动画异常的修复范围。

### 覆盖的场景

覆盖正常打开、正常关闭，以及打开尚未完成就关闭时取消正向动画并反向收拢的路径。照片加载中与加载失败仍沿用原有提示。

### 明确未覆盖

不改普通图库图片动画，不改 Print 网格布局、图片内容、保存、缩放和平移手势。未做真机截图验收，因为仓库当前没有启用设备测试通道。

### 关键假设

完整 Print 画面和现有 500 毫秒总时长继续作为既有体验保留；依据见上方实现假设清单。