### PR TITLE
refactor(desktop): inject filesystem into persisted storage

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -62,6 +62,7 @@ kotlin {
 
             implementation(libs.ktor.client.okhttp)
             implementation(libs.jna.platform)
+            implementation(libs.okio)
         }
 
         val desktopTest by getting
@@ -69,6 +70,7 @@ kotlin {
             implementation(compose.desktop.currentOs)
             @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
             implementation(compose.uiTest)
+            implementation(libs.okio.fakefilesystem)
         }
 
         commonMain.dependencies {

--- a/composeApp/src/desktopMain/kotlin/di/modules/PlatformModule.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/di/modules/PlatformModule.desktop.kt
@@ -10,18 +10,16 @@ import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PlatformImage
 import io.github.vrcmteam.vrcm.storage.DaoKeys
 import io.github.vrcmteam.vrcm.storage.DesktopSecureStorage
 import io.github.vrcmteam.vrcm.storage.SecureStorage
+import io.github.vrcmteam.vrcm.storage.moveReplacing
 import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
 import org.koin.core.logger.Logger
 import org.koin.core.logger.PrintLogger
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
-import java.io.File
-import java.nio.charset.StandardCharsets
-import java.nio.file.AtomicMoveNotSupportedException
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 import java.util.*
 
 internal const val MAX_SETTINGS_FILE_SIZE = 64L * 1024L * 1024L
@@ -30,51 +28,65 @@ internal fun desktopSettingsDirectory(
     environment: Map<String, String> = System.getenv(),
     osName: String = System.getProperty("os.name"),
     userHome: String = System.getProperty("user.home"),
-): File = when {
-    osName.startsWith("Windows", ignoreCase = true) ->
-        File(environment["APPDATA"] ?: File(userHome, "AppData/Roaming").path, "VRCM")
-    osName.startsWith("Mac", ignoreCase = true) ->
-        File(userHome, "Library/Application Support/VRCM")
-    else -> File(environment["XDG_CONFIG_HOME"] ?: File(userHome, ".config").path, "vrcm")
-}
-
-internal fun migrateLegacySettingsFile(legacyFile: File, targetFile: File) {
-    if (targetFile.exists() || !legacyFile.isFile) return
-    targetFile.parentFile.mkdirs()
-    try {
-        Files.move(legacyFile.toPath(), targetFile.toPath(), StandardCopyOption.ATOMIC_MOVE)
-    } catch (_: AtomicMoveNotSupportedException) {
-        Files.move(legacyFile.toPath(), targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
-    }
-}
-
-internal fun loadSettingsProperties(file: File): Properties {
-    if (file.exists() && file.length() > MAX_SETTINGS_FILE_SIZE) {
-        val quarantine = file.parentFile.resolve("${file.name}.corrupt-${System.currentTimeMillis()}")
-        Files.move(file.toPath(), quarantine.toPath())
-    }
-    if (!file.exists()) file.createNewFile()
-    return Properties().apply {
-        Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8).use(::load)
-    }
-}
-
-internal fun storeSettingsProperties(file: File, properties: Properties, comment: String) {
-    val temporary = Files.createTempFile(file.parentFile.toPath(), "${file.name}.", ".tmp")
-    try {
-        Files.newBufferedWriter(temporary, StandardCharsets.UTF_8).use { properties.store(it, comment) }
-        try {
-            Files.move(
-                temporary,
-                file.toPath(),
-                StandardCopyOption.ATOMIC_MOVE,
-                StandardCopyOption.REPLACE_EXISTING,
-            )
-        } catch (_: AtomicMoveNotSupportedException) {
-            Files.move(temporary, file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+): Path {
+    val directory = when {
+        osName.startsWith("Windows", ignoreCase = true) -> {
+            val applicationData = environment["APPDATA"]
+                ?: "${userHome.trimEnd('/', '\\')}\\AppData\\Roaming"
+            "${applicationData.trimEnd('/', '\\')}\\VRCM"
         }
+        osName.startsWith("Mac", ignoreCase = true) ->
+            "${userHome.trimEnd('/', '\\')}/Library/Application Support/VRCM"
+        else -> {
+            val configHome = environment["XDG_CONFIG_HOME"]
+                ?: "${userHome.trimEnd('/', '\\')}/.config"
+            "${configHome.trimEnd('/', '\\')}/vrcm"
+        }
+    }
+    return directory.toPath()
+}
+
+internal fun migrateLegacySettingsFile(fileSystem: FileSystem, legacyFile: Path, targetFile: Path) {
+    if (fileSystem.exists(targetFile) || fileSystem.metadataOrNull(legacyFile)?.isRegularFile != true) return
+    fileSystem.createDirectories(requireNotNull(targetFile.parent))
+    fileSystem.moveReplacing(legacyFile, targetFile)
+}
+
+internal fun loadSettingsProperties(
+    fileSystem: FileSystem,
+    file: Path,
+    maxFileSize: Long = MAX_SETTINGS_FILE_SIZE,
+): Properties {
+    if ((fileSystem.metadataOrNull(file)?.size ?: 0L) > maxFileSize) {
+        val quarantine = requireNotNull(file.parent) / "${file.name}.corrupt-${System.currentTimeMillis()}"
+        fileSystem.moveReplacing(file, quarantine)
+    }
+    fileSystem.createDirectories(requireNotNull(file.parent))
+    if (!fileSystem.exists(file)) fileSystem.write(file) {}
+    return Properties().apply {
+        fileSystem.read(file) { load(inputStream().reader(Charsets.UTF_8)) }
+    }
+}
+
+internal fun storeSettingsProperties(
+    fileSystem: FileSystem,
+    file: Path,
+    properties: Properties,
+    comment: String,
+) {
+    val parent = requireNotNull(file.parent)
+    fileSystem.createDirectories(parent)
+    val temporary = parent / "${file.name}.${UUID.randomUUID()}.tmp"
+    try {
+        fileSystem.write(temporary, mustCreate = true) {
+            outputStream().writer(Charsets.UTF_8).also { writer ->
+                properties.store(writer, comment)
+                writer.flush()
+            }
+        }
+        fileSystem.moveReplacing(temporary, file)
     } finally {
-        Files.deleteIfExists(temporary)
+        fileSystem.delete(temporary, mustExist = false)
     }
 }
 
@@ -84,21 +96,22 @@ actual val platformModule: Module = module {
     single<Settings.Factory> {
         object : Settings.Factory {
             override fun create(name: String?): Settings {
-                val directory = desktopSettingsDirectory().apply { mkdirs() }
-                val file = directory.resolve("$name-settings.properties")
-                val legacyFile = FileSystem.SYSTEM_TEMPORARY_DIRECTORY.resolve("$name-settings.properties").toFile()
-                migrateLegacySettingsFile(legacyFile, file)
-                if (!file.exists()) {
-                    file.createNewFile()
-                }
-                val delegate = loadSettingsProperties(file)
+                val fileSystem = FileSystem.SYSTEM
+                val directory = desktopSettingsDirectory()
+                fileSystem.createDirectories(directory)
+                val file = directory / "$name-settings.properties"
+                val legacyFile = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "$name-settings.properties"
+                migrateLegacySettingsFile(fileSystem, legacyFile, file)
+                val delegate = loadSettingsProperties(fileSystem, file)
                 return PropertiesSettings(delegate){
-                    storeSettingsProperties(file, it, "$name-settings")
+                    storeSettingsProperties(fileSystem, file, it, "$name-settings")
                 }
             }
         }
     }
     singleOf<AppPlatform>(::DesktopAppPlatform)
     singleOf(::DesktopPlatformImageCodec) bind PlatformImageCodec::class
-    single<SecureStorage> { DesktopSecureStorage(desktopSettingsDirectory(), DaoKeys.Account.NAME) }
+    single<SecureStorage> {
+        DesktopSecureStorage(FileSystem.SYSTEM, desktopSettingsDirectory(), DaoKeys.Account.NAME)
+    }
 }

--- a/composeApp/src/desktopMain/kotlin/storage/DesktopFileSystem.kt
+++ b/composeApp/src/desktopMain/kotlin/storage/DesktopFileSystem.kt
@@ -1,0 +1,19 @@
+package io.github.vrcmteam.vrcm.storage
+
+import okio.FileSystem
+import okio.IOException
+import okio.Path
+
+internal fun FileSystem.moveReplacing(source: Path, target: Path) {
+    try {
+        atomicMove(source, target)
+    } catch (atomicMoveFailure: IOException) {
+        try {
+            copy(source, target)
+            delete(source, mustExist = true)
+        } catch (fallbackFailure: IOException) {
+            fallbackFailure.addSuppressed(atomicMoveFailure)
+            throw fallbackFailure
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/storage/DesktopSecureStorage.kt
+++ b/composeApp/src/desktopMain/kotlin/storage/DesktopSecureStorage.kt
@@ -1,26 +1,34 @@
 package io.github.vrcmteam.vrcm.storage
 
 import com.sun.jna.platform.win32.Crypt32Util
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toOkioPath
 import java.io.File
 import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 import java.security.SecureRandom
 import java.util.Base64
 import java.util.Properties
+import java.util.UUID
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
 
-class DesktopSecureStorage(directory: File, name: String) : SecureStorage {
-    private val secretsFile = directory.resolve("$name-secrets.properties")
-    private val keyFile = directory.resolve("$name-secrets.key")
-    private val isWindows = System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
+class DesktopSecureStorage(
+    private val fileSystem: FileSystem,
+    directory: Path,
+    name: String,
+    private val isWindows: Boolean = System.getProperty("os.name").startsWith("Windows", ignoreCase = true),
+) : SecureStorage {
+    constructor(directory: File, name: String) : this(FileSystem.SYSTEM, directory.toOkioPath(), name)
+
+    private val secretsFile = directory / "$name-secrets.properties"
+    private val keyFile = directory / "$name-secrets.key"
     private val lock = Any()
 
-    init { directory.mkdirs() }
+    init { fileSystem.createDirectories(directory) }
 
     override fun get(key: String): String? = synchronized(lock) {
         load()[key]?.toString()?.let(::decrypt)
@@ -36,7 +44,7 @@ class DesktopSecureStorage(directory: File, name: String) : SecureStorage {
     }
 
     override fun clear() = synchronized(lock) {
-        if (secretsFile.exists()) secretsFile.delete()
+        fileSystem.delete(secretsFile, mustExist = false)
     }
 
     private fun encrypt(value: String): String = if (isWindows) {
@@ -62,33 +70,46 @@ class DesktopSecureStorage(directory: File, name: String) : SecureStorage {
     }.getOrNull()
 
     private fun secretKey(): SecretKey {
-        if (!keyFile.exists()) {
+        if (!fileSystem.exists(keyFile)) {
             val key = KeyGenerator.getInstance("AES").apply { init(256, SecureRandom()) }.generateKey().encoded
-            Files.write(keyFile.toPath(), key)
-            keyFile.setReadable(false, false)
-            keyFile.setWritable(false, false)
-            keyFile.setReadable(true, true)
-            keyFile.setWritable(true, true)
+            fileSystem.write(keyFile, mustCreate = true) { write(key) }
+            if (fileSystem === FileSystem.SYSTEM) restrictKeyFilePermissions(keyFile.toFile())
         }
-        return SecretKeySpec(Files.readAllBytes(keyFile.toPath()), "AES")
+        return SecretKeySpec(fileSystem.read(keyFile) { readByteArray() }, "AES")
     }
 
     private fun load() = Properties().apply {
-        if (secretsFile.isFile) Files.newBufferedReader(secretsFile.toPath(), StandardCharsets.UTF_8).use(::load)
+        if (fileSystem.metadataOrNull(secretsFile)?.isRegularFile == true) {
+            fileSystem.read(secretsFile) { load(inputStream().reader(StandardCharsets.UTF_8)) }
+        }
     }
 
     private fun store(properties: Properties) {
-        val temporary = Files.createTempFile(secretsFile.parentFile.toPath(), secretsFile.name, ".tmp")
+        val temporary = requireNotNull(secretsFile.parent) / "${secretsFile.name}.${UUID.randomUUID()}.tmp"
         try {
-            Files.newBufferedWriter(temporary, StandardCharsets.UTF_8).use { properties.store(it, null) }
-            Files.move(temporary, secretsFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            fileSystem.write(temporary, mustCreate = true) {
+                outputStream().writer(StandardCharsets.UTF_8).also { writer ->
+                    properties.store(writer, null)
+                    writer.flush()
+                }
+            }
+            fileSystem.moveReplacing(temporary, secretsFile)
         } finally {
-            Files.deleteIfExists(temporary)
+            fileSystem.delete(temporary, mustExist = false)
         }
     }
 
     private fun encode(bytes: ByteArray) = Base64.getEncoder().encodeToString(bytes)
     private fun decode(value: String) = Base64.getDecoder().decode(value)
 
-    private companion object { const val TRANSFORMATION = "AES/GCM/NoPadding" }
+    private companion object {
+        const val TRANSFORMATION = "AES/GCM/NoPadding"
+
+        fun restrictKeyFilePermissions(file: File) {
+            file.setReadable(false, false)
+            file.setWritable(false, false)
+            file.setReadable(true, true)
+            file.setWritable(true, true)
+        }
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/di/modules/PlatformSettingsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/di/modules/PlatformSettingsTest.kt
@@ -1,7 +1,10 @@
 package io.github.vrcmteam.vrcm.di.modules
 
-import java.nio.file.Files
-import java.io.RandomAccessFile
+import okio.ForwardingFileSystem
+import okio.IOException
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
 import java.util.Properties
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -17,64 +20,94 @@ class PlatformSettingsTest {
                 environment = mapOf("APPDATA" to "C:\\Users\\alice\\AppData\\Roaming"),
                 osName = "Windows 11",
                 userHome = "C:\\Users\\alice",
-            ).path,
+            ).toString(),
         )
         assertEquals(
             "/Users/alice/Library/Application Support/VRCM",
-            desktopSettingsDirectory(emptyMap(), "Mac OS X", "/Users/alice").path.replace('\\', '/'),
+            desktopSettingsDirectory(emptyMap(), "Mac OS X", "/Users/alice").toString(),
         )
         assertEquals(
             "/home/alice/.config/vrcm",
-            desktopSettingsDirectory(emptyMap(), "Linux", "/home/alice").path.replace('\\', '/'),
+            desktopSettingsDirectory(emptyMap(), "Linux", "/home/alice").toString(),
         )
     }
 
     @Test
     fun legacyTemporarySettingsAreMovedOnce() {
-        val directory = Files.createTempDirectory("vrcm-settings-migration").toFile()
-        try {
-            val legacy = directory.resolve("legacy.properties").apply { writeText("key=value") }
-            val target = directory.resolve("config/settings.properties")
+        val fileSystem = FakeFileSystem()
+        val legacy = "/temporary/legacy.properties".toPath()
+        val target = "/config/settings.properties".toPath()
+        fileSystem.createDirectories(legacy.parent!!)
+        fileSystem.write(legacy) { writeUtf8("key=value") }
 
-            migrateLegacySettingsFile(legacy, target)
+        migrateLegacySettingsFile(fileSystem, legacy, target)
 
-            assertFalse(legacy.exists())
-            assertEquals("key=value", target.readText())
-        } finally {
-            directory.deleteRecursively()
-        }
+        assertFalse(fileSystem.exists(legacy))
+        assertEquals("key=value", fileSystem.read(target) { readUtf8() })
+        fileSystem.checkNoOpenFiles()
+    }
+
+    @Test
+    fun legacyTemporarySettingsFallBackWhenAtomicMovesAreUnavailable() {
+        val backingFileSystem = FakeFileSystem()
+        val fileSystem = withoutAtomicMoves(backingFileSystem)
+        val legacy = "/temporary/legacy.properties".toPath()
+        val target = "/config/settings.properties".toPath()
+        backingFileSystem.createDirectories(legacy.parent!!)
+        backingFileSystem.write(legacy) { writeUtf8("key=value") }
+
+        migrateLegacySettingsFile(fileSystem, legacy, target)
+
+        assertFalse(backingFileSystem.exists(legacy))
+        assertEquals("key=value", backingFileSystem.read(target) { readUtf8() })
+        backingFileSystem.checkNoOpenFiles()
     }
 
     @Test
     fun settingsRoundTripUsesUtf8() {
-        val directory = Files.createTempDirectory("vrcm-settings-test").toFile()
-        try {
-            val file = directory.resolve("settings.properties")
-            val expected = Properties().apply { setProperty("profile", "中文状态") }
+        val fileSystem = FakeFileSystem()
+        val file = "/settings/settings.properties".toPath()
+        val expected = Properties().apply { setProperty("profile", "中文状态") }
 
-            storeSettingsProperties(file, expected, "test")
+        storeSettingsProperties(fileSystem, file, expected, "test")
 
-            assertEquals("中文状态", loadSettingsProperties(file).getProperty("profile"))
-        } finally {
-            directory.deleteRecursively()
-        }
+        assertEquals("中文状态", loadSettingsProperties(fileSystem, file).getProperty("profile"))
+        fileSystem.checkNoOpenFiles()
+    }
+
+    @Test
+    fun settingsRoundTripFallsBackWhenAtomicMovesAreUnavailable() {
+        val backingFileSystem = FakeFileSystem()
+        val fileSystem = withoutAtomicMoves(backingFileSystem)
+        val file = "/settings/settings.properties".toPath()
+        val expected = Properties().apply { setProperty("profile", "中文状态") }
+
+        storeSettingsProperties(fileSystem, file, expected, "test")
+
+        assertEquals("中文状态", loadSettingsProperties(fileSystem, file).getProperty("profile"))
+        backingFileSystem.checkNoOpenFiles()
     }
 
     @Test
     fun oversizedSettingsFileIsQuarantined() {
-        val directory = Files.createTempDirectory("vrcm-settings-test").toFile()
-        try {
-            val file = directory.resolve("settings.properties")
-            RandomAccessFile(file, "rw").use { it.setLength(MAX_SETTINGS_FILE_SIZE + 1) }
+        val fileSystem = FakeFileSystem()
+        val directory = "/settings".toPath()
+        val file = directory / "settings.properties"
+        fileSystem.createDirectories(directory)
+        fileSystem.write(file) { writeUtf8("oversized") }
 
-            val loaded = loadSettingsProperties(file)
+        val loaded = loadSettingsProperties(fileSystem, file, maxFileSize = 4L)
 
-            assertTrue(loaded.isEmpty())
-            assertEquals(0, file.length())
-            assertTrue(directory.listFiles().orEmpty().any { it.name.startsWith("settings.properties.corrupt-") })
-            assertFalse(directory.listFiles().orEmpty().any { it.name.endsWith(".tmp") })
-        } finally {
-            directory.deleteRecursively()
-        }
+        assertTrue(loaded.isEmpty())
+        assertEquals(0L, fileSystem.metadata(file).size)
+        assertTrue(fileSystem.list(directory).any { it.name.startsWith("settings.properties.corrupt-") })
+        assertFalse(fileSystem.list(directory).any { it.name.endsWith(".tmp") })
+        fileSystem.checkNoOpenFiles()
+    }
+}
+
+private fun withoutAtomicMoves(fileSystem: FakeFileSystem) = object : ForwardingFileSystem(fileSystem) {
+    override fun atomicMove(source: Path, target: Path): Nothing {
+        throw IOException("atomic moves unavailable")
     }
 }

--- a/composeApp/src/desktopTest/kotlin/storage/DesktopSecureStorageTest.kt
+++ b/composeApp/src/desktopTest/kotlin/storage/DesktopSecureStorageTest.kt
@@ -1,28 +1,50 @@
 package io.github.vrcmteam.vrcm.storage
 
-import java.io.File
-import java.nio.file.Files
+import okio.ForwardingFileSystem
+import okio.IOException
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class DesktopSecureStorageTest {
     @Test
-    fun secretsRoundTripWithoutPlaintextOnDisk() {
-        val directory = Files.createTempDirectory("vrcm-secrets-test").toFile()
-        try {
-            val storage = DesktopSecureStorage(directory, "account")
+    fun credentialsAndEncryptionKeyPersistWithoutPlaintext() {
+        val fileSystem = FakeFileSystem()
+        val directory = "/secure-storage".toPath()
+        val storage = DesktopSecureStorage(fileSystem, directory, "account", isWindows = false)
 
-            storage.put("usr_a|password", "highly-sensitive-password")
+        storage.put("usr_a|password", "highly-sensitive-password")
 
-            assertEquals("highly-sensitive-password", storage.get("usr_a|password"))
-            assertFalse(
-                directory.walkTopDown()
-                    .filter(File::isFile)
-                    .any { it.readBytes().decodeToString().contains("highly-sensitive-password") }
-            )
-        } finally {
-            directory.deleteRecursively()
+        val keyFile = directory / "account-secrets.key"
+        val credentialsFile = directory / "account-secrets.properties"
+        assertTrue(fileSystem.exists(keyFile))
+        assertTrue(fileSystem.exists(credentialsFile))
+        assertFalse(fileSystem.read(credentialsFile) { readUtf8() }.contains("highly-sensitive-password"))
+        assertEquals(
+            "highly-sensitive-password",
+            DesktopSecureStorage(fileSystem, directory, "account", isWindows = false).get("usr_a|password"),
+        )
+        fileSystem.checkNoOpenFiles()
+    }
+
+    @Test
+    fun credentialsPersistWhenAtomicMovesAreUnavailable() {
+        val backingFileSystem = FakeFileSystem()
+        val fileSystem = object : ForwardingFileSystem(backingFileSystem) {
+            override fun atomicMove(source: Path, target: Path): Nothing {
+                throw IOException("atomic moves unavailable")
+            }
         }
+        val directory = "/secure-storage".toPath()
+        val storage = DesktopSecureStorage(fileSystem, directory, "account", isWindows = false)
+
+        storage.put("usr_a|password", "highly-sensitive-password")
+
+        assertEquals("highly-sensitive-password", storage.get("usr_a|password"))
+        backingFileSystem.checkNoOpenFiles()
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ landscapist = "2.4.7"
 robolectric = "4.16.1"
 filekit = "0.11.0"
 jna = "5.17.0"
+okio = "3.16.4"
 
 [libraries]
 # kotlinx
@@ -84,6 +85,8 @@ landscapist-animation = { module = "com.github.skydoves:landscapist-animation", 
 landscapist-placeholder = { module = "com.github.skydoves:landscapist-placeholder", version.ref = "landscapist" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }
+okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
+okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
 
 # chrisbanes-haze
 chrisbanes-haze = { module = "dev.chrisbanes.haze:haze", version.ref = "chrisbanes-haze" }


### PR DESCRIPTION
## Summary
- Inject Okio `FileSystem` and `Path` into desktop settings and secure storage file access.
- Migrate settings, encryption key, and credential tests to `FakeFileSystem` without touching the host disk.
- Preserve encryption key permissions and fall back safely when atomic moves are unavailable.

## Test Plan
- [x] `./gradlew :composeApp:desktopTest --rerun-tasks`