### PR TITLE
fix(animations): keep long usernames visible during profile transitions

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/compoments/UserStateIcon.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/UserStateIcon.kt
@@ -2,6 +2,7 @@ package io.github.vrcmteam.vrcm.presentation.compoments
 
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope.ResizeMode
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
@@ -25,6 +26,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -47,6 +49,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+internal val UserNameBoundsResizeMode: ResizeMode =
+    ResizeMode.scaleToBounds(
+        contentScale = ContentScale.FillWidth,
+        alignment = Alignment.Center,
+    )
 
 @Composable
 fun UserStateIcon(
@@ -195,6 +204,7 @@ fun LazyItemScope.LocationFriend(
         Text(
             modifier = Modifier.sharedBoundsBy(
                 key = "${id}UserName",
+                resizeMode = UserNameBoundsResizeMode,
                 boundsTransform = TextBoundsTransform,
                 clipInOverlayDuringTransition = NoClip,
             ).fillMaxWidth(),
@@ -221,6 +231,7 @@ fun UserInfoRow(
         Text(
             modifier = Modifier.sharedBoundsBy(
                 key = "${user?.id}UserName",
+                resizeMode = UserNameBoundsResizeMode,
                 boundsTransform = TextBoundsTransform,
                 clipInOverlayDuringTransition = NoClip,
             ),

--- a/composeApp/src/commonTest/kotlin/presentation/compoments/UserNameSharedBoundsResizeModeTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/compoments/UserNameSharedBoundsResizeModeTest.kt
@@ -1,0 +1,14 @@
+package io.github.vrcmteam.vrcm.presentation.compoments
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope.ResizeMode
+import kotlin.test.Test
+import kotlin.test.assertNotSame
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+class UserNameSharedBoundsResizeModeTest {
+    @Test
+    fun userNameBoundsDoNotRemeasureTextDuringTheTransition() {
+        assertNotSame(ResizeMode.RemeasureToBounds, UserNameBoundsResizeMode)
+    }
+}


### PR DESCRIPTION
## Summary
- render username shared bounds with `scaleToBounds` so long names stay fully laid out during the transition
- scope the resize policy to usernames while preserving the existing path animation and overlay behavior
- add a regression test preventing username transitions from returning to per-frame remeasurement

## Test Plan
- [x] `./gradlew :composeApp:desktopTest :composeApp:compileDebugKotlinAndroid --rerun-tasks`
- [x] independent code review: ready to merge, no findings