### PR TITLE
fix(navigation): preserve profile payloads

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/compoments/LocationDialog.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/LocationDialog.kt
@@ -161,7 +161,9 @@ class LocationDialog(
                                     modifier = if (owner.type == BlueprintType.User || owner.type == BlueprintType.Group)
                                         Modifier.clickable {
                                             if (owner.type == BlueprintType.User) {
-                                                onClickUserIcon(UserProfileVo(owner.id))
+                                                onClickUserIcon(
+                                                    UserProfileVo(id = owner.id, displayName = owner.displayName)
+                                                )
                                             } else {
                                                 currentNavigator push GroupProfileScreen(
                                                     groupProfileVo = GroupProfileVo(groupId = owner.id, name = owner.displayName),

--- a/composeApp/src/commonMain/kotlin/presentation/compoments/StandardSearchList.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/StandardSearchList.kt
@@ -123,7 +123,7 @@ fun StandardSearchList(
         if (currentNavigator.size <= 1) {
             coroutineScope.launch {
                 currentNavigator push GroupProfileScreen(
-                    groupProfileVo = GroupProfileVo(group.id),
+                    groupProfileVo = GroupProfileVo(group),
                     sharedSuffixKey = sharedSuffixKey
                 )
             }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/avatar/AvatarProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/avatar/AvatarProfileScreen.kt
@@ -104,7 +104,10 @@ private fun AvatarProfileContent(
             modifier = Modifier.simpleClickable {
                 navigator.push(
                     UserProfileScreen(
-                        userProfileVO = UserProfileVo(id = avatarProfileVo.authorId)
+                        userProfileVO = UserProfileVo(
+                            id = avatarProfileVo.authorId,
+                            displayName = avatarProfileVo.authorName,
+                        )
                     )
                 )
             }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/group/GroupProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/group/GroupProfileScreen.kt
@@ -792,7 +792,7 @@ private fun MembersContent(members: List<GroupMember>, isLoading: Boolean = fals
             users = users,
             onUserClick = { user ->
                 currentNavigator push UserProfileScreen(
-                    userProfileVO = UserProfileVo(id = user.id, displayName = user.displayName)
+                    userProfileVO = UserProfileVo(user)
                 )
             }
         )
@@ -912,7 +912,7 @@ private fun OwnerCard(
             modifier = Modifier.enableIf(ownerUserId.isNotBlank()) {
                 clickable {
                     currentNavigator push UserProfileScreen(
-                        userProfileVO = UserProfileVo(id = ownerUserId, displayName = owner.displayName)
+                        userProfileVO = UserProfileVo(owner)
                     )
                 }
             }
@@ -955,7 +955,8 @@ private fun MemberCard(member: GroupMember) {
             .enableIf(userId.isNotBlank()) {
                 clickable {
                     currentNavigator push UserProfileScreen(
-                        userProfileVO = UserProfileVo(id = userId, displayName = displayName)
+                        userProfileVO = member.user?.let(::UserProfileVo)
+                            ?: UserProfileVo(id = userId, displayName = displayName)
                     )
                 }
             },

--- a/composeApp/src/commonMain/kotlin/presentation/screens/group/data/GroupProfileVo.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/group/data/GroupProfileVo.kt
@@ -6,6 +6,7 @@ import io.github.vrcmteam.vrcm.network.api.groups.data.GroupData
 import io.github.vrcmteam.vrcm.network.api.groups.data.LimitedGroup
 import io.github.vrcmteam.vrcm.network.api.groups.data.MyMember
 import io.github.vrcmteam.vrcm.network.api.groups.data.Role
+import io.github.vrcmteam.vrcm.network.api.users.data.LimitedUserGroup
 
 data class GroupProfileVo(
     val groupId: String,
@@ -98,5 +99,15 @@ data class GroupProfileVo(
         galleries = group.galleries,
         ownerId = group.ownerId,
         createdAt = group.createdAt,
+    )
+
+    constructor(group: LimitedUserGroup) : this(
+        groupId = group.groupId,
+        name = group.name,
+        shortCode = group.shortCode,
+        description = group.description,
+        iconUrl = group.iconUrl,
+        bannerUrl = group.bannerUrl,
+        memberCount = group.memberCount,
     )
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreen.kt
@@ -541,14 +541,7 @@ private fun ColumnScope.ProfileContent(
             title = strings.userMutualGroups,
             onGroupClick = { group ->
                 navigator push GroupProfileScreen(
-                    groupProfileVo = GroupProfileVo(
-                        groupId = group.groupId,
-                        name = group.name,
-                        shortCode = group.shortCode,
-                        iconUrl = group.iconUrl,
-                        bannerUrl = group.bannerUrl,
-                        memberCount = group.memberCount,
-                    ),
+                    groupProfileVo = GroupProfileVo(group),
                     sharedSuffixKey = sharedSuffixKey
                 )
             }
@@ -559,14 +552,7 @@ private fun ColumnScope.ProfileContent(
         groups = userGroups,
         onGroupClick = { group ->
             navigator push GroupProfileScreen(
-                groupProfileVo = GroupProfileVo(
-                    groupId = group.groupId,
-                    name = group.name,
-                    shortCode = group.shortCode,
-                    iconUrl = group.iconUrl,
-                    bannerUrl = group.bannerUrl,
-                    memberCount = group.memberCount,
-                ),
+                groupProfileVo = GroupProfileVo(group),
                 sharedSuffixKey = sharedSuffixKey
             )
         }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
@@ -526,7 +526,8 @@ private fun RenderMainContent(
                         worldProfileVo.authorID?.let {
                             val userProfileScreen = UserProfileScreen(
                                 userProfileVO = UserProfileVo(
-                                    id = it
+                                    id = it,
+                                    displayName = worldProfileVo.authorName.orEmpty(),
                                 )
                             )
                             navigator.push(userProfileScreen)

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/components/InstanceCard.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/components/InstanceCard.kt
@@ -277,7 +277,9 @@ private fun BottomActionSection(instance: InstanceVo, expandProgress: Float = 1f
                 modifier = Modifier.enableIf(isExtended) {
                     clickable {
                         if (owner.type == BlueprintType.User) {
-                            onClickUserIcon(UserProfileVo(owner.id))
+                            onClickUserIcon(
+                                UserProfileVo(id = owner.id, displayName = owner.displayName)
+                            )
                         } else if (owner.type == BlueprintType.Group) {
                             onClickGroup(owner.id, owner.displayName)
                         }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/components/InstancesDialog.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/components/InstancesDialog.kt
@@ -101,7 +101,11 @@ class InstancesDialog(
                                 // TODO: Group详情页跳转
                                 Text(
                                     modifier = if (owner.type == BlueprintType.User)
-                                        Modifier.clickable { onClickUserIcon(UserProfileVo(owner.id)) }
+                                        Modifier.clickable {
+                                            onClickUserIcon(
+                                                UserProfileVo(id = owner.id, displayName = owner.displayName)
+                                            )
+                                        }
                                     else Modifier,
                                     textDecoration = if (owner.type == BlueprintType.User) TextDecoration.Underline else null,
                                     text = owner.displayName,

--- a/composeApp/src/commonTest/kotlin/presentation/screens/group/GroupProfileVoTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/group/GroupProfileVoTest.kt
@@ -1,0 +1,56 @@
+package io.github.vrcmteam.vrcm.presentation.screens.group
+
+import io.github.vrcmteam.vrcm.network.api.groups.data.LimitedGroup
+import io.github.vrcmteam.vrcm.network.api.users.data.LimitedUserGroup
+import io.github.vrcmteam.vrcm.presentation.screens.group.data.GroupProfileVo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GroupProfileVoTest {
+    @Test
+    fun limitedGroupPreservesAvailableProfileFields() {
+        val group = LimitedGroup(
+            id = "grp_search",
+            name = "Search Group",
+            shortCode = "SRCH",
+            description = "Search result data",
+            iconUrl = "https://example.test/search-icon.png",
+            bannerUrl = "https://example.test/search-banner.png",
+            memberCount = 84,
+        )
+
+        val profile = GroupProfileVo(group)
+
+        assertEquals("grp_search", profile.groupId)
+        assertEquals("Search Group", profile.name)
+        assertEquals("SRCH", profile.shortCode)
+        assertEquals("Search result data", profile.description)
+        assertEquals("https://example.test/search-icon.png", profile.iconUrl)
+        assertEquals("https://example.test/search-banner.png", profile.bannerUrl)
+        assertEquals(84, profile.memberCount)
+    }
+
+    @Test
+    fun limitedUserGroupPreservesAvailableProfileFields() {
+        val group = LimitedUserGroup(
+            id = "membership-id",
+            groupId = "grp_navigation",
+            name = "Navigation Group",
+            shortCode = "NAV",
+            description = "Already loaded",
+            iconUrl = "https://example.test/icon.png",
+            bannerUrl = "https://example.test/banner.png",
+            memberCount = 42,
+        )
+
+        val profile = GroupProfileVo(group)
+
+        assertEquals("grp_navigation", profile.groupId)
+        assertEquals("Navigation Group", profile.name)
+        assertEquals("NAV", profile.shortCode)
+        assertEquals("Already loaded", profile.description)
+        assertEquals("https://example.test/icon.png", profile.iconUrl)
+        assertEquals("https://example.test/banner.png", profile.bannerUrl)
+        assertEquals(42, profile.memberCount)
+    }
+}


### PR DESCRIPTION
## Summary
- Pass complete group search and user-profile group data into group details so names, icons, banners, descriptions, and counts render immediately.
- Preserve available user identity and avatar data when navigating from group members/owners, and preserve known author or instance-owner names.
- Add mapping coverage for both `LimitedGroup` and `LimitedUserGroup` navigation payloads.

## Test Plan
- [x] `./gradlew :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.presentation.screens.group.*" --tests "io.github.vrcmteam.vrcm.presentation.screens.user.*" --tests "io.github.vrcmteam.vrcm.presentation.screens.avatar.*" --tests "io.github.vrcmteam.vrcm.presentation.screens.world.*"`
- [x] `./gradlew :composeApp:desktopTest --rerun-tasks`