### PR TITLE
fix: 优化好友活动记录的逻辑

### DIFF
--- a/composeApp/src/androidMain/kotlin/service/FriendActivityForegroundService.kt
+++ b/composeApp/src/androidMain/kotlin/service/FriendActivityForegroundService.kt
@@ -31,7 +31,7 @@ class FriendActivityForegroundService : Service() {
         val koin = GlobalContext.get()
         koin.get<WebSocketApi>().setBackgroundMonitoringEnabled(true)
         val friendService = koin.get<FriendService>()
-        koin.get<FriendActivityService>()
+        koin.get<FriendActivityService>().onBackgroundMonitoringStarted()
         val webSocketApi = koin.get<WebSocketApi>()
         val logger = koin.get<Logger>()
         scope.launch {
@@ -50,9 +50,7 @@ class FriendActivityForegroundService : Service() {
         GlobalContext.getOrNull()?.let { koin ->
             val webSocketApi = koin.get<WebSocketApi>()
             webSocketApi.setBackgroundMonitoringEnabled(false)
-            if (!webSocketApi.isAppForeground()) {
-                koin.get<FriendActivityService>().onAppStopped()
-            }
+            koin.get<FriendActivityService>().onBackgroundMonitoringStopped()
         }
         scope.cancel()
         stopForeground(STOP_FOREGROUND_REMOVE)

--- a/composeApp/src/androidMain/kotlin/service/FriendActivityForegroundService.kt
+++ b/composeApp/src/androidMain/kotlin/service/FriendActivityForegroundService.kt
@@ -31,6 +31,7 @@ class FriendActivityForegroundService : Service() {
         val koin = GlobalContext.get()
         koin.get<WebSocketApi>().setBackgroundMonitoringEnabled(true)
         val friendService = koin.get<FriendService>()
+        koin.get<FriendActivityService>()
         val webSocketApi = koin.get<WebSocketApi>()
         val logger = koin.get<Logger>()
         scope.launch {
@@ -46,7 +47,13 @@ class FriendActivityForegroundService : Service() {
     }
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int) = START_STICKY
     override fun onDestroy() {
-        GlobalContext.getOrNull()?.get<WebSocketApi>()?.setBackgroundMonitoringEnabled(false)
+        GlobalContext.getOrNull()?.let { koin ->
+            val webSocketApi = koin.get<WebSocketApi>()
+            webSocketApi.setBackgroundMonitoringEnabled(false)
+            if (!webSocketApi.isAppForeground()) {
+                koin.get<FriendActivityService>().onAppStopped()
+            }
+        }
         scope.cancel()
         stopForeground(STOP_FOREGROUND_REMOVE)
         super.onDestroy()

--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -78,15 +78,19 @@ fun App(
     KoinContext {
         val webSocketApi = koinInject<WebSocketApi>()
         val friendLocationPagerModel = koinInject<FriendLocationPagerModel>()
-        koinInject<FriendActivityService>()
+        val friendActivityService = koinInject<FriendActivityService>()
         LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
             if (lifecycleEventGate.onStop(isConfigurationChange())) {
                 friendLocationPagerModel.onBackground()
                 webSocketApi.onBackground()
+                if (!webSocketApi.isBackgroundMonitoringEnabled()) {
+                    friendActivityService.onAppStopped()
+                }
             }
         }
         LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
             if (lifecycleEventGate.onResume()) {
+                friendActivityService.onAppResumed()
                 webSocketApi.onForeground()
                 friendLocationPagerModel.onForeground()
             }

--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
@@ -79,13 +80,14 @@ fun App(
         val webSocketApi = koinInject<WebSocketApi>()
         val friendLocationPagerModel = koinInject<FriendLocationPagerModel>()
         val friendActivityService = koinInject<FriendActivityService>()
+        LaunchedEffect(friendActivityService) {
+            friendActivityService.onAppResumed()
+        }
         LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
             if (lifecycleEventGate.onStop(isConfigurationChange())) {
                 friendLocationPagerModel.onBackground()
                 webSocketApi.onBackground()
-                if (!webSocketApi.isBackgroundMonitoringEnabled()) {
-                    friendActivityService.onAppStopped()
-                }
+                friendActivityService.onAppStopped()
             }
         }
         LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {

--- a/composeApp/src/commonMain/kotlin/network/websocket/WebSocketApi.kt
+++ b/composeApp/src/commonMain/kotlin/network/websocket/WebSocketApi.kt
@@ -65,6 +65,10 @@ class WebSocketApi(
         if (enabled || !isForeground.value) replaceConnection(SharedFlowCentre.currentSession.value?.token.takeIf { enabled || isForeground.value })
     }
 
+    fun isBackgroundMonitoringEnabled(): Boolean = backgroundMonitoringEnabled.value
+
+    fun isAppForeground(): Boolean = isForeground.value
+
     private fun replaceConnection(sessionToken: AccountSessionToken?) = synchronized(connectionLock) {
         currentJob?.cancel()
         connectedSessionToken.value = null

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendLocationPresenceStore.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendLocationPresenceStore.kt
@@ -87,9 +87,9 @@ internal class FriendLocationPresenceStore {
             }
 
             is FriendUpdateEvent.Online -> {
-                markRefreshOverride(event.friend.id, isActive = false)
-                activeFriendIds -= event.friend.id
-                friendsById[event.friend.id] = event.friend
+                markRefreshOverride(event.userId, isActive = false)
+                activeFriendIds -= event.userId
+                event.friend?.let { friendsById[event.userId] = it }
             }
 
             is FriendUpdateEvent.LocationChanged -> {

--- a/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
@@ -16,11 +16,11 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
@@ -29,10 +29,12 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 import org.koin.core.logger.Logger
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
@@ -80,20 +82,42 @@ internal data class FriendActivityInputSnapshot(
 
 internal enum class FriendActivityTrackingControl { Stop, Resume }
 
+internal data class FriendActivityTrackingTransition(
+    val sequence: Long,
+    val control: FriendActivityTrackingControl,
+    val occurredAtMillis: Long,
+)
+
 /**
  * Combines every lifecycle owner that can keep friend activity tracking alive.
- * Tracking changes only when the aggregate state crosses between zero and one active source.
+ * The current transition initializes a new account collector, while the channel preserves every
+ * later transition in occurrence order if database work temporarily suspends that collector.
  */
-internal class FriendActivityTrackingState {
-    private val activeSources = MutableStateFlow(0)
+@OptIn(ExperimentalTime::class)
+internal class FriendActivityTrackingState(
+    private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+) {
+    private val lock = SynchronizedObject()
+    private var activeSources = 0
+    private var sequence = 0L
+    private val transitionEvents = Channel<FriendActivityTrackingTransition>(Channel.UNLIMITED)
+    private val currentTransition = MutableStateFlow(
+        FriendActivityTrackingTransition(
+            sequence = sequence,
+            control = FriendActivityTrackingControl.Stop,
+            occurredAtMillis = nowMillis(),
+        )
+    )
 
-    /** Replays the current aggregate state whenever an account collector starts. */
-    val controls: Flow<FriendActivityTrackingControl> = activeSources
-        .map { sources ->
-            if (sources == 0) FriendActivityTrackingControl.Stop
-            else FriendActivityTrackingControl.Resume
+    val controls: Flow<FriendActivityTrackingTransition> = flow {
+        val initial = currentTransition.value
+        emit(initial)
+        transitionEvents.receiveAsFlow().collect { transition ->
+            if (transition.sequence > initial.sequence) {
+                emit(transition)
+            }
         }
-        .distinctUntilChanged()
+    }
 
     fun setAppForeground(active: Boolean) =
         setSourceActive(APP_FOREGROUND_SOURCE, active)
@@ -101,11 +125,36 @@ internal class FriendActivityTrackingState {
     fun setBackgroundMonitoring(active: Boolean) =
         setSourceActive(BACKGROUND_MONITORING_SOURCE, active)
 
-    fun isEnabled(): Boolean = activeSources.value != 0
+    fun isEnabled(): Boolean =
+        currentTransition.value.control == FriendActivityTrackingControl.Resume
 
     private fun setSourceActive(source: Int, active: Boolean) {
-        activeSources.update { current ->
-            if (active) current or source else current and source.inv()
+        synchronized(lock) {
+            val updatedSources = if (active) {
+                activeSources or source
+            } else {
+                activeSources and source.inv()
+            }
+            if (updatedSources == activeSources) return@synchronized
+
+            val wasEnabled = activeSources != 0
+            activeSources = updatedSources
+            val isEnabled = activeSources != 0
+            if (wasEnabled == isEnabled) return@synchronized
+
+            val transition = FriendActivityTrackingTransition(
+                sequence = ++sequence,
+                control = if (isEnabled) {
+                    FriendActivityTrackingControl.Resume
+                } else {
+                    FriendActivityTrackingControl.Stop
+                },
+                occurredAtMillis = nowMillis(),
+            )
+            currentTransition.value = transition
+            check(transitionEvents.trySend(transition).isSuccess) {
+                "Friend activity tracking transition channel is unavailable"
+            }
         }
     }
 
@@ -182,19 +231,18 @@ class FriendActivityService internal constructor(
                                     }
                                 }
                             },
-                            trackingState.controls.map { control ->
-                                val observedAtMillis = Clock.System.now().toEpochMilliseconds()
+                            trackingState.controls.map { transition ->
                                 val source = friendService.friendActivitySource.value
                                     ?.takeIf { it.token == session.token }
                                 source?.toInputSnapshot(
-                                    trackingControl = control,
-                                    observedAtMillis = observedAtMillis,
+                                    trackingControl = transition.control,
+                                    observedAtMillis = transition.occurredAtMillis,
                                 ) ?: FriendActivityInputSnapshot(
                                     token = session.token,
                                     friends = emptyList(),
                                     selfLocation = null,
-                                    observedAtMillis = observedAtMillis,
-                                    trackingControl = control,
+                                    observedAtMillis = transition.occurredAtMillis,
+                                    trackingControl = transition.control,
                                 )
                             },
                         ),

--- a/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
@@ -13,17 +13,25 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.atomicfu.atomic
 import org.koin.core.logger.Logger
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
@@ -64,6 +72,17 @@ internal data class FriendActivityInputSnapshot(
     val friends: Collection<FriendActivityObservation>,
     val selfLocation: String?,
     val observedAtMillis: Long,
+    val socketPresenceEvent: FriendSocketPresenceEvent? = null,
+    val trackingControl: FriendActivityTrackingControl? = null,
+    val updateLastActivityOnly: Boolean = false,
+)
+
+internal enum class FriendActivityTrackingControl { Stop, Resume }
+
+private data class FriendActivityTrackingSignal(
+    val token: AccountSessionToken,
+    val control: FriendActivityTrackingControl,
+    val occurredAtMillis: Long,
 )
 
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
@@ -74,6 +93,10 @@ class FriendActivityService internal constructor(
     private val logger: Logger,
 ) {
     private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val appTrackingEnabled = atomic(true)
+    private val trackingControls = MutableSharedFlow<FriendActivityTrackingSignal>(
+        extraBufferCapacity = TRACKING_CONTROL_BUFFER_CAPACITY,
+    )
     private val worldNameResolver = FriendActivityWorldNameResolver(
         readCachedName = store::cachedWorldName,
         fetchWorldName = { worldId ->
@@ -92,9 +115,65 @@ class FriendActivityService internal constructor(
                 try {
                     trackFriendActivity(
                         session = session,
-                        snapshots = friendService.friendActivitySource
-                            .filterNotNull()
-                            .map { it.toInputSnapshot() },
+                        snapshots = merge(
+                            friendService.friendActivitySource.filterNotNull().mapNotNull {
+                                it.takeIf { appTrackingEnabled.value }?.toInputSnapshot()
+                            },
+                            friendService.friendLastActivitySource.filterNotNull().map {
+                                it.toInputSnapshot(
+                                    includeLastActivity = true,
+                                    updateLastActivityOnly = true,
+                                )
+                            },
+                            friendService.friendUpdateFlow.mapNotNull { update ->
+                                if (!appTrackingEnabled.value) return@mapNotNull null
+                                val type = when (update.event) {
+                                    is FriendUpdateEvent.Online -> FriendSocketPresenceType.Online
+                                    is FriendUpdateEvent.Offline -> FriendSocketPresenceType.Offline
+                                    else -> return@mapNotNull null
+                                }
+                                val presenceEvent = FriendSocketPresenceEvent(
+                                    userId = when (val event = update.event) {
+                                        is FriendUpdateEvent.Online -> event.userId
+                                        is FriendUpdateEvent.Offline -> event.userId
+                                        else -> return@mapNotNull null
+                                    },
+                                    type = type,
+                                    occurredAtMillis = update.occurredAtMillis
+                                        ?: Clock.System.now().toEpochMilliseconds(),
+                                )
+                                friendService.friendActivitySource.value?.toInputSnapshot(presenceEvent)
+                                    ?: FriendActivityInputSnapshot(
+                                        token = update.sessionToken,
+                                        friends = emptyList(),
+                                        selfLocation = null,
+                                        observedAtMillis = presenceEvent.occurredAtMillis,
+                                        socketPresenceEvent = presenceEvent,
+                                    )
+                            },
+                            flow {
+                                while (true) {
+                                    delay(MEETING_CHECKPOINT_MILLIS)
+                                    if (appTrackingEnabled.value) {
+                                        friendService.friendActivitySource.value?.let { emit(it.toInputSnapshot()) }
+                                    }
+                                }
+                            },
+                            trackingControls.map { signal ->
+                                val source = friendService.friendActivitySource.value
+                                    ?.takeIf { it.token == signal.token }
+                                source?.toInputSnapshot(
+                                    trackingControl = signal.control,
+                                    observedAtMillis = signal.occurredAtMillis,
+                                ) ?: FriendActivityInputSnapshot(
+                                    token = signal.token,
+                                    friends = emptyList(),
+                                    selfLocation = null,
+                                    observedAtMillis = signal.occurredAtMillis,
+                                    trackingControl = signal.control,
+                                )
+                            },
+                        ),
                         store = store,
                     )
                 } catch (error: CancellationException) {
@@ -151,6 +230,30 @@ class FriendActivityService internal constructor(
         serviceScope.cancel()
     }
 
+    fun onAppStopped() {
+        appTrackingEnabled.value = false
+        val token = SharedFlowCentre.currentSession.value?.token ?: return
+        trackingControls.tryEmit(
+            FriendActivityTrackingSignal(
+                token = token,
+                control = FriendActivityTrackingControl.Stop,
+                occurredAtMillis = Clock.System.now().toEpochMilliseconds(),
+            )
+        )
+    }
+
+    fun onAppResumed() {
+        appTrackingEnabled.value = true
+        val token = SharedFlowCentre.currentSession.value?.token ?: return
+        trackingControls.tryEmit(
+            FriendActivityTrackingSignal(
+                token = token,
+                control = FriendActivityTrackingControl.Resume,
+                occurredAtMillis = Clock.System.now().toEpochMilliseconds(),
+            )
+        )
+    }
+
     private fun resolveWorldName(ownerUserId: String, worldId: String) {
         serviceScope.launch {
             try {
@@ -165,50 +268,99 @@ class FriendActivityService internal constructor(
 
     private companion object {
         const val WORLD_NAME_TIMEOUT_MILLIS = 5_000L
-    }
-}
-
-internal suspend fun trackFriendActivity(
-    session: AuthenticatedAccount,
-    snapshots: Flow<FriendActivityInputSnapshot>,
-    store: RoomFriendActivityStore,
-) {
-    var writeToken = store.activateAccount(session.account.userId)
-    store.discardIncompleteSessions(session.account.userId)
-    var tracker = FriendActivityTracker()
-    snapshots.collect { snapshot ->
-        if (snapshot.token != session.token) return@collect
-        val batch = tracker.observe(
-            friends = snapshot.friends,
-            selfLocation = snapshot.selfLocation,
-            nowMillis = snapshot.observedAtMillis,
-        )
-        val recorded = store.record(
-            token = writeToken,
-            observations = snapshot.friends,
-            batch = batch,
-            nowMillis = snapshot.observedAtMillis,
-        )
-        if (!recorded) {
-            writeToken = store.activateAccount(session.account.userId)
-            tracker = FriendActivityTracker()
-            val baseline = tracker.observe(
-                friends = snapshot.friends,
-                selfLocation = snapshot.selfLocation,
-                nowMillis = snapshot.observedAtMillis,
-            )
-            store.record(
-                token = writeToken,
-                observations = snapshot.friends,
-                batch = baseline,
-                nowMillis = snapshot.observedAtMillis,
-            )
-        }
+        const val MEETING_CHECKPOINT_MILLIS = 15_000L
+        const val TRACKING_CONTROL_BUFFER_CAPACITY = 8
     }
 }
 
 @OptIn(ExperimentalTime::class)
-private fun FriendActivitySourceSnapshot.toInputSnapshot() = FriendActivityInputSnapshot(
+internal suspend fun trackFriendActivity(
+    session: AuthenticatedAccount,
+    snapshots: Flow<FriendActivityInputSnapshot>,
+    store: RoomFriendActivityStore,
+    cancellationTimeMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+) {
+    var writeToken = store.activateAccount(session.account.userId)
+    store.discardIncompleteSessions(session.account.userId)
+    var tracker = FriendActivityTracker(derivePresenceEvents = false)
+    var trackingEnabled = true
+    var latestObservations: Collection<FriendActivityObservation> = emptyList()
+    try {
+        snapshots.collect { snapshot ->
+            if (snapshot.token != session.token) return@collect
+            if (!snapshot.updateLastActivityOnly) latestObservations = snapshot.friends
+            val batch = when (snapshot.trackingControl) {
+                FriendActivityTrackingControl.Stop -> {
+                    trackingEnabled = false
+                    tracker.finish(snapshot.observedAtMillis)
+                }
+                FriendActivityTrackingControl.Resume -> {
+                    trackingEnabled = true
+                    tracker.observe(snapshot.friends, snapshot.selfLocation, snapshot.observedAtMillis)
+                }
+                null -> if (snapshot.updateLastActivityOnly) {
+                    FriendActivityBatch()
+                } else if (!trackingEnabled) {
+                    FriendActivityBatch()
+                } else snapshot.socketPresenceEvent?.let {
+                    tracker.observeSocketPresence(snapshot.friends, it)
+                } ?: tracker.observe(snapshot.friends, snapshot.selfLocation, snapshot.observedAtMillis)
+            }
+            val observations = if (snapshot.updateLastActivityOnly) {
+                snapshot.friends
+            } else {
+                snapshot.friends.map { it.copy(lastActivityAtMillis = null) }
+            }
+            val recorded = store.record(
+                token = writeToken,
+                observations = observations,
+                batch = batch,
+                nowMillis = snapshot.observedAtMillis,
+            )
+            if (!recorded) {
+                writeToken = store.activateAccount(session.account.userId)
+                tracker = FriendActivityTracker(derivePresenceEvents = false)
+                val baseline = if (trackingEnabled && !snapshot.updateLastActivityOnly) {
+                    tracker.observe(
+                        friends = snapshot.friends,
+                        selfLocation = snapshot.selfLocation,
+                        nowMillis = snapshot.observedAtMillis,
+                    )
+                } else {
+                    FriendActivityBatch()
+                }
+                store.record(
+                    token = writeToken,
+                    observations = observations,
+                    batch = baseline,
+                    nowMillis = snapshot.observedAtMillis,
+                )
+            }
+        }
+    } catch (error: CancellationException) {
+        if (trackingEnabled) {
+            withContext(NonCancellable) {
+                val stoppedAtMillis = cancellationTimeMillis()
+                store.record(
+                    token = writeToken,
+                    observations = latestObservations.map { it.copy(lastActivityAtMillis = null) },
+                    batch = tracker.finish(stoppedAtMillis),
+                    nowMillis = stoppedAtMillis,
+                )
+            }
+        }
+        throw error
+    }
+}
+
+@OptIn(ExperimentalTime::class)
+private fun FriendActivitySourceSnapshot.toInputSnapshot(
+        socketPresenceEvent: FriendSocketPresenceEvent? = null,
+        trackingControl: FriendActivityTrackingControl? = null,
+        includeLastActivity: Boolean = false,
+        updateLastActivityOnly: Boolean = false,
+        observedAtMillis: Long = Clock.System.now().toEpochMilliseconds(),
+) = FriendActivityInputSnapshot(
     token = token,
     friends = friends.map { friend ->
         FriendActivityObservation(
@@ -219,11 +371,16 @@ private fun FriendActivitySourceSnapshot.toInputSnapshot() = FriendActivityInput
             status = friend.status.value,
             statusDescription = friend.statusDescription,
             bio = friend.bio.orEmpty(),
-            lastActivityAtMillis = friend.lastActivity.toEpochMillisOrNull(),
+            lastActivityAtMillis = friend.lastActivity.toEpochMillisOrNull()
+                ?.takeIf { includeLastActivity }
+                ?.takeIf { friend.status == io.github.vrcmteam.vrcm.network.api.attributes.UserStatus.Offline },
         )
     },
     selfLocation = selfLocation,
-    observedAtMillis = Clock.System.now().toEpochMilliseconds(),
+    observedAtMillis = observedAtMillis,
+    socketPresenceEvent = socketPresenceEvent,
+    trackingControl = trackingControl,
+    updateLastActivityOnly = updateLastActivityOnly,
 )
 
 @OptIn(ExperimentalTime::class)

--- a/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
@@ -142,14 +142,10 @@ class FriendActivityService internal constructor(
                                     occurredAtMillis = update.occurredAtMillis
                                         ?: Clock.System.now().toEpochMilliseconds(),
                                 )
-                                friendService.friendActivitySource.value?.toInputSnapshot(presenceEvent)
-                                    ?: FriendActivityInputSnapshot(
-                                        token = update.sessionToken,
-                                        friends = emptyList(),
-                                        selfLocation = null,
-                                        observedAtMillis = presenceEvent.occurredAtMillis,
-                                        socketPresenceEvent = presenceEvent,
-                                    )
+                                friendService.friendActivitySource.value.toSocketPresenceInputSnapshot(
+                                    eventToken = update.sessionToken,
+                                    presenceEvent = presenceEvent,
+                                )
                             },
                             flow {
                                 while (true) {
@@ -382,6 +378,19 @@ private fun FriendActivitySourceSnapshot.toInputSnapshot(
     trackingControl = trackingControl,
     updateLastActivityOnly = updateLastActivityOnly,
 )
+
+/** Keeps the event token authoritative and only enriches it from the same session snapshot. */
+internal fun FriendActivitySourceSnapshot?.toSocketPresenceInputSnapshot(
+    eventToken: AccountSessionToken,
+    presenceEvent: FriendSocketPresenceEvent,
+): FriendActivityInputSnapshot = this?.takeIf { it.token == eventToken }?.toInputSnapshot(presenceEvent)
+    ?: FriendActivityInputSnapshot(
+        token = eventToken,
+        friends = emptyList(),
+        selfLocation = null,
+        observedAtMillis = presenceEvent.occurredAtMillis,
+        socketPresenceEvent = presenceEvent,
+    )
 
 @OptIn(ExperimentalTime::class)
 private fun String.toEpochMillisOrNull(): Long? =

--- a/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
@@ -79,6 +79,41 @@ internal data class FriendActivityInputSnapshot(
 
 internal enum class FriendActivityTrackingControl { Stop, Resume }
 
+/**
+ * Combines every lifecycle owner that can keep friend activity tracking alive.
+ * Tracking changes only when the aggregate state crosses between zero and one active source.
+ */
+internal class FriendActivityTrackingState {
+    private val activeSources = atomic(0)
+
+    fun setAppForeground(active: Boolean): FriendActivityTrackingControl? =
+        setSourceActive(APP_FOREGROUND_SOURCE, active)
+
+    fun setBackgroundMonitoring(active: Boolean): FriendActivityTrackingControl? =
+        setSourceActive(BACKGROUND_MONITORING_SOURCE, active)
+
+    fun isEnabled(): Boolean = activeSources.value != 0
+
+    private fun setSourceActive(source: Int, active: Boolean): FriendActivityTrackingControl? {
+        while (true) {
+            val previous = activeSources.value
+            val updated = if (active) previous or source else previous and source.inv()
+            if (previous == updated) return null
+            if (!activeSources.compareAndSet(previous, updated)) continue
+            return when {
+                previous == 0 && updated != 0 -> FriendActivityTrackingControl.Resume
+                previous != 0 && updated == 0 -> FriendActivityTrackingControl.Stop
+                else -> null
+            }
+        }
+    }
+
+    private companion object {
+        const val APP_FOREGROUND_SOURCE = 1
+        const val BACKGROUND_MONITORING_SOURCE = 1 shl 1
+    }
+}
+
 private data class FriendActivityTrackingSignal(
     val token: AccountSessionToken,
     val control: FriendActivityTrackingControl,
@@ -93,7 +128,7 @@ class FriendActivityService internal constructor(
     private val logger: Logger,
 ) {
     private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private val appTrackingEnabled = atomic(true)
+    private val trackingState = FriendActivityTrackingState()
     private val trackingControls = MutableSharedFlow<FriendActivityTrackingSignal>(
         extraBufferCapacity = TRACKING_CONTROL_BUFFER_CAPACITY,
     )
@@ -117,7 +152,7 @@ class FriendActivityService internal constructor(
                         session = session,
                         snapshots = merge(
                             friendService.friendActivitySource.filterNotNull().mapNotNull {
-                                it.takeIf { appTrackingEnabled.value }?.toInputSnapshot()
+                                it.takeIf { trackingState.isEnabled() }?.toInputSnapshot()
                             },
                             friendService.friendLastActivitySource.filterNotNull().map {
                                 it.toInputSnapshot(
@@ -126,7 +161,7 @@ class FriendActivityService internal constructor(
                                 )
                             },
                             friendService.friendUpdateFlow.mapNotNull { update ->
-                                if (!appTrackingEnabled.value) return@mapNotNull null
+                                if (!trackingState.isEnabled()) return@mapNotNull null
                                 val type = when (update.event) {
                                     is FriendUpdateEvent.Online -> FriendSocketPresenceType.Online
                                     is FriendUpdateEvent.Offline -> FriendSocketPresenceType.Offline
@@ -150,7 +185,7 @@ class FriendActivityService internal constructor(
                             flow {
                                 while (true) {
                                     delay(MEETING_CHECKPOINT_MILLIS)
-                                    if (appTrackingEnabled.value) {
+                                    if (trackingState.isEnabled()) {
                                         friendService.friendActivitySource.value?.let { emit(it.toInputSnapshot()) }
                                     }
                                 }
@@ -171,6 +206,7 @@ class FriendActivityService internal constructor(
                             },
                         ),
                         store = store,
+                        initialTrackingEnabled = trackingState.isEnabled(),
                     )
                 } catch (error: CancellationException) {
                     throw error
@@ -227,24 +263,28 @@ class FriendActivityService internal constructor(
     }
 
     fun onAppStopped() {
-        appTrackingEnabled.value = false
-        val token = SharedFlowCentre.currentSession.value?.token ?: return
-        trackingControls.tryEmit(
-            FriendActivityTrackingSignal(
-                token = token,
-                control = FriendActivityTrackingControl.Stop,
-                occurredAtMillis = Clock.System.now().toEpochMilliseconds(),
-            )
-        )
+        dispatchTrackingControl(trackingState.setAppForeground(false))
     }
 
     fun onAppResumed() {
-        appTrackingEnabled.value = true
+        dispatchTrackingControl(trackingState.setAppForeground(true))
+    }
+
+    fun onBackgroundMonitoringStarted() {
+        dispatchTrackingControl(trackingState.setBackgroundMonitoring(true))
+    }
+
+    fun onBackgroundMonitoringStopped() {
+        dispatchTrackingControl(trackingState.setBackgroundMonitoring(false))
+    }
+
+    private fun dispatchTrackingControl(control: FriendActivityTrackingControl?) {
+        if (control == null) return
         val token = SharedFlowCentre.currentSession.value?.token ?: return
         trackingControls.tryEmit(
             FriendActivityTrackingSignal(
                 token = token,
-                control = FriendActivityTrackingControl.Resume,
+                control = control,
                 occurredAtMillis = Clock.System.now().toEpochMilliseconds(),
             )
         )
@@ -274,12 +314,13 @@ internal suspend fun trackFriendActivity(
     session: AuthenticatedAccount,
     snapshots: Flow<FriendActivityInputSnapshot>,
     store: RoomFriendActivityStore,
+    initialTrackingEnabled: Boolean = true,
     cancellationTimeMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) {
     var writeToken = store.activateAccount(session.account.userId)
     store.discardIncompleteSessions(session.account.userId)
     var tracker = FriendActivityTracker(derivePresenceEvents = false)
-    var trackingEnabled = true
+    var trackingEnabled = initialTrackingEnabled
     var latestObservations: Collection<FriendActivityObservation> = emptyList()
     try {
         snapshots.collect { snapshot ->

--- a/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
@@ -3,6 +3,7 @@ package io.github.vrcmteam.vrcm.service
 import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
 import io.github.vrcmteam.vrcm.core.shared.AuthenticatedAccount
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
+import io.github.vrcmteam.vrcm.network.api.attributes.UserStatus
 import io.github.vrcmteam.vrcm.network.api.friends.date.FriendData
 import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
 import io.github.vrcmteam.vrcm.storage.FriendActivityEventEntity
@@ -371,10 +372,15 @@ internal suspend fun trackFriendActivity(
                     tracker.observeSocketPresence(snapshot.friends, it)
                 } ?: tracker.observe(snapshot.friends, snapshot.selfLocation, snapshot.observedAtMillis)
             }
-            val observations = if (snapshot.updateLastActivityOnly) {
-                snapshot.friends
-            } else {
-                snapshot.friends.map { it.copy(lastActivityAtMillis = null) }
+            val observations = snapshot.friends.map { observation ->
+                if (snapshot.updateLastActivityOnly) {
+                    observation
+                } else {
+                    observation.copy(
+                        lastActivityAtMillis = snapshot.observedAtMillis
+                            .takeIf { observation.status != UserStatus.Offline.value },
+                    )
+                }
             }
             val recorded = store.record(
                 token = writeToken,
@@ -408,7 +414,12 @@ internal suspend fun trackFriendActivity(
                 val stoppedAtMillis = cancellationTimeMillis()
                 store.record(
                     token = writeToken,
-                    observations = latestObservations.map { it.copy(lastActivityAtMillis = null) },
+                    observations = latestObservations.map { observation ->
+                        observation.copy(
+                            lastActivityAtMillis = stoppedAtMillis
+                                .takeIf { observation.status != UserStatus.Offline.value },
+                        )
+                    },
                     batch = tracker.finish(stoppedAtMillis),
                     nowMillis = stoppedAtMillis,
                 )
@@ -438,7 +449,7 @@ private fun FriendActivitySourceSnapshot.toInputSnapshot(
             bio = friend.bio.orEmpty(),
             lastActivityAtMillis = friend.lastActivity.toEpochMillisOrNull()
                 ?.takeIf { includeLastActivity }
-                ?.takeIf { friend.status == io.github.vrcmteam.vrcm.network.api.attributes.UserStatus.Offline },
+                ?.takeIf { friend.status == UserStatus.Offline },
         )
     },
     selfLocation = selfLocation,

--- a/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
@@ -18,8 +18,9 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
@@ -28,10 +29,10 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
-import kotlinx.atomicfu.atomic
 import org.koin.core.logger.Logger
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
@@ -84,27 +85,27 @@ internal enum class FriendActivityTrackingControl { Stop, Resume }
  * Tracking changes only when the aggregate state crosses between zero and one active source.
  */
 internal class FriendActivityTrackingState {
-    private val activeSources = atomic(0)
+    private val activeSources = MutableStateFlow(0)
 
-    fun setAppForeground(active: Boolean): FriendActivityTrackingControl? =
+    /** Replays the current aggregate state whenever an account collector starts. */
+    val controls: Flow<FriendActivityTrackingControl> = activeSources
+        .map { sources ->
+            if (sources == 0) FriendActivityTrackingControl.Stop
+            else FriendActivityTrackingControl.Resume
+        }
+        .distinctUntilChanged()
+
+    fun setAppForeground(active: Boolean) =
         setSourceActive(APP_FOREGROUND_SOURCE, active)
 
-    fun setBackgroundMonitoring(active: Boolean): FriendActivityTrackingControl? =
+    fun setBackgroundMonitoring(active: Boolean) =
         setSourceActive(BACKGROUND_MONITORING_SOURCE, active)
 
     fun isEnabled(): Boolean = activeSources.value != 0
 
-    private fun setSourceActive(source: Int, active: Boolean): FriendActivityTrackingControl? {
-        while (true) {
-            val previous = activeSources.value
-            val updated = if (active) previous or source else previous and source.inv()
-            if (previous == updated) return null
-            if (!activeSources.compareAndSet(previous, updated)) continue
-            return when {
-                previous == 0 && updated != 0 -> FriendActivityTrackingControl.Resume
-                previous != 0 && updated == 0 -> FriendActivityTrackingControl.Stop
-                else -> null
-            }
+    private fun setSourceActive(source: Int, active: Boolean) {
+        activeSources.update { current ->
+            if (active) current or source else current and source.inv()
         }
     }
 
@@ -113,12 +114,6 @@ internal class FriendActivityTrackingState {
         const val BACKGROUND_MONITORING_SOURCE = 1 shl 1
     }
 }
-
-private data class FriendActivityTrackingSignal(
-    val token: AccountSessionToken,
-    val control: FriendActivityTrackingControl,
-    val occurredAtMillis: Long,
-)
 
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
 class FriendActivityService internal constructor(
@@ -129,9 +124,6 @@ class FriendActivityService internal constructor(
 ) {
     private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val trackingState = FriendActivityTrackingState()
-    private val trackingControls = MutableSharedFlow<FriendActivityTrackingSignal>(
-        extraBufferCapacity = TRACKING_CONTROL_BUFFER_CAPACITY,
-    )
     private val worldNameResolver = FriendActivityWorldNameResolver(
         readCachedName = store::cachedWorldName,
         fetchWorldName = { worldId ->
@@ -190,23 +182,23 @@ class FriendActivityService internal constructor(
                                     }
                                 }
                             },
-                            trackingControls.map { signal ->
+                            trackingState.controls.map { control ->
+                                val observedAtMillis = Clock.System.now().toEpochMilliseconds()
                                 val source = friendService.friendActivitySource.value
-                                    ?.takeIf { it.token == signal.token }
+                                    ?.takeIf { it.token == session.token }
                                 source?.toInputSnapshot(
-                                    trackingControl = signal.control,
-                                    observedAtMillis = signal.occurredAtMillis,
+                                    trackingControl = control,
+                                    observedAtMillis = observedAtMillis,
                                 ) ?: FriendActivityInputSnapshot(
-                                    token = signal.token,
+                                    token = session.token,
                                     friends = emptyList(),
                                     selfLocation = null,
-                                    observedAtMillis = signal.occurredAtMillis,
-                                    trackingControl = signal.control,
+                                    observedAtMillis = observedAtMillis,
+                                    trackingControl = control,
                                 )
                             },
                         ),
                         store = store,
-                        initialTrackingEnabled = trackingState.isEnabled(),
                     )
                 } catch (error: CancellationException) {
                     throw error
@@ -263,31 +255,19 @@ class FriendActivityService internal constructor(
     }
 
     fun onAppStopped() {
-        dispatchTrackingControl(trackingState.setAppForeground(false))
+        trackingState.setAppForeground(false)
     }
 
     fun onAppResumed() {
-        dispatchTrackingControl(trackingState.setAppForeground(true))
+        trackingState.setAppForeground(true)
     }
 
     fun onBackgroundMonitoringStarted() {
-        dispatchTrackingControl(trackingState.setBackgroundMonitoring(true))
+        trackingState.setBackgroundMonitoring(true)
     }
 
     fun onBackgroundMonitoringStopped() {
-        dispatchTrackingControl(trackingState.setBackgroundMonitoring(false))
-    }
-
-    private fun dispatchTrackingControl(control: FriendActivityTrackingControl?) {
-        if (control == null) return
-        val token = SharedFlowCentre.currentSession.value?.token ?: return
-        trackingControls.tryEmit(
-            FriendActivityTrackingSignal(
-                token = token,
-                control = control,
-                occurredAtMillis = Clock.System.now().toEpochMilliseconds(),
-            )
-        )
+        trackingState.setBackgroundMonitoring(false)
     }
 
     private fun resolveWorldName(ownerUserId: String, worldId: String) {
@@ -305,7 +285,6 @@ class FriendActivityService internal constructor(
     private companion object {
         const val WORLD_NAME_TIMEOUT_MILLIS = 5_000L
         const val MEETING_CHECKPOINT_MILLIS = 15_000L
-        const val TRACKING_CONTROL_BUFFER_CAPACITY = 8
     }
 }
 
@@ -314,13 +293,12 @@ internal suspend fun trackFriendActivity(
     session: AuthenticatedAccount,
     snapshots: Flow<FriendActivityInputSnapshot>,
     store: RoomFriendActivityStore,
-    initialTrackingEnabled: Boolean = true,
     cancellationTimeMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) {
     var writeToken = store.activateAccount(session.account.userId)
     store.discardIncompleteSessions(session.account.userId)
     var tracker = FriendActivityTracker(derivePresenceEvents = false)
-    var trackingEnabled = initialTrackingEnabled
+    var trackingEnabled = true
     var latestObservations: Collection<FriendActivityObservation> = emptyList()
     try {
         snapshots.collect { snapshot ->

--- a/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
@@ -90,8 +90,8 @@ internal data class FriendActivityTrackingTransition(
 
 /**
  * Combines every lifecycle owner that can keep friend activity tracking alive.
- * The current transition initializes a new account collector, while the channel preserves every
- * later transition in occurrence order if database work temporarily suspends that collector.
+ * The current control initializes a new account collector at subscription time, while the channel
+ * preserves every later transition in occurrence order if database work suspends that collector.
  */
 @OptIn(ExperimentalTime::class)
 internal class FriendActivityTrackingState(
@@ -110,7 +110,9 @@ internal class FriendActivityTrackingState(
     )
 
     val controls: Flow<FriendActivityTrackingTransition> = flow {
-        val initial = currentTransition.value
+        val initial = synchronized(lock) {
+            currentTransition.value.copy(occurredAtMillis = nowMillis())
+        }
         emit(initial)
         transitionEvents.receiveAsFlow().collect { transition ->
             if (transition.sequence > initial.sequence) {

--- a/composeApp/src/commonMain/kotlin/service/FriendActivityTracker.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendActivityTracker.kt
@@ -93,6 +93,7 @@ internal class FriendActivityTracker(
     private val activeMeetings = mutableMapOf<String, ActiveMeeting>()
     private val lastKnownInstanceByUserId = mutableMapOf<String, String>()
     private val lastKnownFriendByUserId = mutableMapOf<String, FriendActivityObservation>()
+    private var hasObservedSelfLocation = false
 
     fun observe(
         friends: Collection<FriendActivityObservation>,
@@ -100,6 +101,8 @@ internal class FriendActivityTracker(
         nowMillis: Long,
     ): FriendActivityBatch {
         val selfInstance = selfLocation.normalizedInstanceKey()
+        val canAnnounceNewMeeting = hasObservedSelfLocation
+        if (selfLocation != null) hasObservedSelfLocation = true
         val events = mutableListOf<FriendActivityEventDraft>()
         val currentUserIds = friends.mapTo(mutableSetOf(), FriendActivityObservation::userId)
         val meetings = buildList {
@@ -168,7 +171,7 @@ internal class FriendActivityTracker(
                             occurredAtMillis = nowMillis,
                             worldId = sharedInstance.substringBefore(':'),
                             accessType = sharedInstance.accessType(),
-                            announce = true,
+                            announce = canAnnounceNewMeeting,
                         )
                     )
                 }
@@ -223,6 +226,7 @@ internal class FriendActivityTracker(
         previousByUserId.clear()
         lastKnownInstanceByUserId.clear()
         lastKnownFriendByUserId.clear()
+        hasObservedSelfLocation = false
         return FriendActivityBatch(meetings = ended)
     }
 

--- a/composeApp/src/commonMain/kotlin/service/FriendActivityTracker.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendActivityTracker.kt
@@ -11,6 +11,14 @@ internal data class FriendActivityObservation(
     val lastActivityAtMillis: Long?,
 )
 
+internal enum class FriendSocketPresenceType { Online, Offline }
+
+internal data class FriendSocketPresenceEvent(
+    val userId: String,
+    val type: FriendSocketPresenceType,
+    val occurredAtMillis: Long,
+)
+
 enum class FriendActivityAccessType {
     Public,
     FriendsPlus,
@@ -34,6 +42,12 @@ internal sealed interface FriendMeetingChange {
     ) : FriendMeetingChange
 
     data class Ended(
+        override val userId: String,
+        override val occurredAtMillis: Long,
+        val durationMillis: Long,
+    ) : FriendMeetingChange
+
+    data class Checkpoint(
         override val userId: String,
         override val occurredAtMillis: Long,
         val durationMillis: Long,
@@ -67,7 +81,9 @@ internal data class FriendActivityBatch(
     val events: List<FriendActivityEventDraft> = emptyList(),
 )
 
-internal class FriendActivityTracker {
+internal class FriendActivityTracker(
+    private val derivePresenceEvents: Boolean = false,
+) {
     private data class ActiveMeeting(
         val instanceKey: String,
         val startedAtMillis: Long,
@@ -75,6 +91,8 @@ internal class FriendActivityTracker {
 
     private val previousByUserId = mutableMapOf<String, FriendActivityObservation>()
     private val activeMeetings = mutableMapOf<String, ActiveMeeting>()
+    private val lastKnownInstanceByUserId = mutableMapOf<String, String>()
+    private val lastKnownFriendByUserId = mutableMapOf<String, FriendActivityObservation>()
 
     fun observe(
         friends: Collection<FriendActivityObservation>,
@@ -100,8 +118,10 @@ internal class FriendActivityTracker {
             }
 
             friends.forEach { friend ->
+                lastKnownFriendByUserId[friend.userId] = friend
                 val previous = previousByUserId[friend.userId]
                 val friendInstance = friend.location.normalizedInstanceKey()
+                if (friendInstance != null) lastKnownInstanceByUserId[friend.userId] = friendInstance
                 val sharedInstance = selfInstance?.takeIf { it == friendInstance }
                 val activeMeeting = activeMeetings[friend.userId]
 
@@ -123,6 +143,11 @@ internal class FriendActivityTracker {
                 }
 
                 events += friend.eventsSince(previous, nowMillis)
+
+                if (activeMeeting != null && sharedInstance == activeMeeting.instanceKey) {
+                    val elapsed = (nowMillis - activeMeeting.startedAtMillis).coerceAtLeast(0L)
+                    if (elapsed > 0L) add(FriendMeetingChange.Checkpoint(friend.userId, nowMillis, elapsed))
+                }
 
                 if (activeMeeting != null && activeMeeting.instanceKey != sharedInstance) {
                     add(
@@ -153,6 +178,54 @@ internal class FriendActivityTracker {
         return FriendActivityBatch(meetings = meetings, events = events)
     }
 
+    fun observeSocketPresence(
+        friends: Collection<FriendActivityObservation>,
+        event: FriendSocketPresenceEvent,
+    ): FriendActivityBatch {
+        val friend = friends.firstOrNull { it.userId == event.userId }
+            ?: lastKnownFriendByUserId[event.userId]
+            ?: FriendActivityObservation(
+                userId = event.userId,
+                displayName = "",
+                profileImageUrl = "",
+                location = "offline",
+                status = "offline",
+                statusDescription = "",
+                bio = "",
+                lastActivityAtMillis = null,
+            )
+        val type = when (event.type) {
+            FriendSocketPresenceType.Online -> FriendActivityEventType.Online
+            FriendSocketPresenceType.Offline -> FriendActivityEventType.Offline
+        }
+        val location = friend.location.normalizedInstanceKey() ?: lastKnownInstanceByUserId[event.userId]
+        return FriendActivityBatch(events = listOf(FriendActivityEventDraft(
+            userId = friend.userId,
+            displayName = friend.displayName,
+            profileImageUrl = friend.profileImageUrl,
+            type = type,
+            occurredAtMillis = event.occurredAtMillis,
+            currentValue = if (type == FriendActivityEventType.Online) friend.statusValue() else null,
+            worldId = location?.substringBefore(':'),
+            accessType = location?.accessType(),
+        )))
+    }
+
+    fun finish(nowMillis: Long): FriendActivityBatch {
+        val ended = activeMeetings.map { (userId, active) ->
+            FriendMeetingChange.Ended(
+                userId = userId,
+                occurredAtMillis = nowMillis,
+                durationMillis = (nowMillis - active.startedAtMillis).coerceAtLeast(0L),
+            )
+        }
+        activeMeetings.clear()
+        previousByUserId.clear()
+        lastKnownInstanceByUserId.clear()
+        lastKnownFriendByUserId.clear()
+        return FriendActivityBatch(meetings = ended)
+    }
+
     private fun FriendActivityObservation.eventsSince(
         previous: FriendActivityObservation,
         nowMillis: Long,
@@ -170,7 +243,7 @@ internal class FriendActivityTracker {
         )
 
         when {
-            previousInstance == null && currentInstance != null -> add(
+            derivePresenceEvents && previousInstance == null && currentInstance != null -> add(
                 baseEvent.copy(
                     type = FriendActivityEventType.Online,
                     currentValue = statusValue(),
@@ -178,7 +251,7 @@ internal class FriendActivityTracker {
                     accessType = currentInstance.accessType(),
                 )
             )
-            previousInstance != null && currentInstance == null -> add(
+            derivePresenceEvents && previousInstance != null && currentInstance == null -> add(
                 baseEvent.copy(
                     type = FriendActivityEventType.Offline,
                     worldId = previousInstance.substringBefore(':'),

--- a/composeApp/src/commonMain/kotlin/service/FriendService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendService.kt
@@ -43,6 +43,8 @@ import kotlinx.coroutines.flow.retry
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 import kotlinx.serialization.json.Json
 
 class FriendService(
@@ -83,6 +85,9 @@ class FriendService(
     private val _friendActivitySource = MutableStateFlow<FriendActivitySourceSnapshot?>(null)
     internal val friendActivitySource: StateFlow<FriendActivitySourceSnapshot?> =
         _friendActivitySource.asStateFlow()
+    private val _friendLastActivitySource = MutableStateFlow<FriendActivitySourceSnapshot?>(null)
+    internal val friendLastActivitySource: StateFlow<FriendActivitySourceSnapshot?> =
+        _friendLastActivitySource.asStateFlow()
 
     private val _initialRefreshCompleted = MutableStateFlow(false)
 
@@ -126,6 +131,7 @@ class FriendService(
                         currentUserLocationRevision++
                         _currentUserLocation.value = null
                         _friendActivitySource.value = null
+                        _friendLastActivitySource.value = null
                         _initialRefreshCompleted.value = false
                     }
                     preloadTask.cancelAndJoin()
@@ -163,10 +169,12 @@ class FriendService(
         }
     }
 
+    @OptIn(ExperimentalTime::class)
     private suspend fun handleWebSocketEvent(accountEvent: AccountWebSocketEvent) {
         val sessionToken = accountEvent.token
         if (!isCurrentSession(sessionToken)) return
         val socketEvent = accountEvent.event
+        val receivedAtMillis = Clock.System.now().toEpochMilliseconds()
         when (socketEvent.type) {
             "user-location" -> {
                 val content = json.decodeFromString<UserLocationContent>(socketEvent.content)
@@ -188,8 +196,15 @@ class FriendService(
             FriendEvents.FriendOnline.typeName -> {
                 val content = json.decodeFromString<FriendOnlineContent>(socketEvent.content)
                 val friend = updateFriend(sessionToken, content.userId, content::mergeWith)
-                    ?: return refreshAfterIncompleteEvent(sessionToken)
-                emitFriendUpdate(sessionToken, FriendUpdateEvent.Online(friend))
+                    ?: run {
+                        refreshAfterIncompleteEvent(sessionToken)
+                        friendMap[content.userId]
+                    }
+                emitFriendUpdate(
+                    sessionToken = sessionToken,
+                    event = FriendUpdateEvent.Online(friend, content.userId),
+                    occurredAtMillis = receivedAtMillis,
+                )
             }
 
             FriendEvents.FriendActive.typeName -> {
@@ -208,7 +223,11 @@ class FriendService(
                         status = UserStatus.Offline,
                     )
                 }) return
-                emitFriendUpdate(sessionToken, FriendUpdateEvent.Offline(content.userId))
+                emitFriendUpdate(
+                    sessionToken = sessionToken,
+                    event = FriendUpdateEvent.Offline(content.userId),
+                    occurredAtMillis = receivedAtMillis,
+                )
             }
 
             FriendEvents.FriendLocation.typeName -> {
@@ -264,8 +283,9 @@ class FriendService(
     private suspend fun emitFriendUpdate(
         sessionToken: AccountSessionToken,
         event: FriendUpdateEvent,
+        occurredAtMillis: Long? = null,
     ) {
-        _friendUpdateFlow.emit(AccountFriendUpdateEvent(sessionToken, event))
+        _friendUpdateFlow.emit(AccountFriendUpdateEvent(sessionToken, event, occurredAtMillis))
     }
 
     /**
@@ -365,6 +385,13 @@ class FriendService(
         val committed = friendStore.mergeRefresh(token, friends, replaceUntouched)
         if (committed) {
             publishFriendState()
+            activeSessionToken?.let { sessionToken ->
+                _friendLastActivitySource.value = FriendActivitySourceSnapshot(
+                    token = sessionToken,
+                    friends = friends.toList(),
+                    selfLocation = null,
+                )
+            }
             _initialRefreshCompleted.value = true
         }
         committed
@@ -502,7 +529,7 @@ internal fun FriendData.asCachedOffline(): FriendData = copy(
 )
 
 sealed class FriendUpdateEvent {
-    data class Online(val friend: FriendData) : FriendUpdateEvent()
+    data class Online(val friend: FriendData?, val userId: String = friend?.id.orEmpty()) : FriendUpdateEvent()
     data class Active(val friend: FriendData) : FriendUpdateEvent()
     data class Offline(val userId: String) : FriendUpdateEvent()
     data class LocationChanged(val friend: FriendData) : FriendUpdateEvent()
@@ -514,6 +541,7 @@ sealed class FriendUpdateEvent {
 data class AccountFriendUpdateEvent(
     val sessionToken: AccountSessionToken,
     val event: FriendUpdateEvent,
+    val occurredAtMillis: Long? = null,
 )
 
 internal suspend fun <T> collectFriendWebSocketEvents(

--- a/composeApp/src/commonMain/kotlin/service/FriendService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendService.kt
@@ -22,6 +22,7 @@ import io.github.vrcmteam.vrcm.storage.FriendListCacheStore
 import io.github.vrcmteam.vrcm.storage.AccountCacheManager
 import io.github.vrcmteam.vrcm.storage.AccountCacheWriteToken
 import io.github.vrcmteam.vrcm.storage.data.FriendListCache
+import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.CancellationException
@@ -76,6 +77,12 @@ class FriendService(
             synchronized(friendMapLock) { activeAccountUserId == userId }
         },
         runTask = { refreshFriendList() },
+    )
+    private val offlineLastActivityRefreshSequence = atomic(0L)
+    private val offlineLastActivityRefreshTask = AccountBoundTask<OfflineLastActivityRefreshRequest>(
+        scope = serviceScope,
+        isCurrent = { isCurrentSession(it.sessionToken) },
+        runTask = { refreshFriendList(offline = true) },
     )
 
     private val _friendState = MutableStateFlow<Map<String, FriendData>>(emptyMap())
@@ -135,7 +142,9 @@ class FriendService(
                         _initialRefreshCompleted.value = false
                     }
                     preloadTask.cancelAndJoin()
+                    offlineLastActivityRefreshTask.cancelAndJoin()
                 } else {
+                    offlineLastActivityRefreshTask.cancelAndJoin()
                     activateSession(session)
                 }
             }
@@ -227,6 +236,12 @@ class FriendService(
                     sessionToken = sessionToken,
                     event = FriendUpdateEvent.Offline(content.userId),
                     occurredAtMillis = receivedAtMillis,
+                )
+                offlineLastActivityRefreshTask.start(
+                    OfflineLastActivityRefreshRequest(
+                        sessionToken = sessionToken,
+                        sequence = offlineLastActivityRefreshSequence.incrementAndGet(),
+                    )
                 )
             }
 
@@ -520,6 +535,11 @@ private fun io.github.vrcmteam.vrcm.network.api.auth.data.Presence.toFriendPrese
 private data class PendingFriendCacheSnapshot(
     val token: AccountCacheWriteToken,
     val snapshot: Map<String, FriendData>,
+)
+
+private data class OfflineLastActivityRefreshRequest(
+    val sessionToken: AccountSessionToken,
+    val sequence: Long,
 )
 
 internal fun FriendData.asCachedOffline(): FriendData = copy(

--- a/composeApp/src/commonMain/kotlin/service/FriendService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendService.kt
@@ -152,7 +152,7 @@ class FriendService(
     }
 
     private fun activateSession(session: AuthenticatedAccount) {
-        var accountToRestore: String? = null
+        var restoreCacheBeforeRefresh = false
         val activated = synchronized(friendMapLock) {
             if (activeSessionToken == session.token) return@synchronized false
             activeSessionToken = session.token
@@ -161,7 +161,7 @@ class FriendService(
                 _currentUserLocation.value = null
                 _friendActivitySource.value = null
                 activeAccountUserId = session.account.userId
-                accountToRestore = session.account.userId
+                restoreCacheBeforeRefresh = true
                 // 新账号要重新完成一次完整刷新，才能把在线状态当作可信读数。
                 _initialRefreshCompleted.value = false
             }
@@ -169,10 +169,18 @@ class FriendService(
             publishFriendActivitySource()
             true
         }
-        // 缓存读取是挂起的（Room），不能在 synchronized 里做；放到协程中回填。
-        accountToRestore?.let { userId -> serviceScope.launch { restoreCachedFriendList(userId) } }
         if (activated) {
-            preloadFriendList(session.account.userId)
+            if (restoreCacheBeforeRefresh) {
+                // 先恢复本地回退数据，再发首次网络刷新，避免两个写入逆序提交。
+                serviceScope.launch {
+                    restoreCachedFriendList(session.token)
+                    if (isCurrentSession(session.token)) {
+                        preloadFriendList(session.account.userId)
+                    }
+                }
+            } else {
+                preloadFriendList(session.account.userId)
+            }
             serviceScope.launch {
                 runCatching { refreshCurrentUserLocation(session.token) }
             }
@@ -484,15 +492,17 @@ class FriendService(
         )
     }
 
-    private suspend fun restoreCachedFriendList(userId: String) {
-        val friends = friendListCacheStore.load(userId)?.friends.orEmpty()
+    private suspend fun restoreCachedFriendList(sessionToken: AccountSessionToken) {
+        val friends = friendListCacheStore.load(sessionToken.userId)?.friends.orEmpty()
             .map(FriendData::asCachedOffline)
         synchronized(friendMapLock) {
-            // 读取期间可能已经切到别的账号，过期结果直接丢弃。
-            if (activeAccountUserId != userId) return
+            // 读取期间可能已经切换 session 或完成网络刷新，迟到缓存不能再覆盖实时数据。
+            if (!isCurrentSessionLocked(sessionToken) || _initialRefreshCompleted.value) {
+                return@synchronized
+            }
             friendStore.restore(friends)
+            publishFriendState()
         }
-        publishFriendState()
     }
 
     private fun isCurrentSession(sessionToken: AccountSessionToken): Boolean =

--- a/composeApp/src/commonMain/kotlin/service/FriendService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendService.kt
@@ -171,7 +171,15 @@ class FriendService(
             if (restoreCacheBeforeRefresh) {
                 // 先恢复本地回退数据，再发首次网络刷新，避免两个写入逆序提交。
                 serviceScope.launch {
-                    restoreCachedFriendList(session.token)
+                    try {
+                        restoreCachedFriendList(session.token)
+                    } catch (error: CancellationException) {
+                        throw error
+                    } catch (error: Exception) {
+                        SharedFlowCentre.toastText.emit(
+                            ToastText.Error("恢复好友缓存失败，将重新获取好友列表: ${error.message}")
+                        )
+                    }
                     if (isCurrentSession(session.token)) {
                         preloadFriendList(session.token)
                     }

--- a/composeApp/src/commonMain/kotlin/service/FriendService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendService.kt
@@ -71,18 +71,16 @@ class FriendService(
                 cache = FriendListCache(pending.snapshot.values.toList()),
             )
     }
-    private val preloadTask = AccountBoundTask<String>(
+    private val preloadTask = AccountBoundTask<AccountSessionToken>(
         scope = serviceScope,
-        isCurrent = { userId ->
-            synchronized(friendMapLock) { activeAccountUserId == userId }
-        },
-        runTask = { refreshFriendList() },
+        isCurrent = ::isCurrentSession,
+        runTask = { refreshFriendList(it) },
     )
     private val offlineLastActivityRefreshSequence = atomic(0L)
     private val offlineLastActivityRefreshTask = AccountBoundTask<OfflineLastActivityRefreshRequest>(
         scope = serviceScope,
         isCurrent = { isCurrentSession(it.sessionToken) },
-        runTask = { refreshFriendList(offline = true) },
+        runTask = { refreshFriendList(it.sessionToken, offline = true) },
     )
 
     private val _friendState = MutableStateFlow<Map<String, FriendData>>(emptyMap())
@@ -175,11 +173,11 @@ class FriendService(
                 serviceScope.launch {
                     restoreCachedFriendList(session.token)
                     if (isCurrentSession(session.token)) {
-                        preloadFriendList(session.account.userId)
+                        preloadFriendList(session.token)
                     }
                 }
             } else {
-                preloadFriendList(session.account.userId)
+                preloadFriendList(session.token)
             }
             serviceScope.launch {
                 runCatching { refreshCurrentUserLocation(session.token) }
@@ -318,8 +316,20 @@ class FriendService(
     suspend fun refreshFriendList(
         offline: Boolean? = null,
         onUpdater: suspend (List<FriendData>) -> Unit = {},
+    ): Boolean {
+        val sessionToken = synchronized(friendMapLock) { activeSessionToken } ?: return false
+        return refreshFriendList(sessionToken, offline, onUpdater)
+    }
+
+    private suspend fun refreshFriendList(
+        sessionToken: AccountSessionToken,
+        offline: Boolean? = null,
+        onUpdater: suspend (List<FriendData>) -> Unit = {},
     ): Boolean = refreshCoordinator.runRefresh {
-        val refreshToken = synchronized(friendMapLock) { friendStore.beginRefresh() }
+        val refreshToken = synchronized(friendMapLock) {
+            if (!isCurrentSessionLocked(sessionToken)) return@synchronized null
+            friendStore.beginRefresh()
+        } ?: return@runRefresh false
         val collectedFriends = mutableListOf<FriendData>()
         var succeeded = true
         try {
@@ -338,6 +348,7 @@ class FriendService(
 
             if (succeeded) {
                 return@runRefresh commitRefresh(
+                    sessionToken = sessionToken,
                     token = refreshToken,
                     friends = collectedFriends,
                     replaceUntouched = offline == null,
@@ -402,23 +413,23 @@ class FriendService(
     }
 
     private fun commitRefresh(
+        sessionToken: AccountSessionToken,
         token: FriendRefreshToken,
         friends: Collection<FriendData>,
         replaceUntouched: Boolean,
     ): Boolean = synchronized(friendMapLock) {
+        if (!isCurrentSessionLocked(sessionToken)) return@synchronized false
         val committed = friendStore.mergeRefresh(token, friends, replaceUntouched)
         if (committed) {
             if (replaceUntouched) {
                 _initialRefreshCompleted.value = true
             }
             publishFriendState()
-            activeSessionToken?.let { sessionToken ->
-                _friendLastActivitySource.value = FriendActivitySourceSnapshot(
-                    token = sessionToken,
-                    friends = friends.toList(),
-                    selfLocation = null,
-                )
-            }
+            _friendLastActivitySource.value = FriendActivitySourceSnapshot(
+                token = sessionToken,
+                friends = friends.toList(),
+                selfLocation = null,
+            )
         }
         committed
     }
@@ -512,11 +523,11 @@ class FriendService(
         activeSessionToken == sessionToken && SharedFlowCentre.isCurrentSession(sessionToken)
 
     fun preloadFriendList() {
-        val userId = synchronized(friendMapLock) { activeAccountUserId } ?: return
-        preloadFriendList(userId)
+        val sessionToken = synchronized(friendMapLock) { activeSessionToken } ?: return
+        preloadFriendList(sessionToken)
     }
 
-    private fun preloadFriendList(userId: String) = preloadTask.start(userId)
+    private fun preloadFriendList(sessionToken: AccountSessionToken) = preloadTask.start(sessionToken)
 
     internal fun dispose() {
         serviceScope.cancel()

--- a/composeApp/src/commonMain/kotlin/service/FriendService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendService.kt
@@ -159,6 +159,7 @@ class FriendService(
             if (activeAccountUserId != session.account.userId) {
                 currentUserLocationRevision++
                 _currentUserLocation.value = null
+                _friendActivitySource.value = null
                 activeAccountUserId = session.account.userId
                 accountToRestore = session.account.userId
                 // 新账号要重新完成一次完整刷新，才能把在线状态当作可信读数。
@@ -399,6 +400,9 @@ class FriendService(
     ): Boolean = synchronized(friendMapLock) {
         val committed = friendStore.mergeRefresh(token, friends, replaceUntouched)
         if (committed) {
+            if (replaceUntouched) {
+                _initialRefreshCompleted.value = true
+            }
             publishFriendState()
             activeSessionToken?.let { sessionToken ->
                 _friendLastActivitySource.value = FriendActivitySourceSnapshot(
@@ -407,7 +411,6 @@ class FriendService(
                     selfLocation = null,
                 )
             }
-            _initialRefreshCompleted.value = true
         }
         committed
     }
@@ -472,6 +475,7 @@ class FriendService(
     }
 
     private fun publishFriendActivitySource() {
+        if (!_initialRefreshCompleted.value) return
         val token = activeSessionToken ?: return
         _friendActivitySource.value = FriendActivitySourceSnapshot(
             token = token,

--- a/composeApp/src/commonMain/kotlin/service/FriendService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendService.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlinx.serialization.json.Json
+import org.koin.core.logger.Logger
 
 class FriendService(
     private val friendsApi: FriendsApi,
@@ -54,6 +55,7 @@ class FriendService(
     private val json: Json,
     private val friendListCacheStore: FriendListCacheStore,
     private val accountCacheManager: AccountCacheManager,
+    private val logger: Logger,
 ) {
     private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val friendMapLock = SynchronizedObject()
@@ -176,9 +178,7 @@ class FriendService(
                     } catch (error: CancellationException) {
                         throw error
                     } catch (error: Exception) {
-                        SharedFlowCentre.toastText.emit(
-                            ToastText.Error("恢复好友缓存失败，将重新获取好友列表: ${error.message}")
-                        )
+                        logger.warn("Failed to restore friend cache: ${error.message.orEmpty()}")
                     }
                     if (isCurrentSession(session.token)) {
                         preloadFriendList(session.token)

--- a/composeApp/src/commonMain/kotlin/storage/FriendActivityDao.kt
+++ b/composeApp/src/commonMain/kotlin/storage/FriendActivityDao.kt
@@ -120,10 +120,19 @@ internal interface FriendActivityDao {
     suspend fun openSession(ownerUserId: String, friendUserId: String): FriendActivitySessionEntity?
 
     @Query(
+        "SELECT * FROM friend_activity_sessions " +
+            "WHERE ownerUserId = :ownerUserId AND endedAtMillis IS NULL"
+    )
+    suspend fun incompleteSessions(ownerUserId: String): List<FriendActivitySessionEntity>
+
+    @Query(
         "UPDATE friend_activity_sessions SET endedAtMillis = :endedAtMillis, durationMillis = :durationMillis " +
             "WHERE id = :sessionId"
     )
     suspend fun completeSession(sessionId: Long, endedAtMillis: Long, durationMillis: Long)
+
+    @Query("UPDATE friend_activity_sessions SET durationMillis = :durationMillis WHERE id = :sessionId")
+    suspend fun checkpointSession(sessionId: Long, durationMillis: Long)
 
     @Query(
         "SELECT * FROM friend_activity_sessions " +
@@ -134,6 +143,24 @@ internal interface FriendActivityDao {
 
     @Query("DELETE FROM friend_activity_sessions WHERE ownerUserId = :ownerUserId AND endedAtMillis IS NULL")
     suspend fun deleteIncompleteSessions(ownerUserId: String)
+
+    @Transaction
+    suspend fun discardIncompleteSessions(ownerUserId: String) {
+        val summariesByUserId = summaries(ownerUserId)
+            .associateByTo(mutableMapOf(), FriendActivitySummaryEntity::friendUserId)
+        incompleteSessions(ownerUserId).forEach { session ->
+            if (session.durationMillis <= 0L) return@forEach
+            val summary = summariesByUserId[session.friendUserId] ?: return@forEach
+            summariesByUserId[session.friendUserId] = summary.copy(
+                lastSeenTogetherAtMillis = latest(
+                    summary.lastSeenTogetherAtMillis,
+                    session.startedAtMillis + session.durationMillis,
+                ),
+            )
+        }
+        if (summariesByUserId.isNotEmpty()) upsertSummaries(summariesByUserId.values.toList())
+        deleteIncompleteSessions(ownerUserId)
+    }
 
     @Query(
         "DELETE FROM friend_activity_sessions WHERE ownerUserId = :ownerUserId " +
@@ -230,7 +257,6 @@ internal interface FriendActivityDao {
                 lastOfflineAtMillis = if (event.type == FriendActivityEventType.Offline) {
                     event.occurredAtMillis
                 } else current.lastOfflineAtMillis,
-                lastActivityAtMillis = latest(current.lastActivityAtMillis, event.occurredAtMillis),
             )
             event.toEntity(token.ownerUserId)
         }.toMutableList()
@@ -258,8 +284,7 @@ internal interface FriendActivityDao {
                         )
                     )
                     summariesByUserId[meeting.userId] = current.copy(
-                        lastSeenTogetherAtMillis = meeting.occurredAtMillis,
-                        lastActivityAtMillis = latest(current.lastActivityAtMillis, meeting.occurredAtMillis),
+                        meetingCount = current.meetingCount + if (meeting.announce) 1 else 0,
                     )
                     if (meeting.announce) {
                         storedEvents += meeting.toEvent(
@@ -272,12 +297,12 @@ internal interface FriendActivityDao {
                 }
                 is FriendMeetingChange.Ended -> {
                     val session = openSession(token.ownerUserId, meeting.userId) ?: return@forEach
-                    completeSession(session.id, meeting.occurredAtMillis, meeting.durationMillis)
+                    val duration = maxOf(session.durationMillis, meeting.durationMillis)
+                    val additionalDuration = duration - session.durationMillis
+                    completeSession(session.id, meeting.occurredAtMillis, duration)
                     summariesByUserId[meeting.userId] = current.copy(
                         lastSeenTogetherAtMillis = meeting.occurredAtMillis,
-                        meetingCount = current.meetingCount + 1,
-                        togetherDurationMillis = current.togetherDurationMillis + meeting.durationMillis,
-                        lastActivityAtMillis = latest(current.lastActivityAtMillis, meeting.occurredAtMillis),
+                        togetherDurationMillis = current.togetherDurationMillis + additionalDuration,
                     )
                     if (session.announced) {
                         storedEvents += meeting.toEvent(
@@ -287,6 +312,15 @@ internal interface FriendActivityDao {
                             accessType = session.accessType,
                         )
                     }
+                }
+                is FriendMeetingChange.Checkpoint -> {
+                    val session = openSession(token.ownerUserId, meeting.userId) ?: return@forEach
+                    val duration = maxOf(session.durationMillis, meeting.durationMillis)
+                    val additionalDuration = duration - session.durationMillis
+                    checkpointSession(session.id, duration)
+                    summariesByUserId[meeting.userId] = current.copy(
+                        togetherDurationMillis = current.togetherDurationMillis + additionalDuration,
+                    )
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/storage/RoomFriendActivityStore.kt
+++ b/composeApp/src/commonMain/kotlin/storage/RoomFriendActivityStore.kt
@@ -24,7 +24,7 @@ internal class RoomFriendActivityStore(
     ): Boolean = dao.record(token, observations, batch, nowMillis)
 
     suspend fun discardIncompleteSessions(ownerUserId: String) =
-        dao.deleteIncompleteSessions(ownerUserId)
+        dao.discardIncompleteSessions(ownerUserId)
 
     override suspend fun clearAccount(ownerUserId: String) = dao.clearAccount(ownerUserId)
 

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/LateSessionConsumerIntegrationTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/LateSessionConsumerIntegrationTest.kt
@@ -85,6 +85,7 @@ class LateSessionConsumerIntegrationTest : MainDispatcherTest() {
             json = json,
             friendListCacheStore = friendListCacheStore,
             accountCacheManager = cacheManager,
+            logger = EmptyLogger(),
         )
         val locationModel = FriendLocationPagerModel(
             friendService = friendService,

--- a/composeApp/src/commonTest/kotlin/service/FriendActivityTrackerTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/FriendActivityTrackerTest.kt
@@ -6,6 +6,55 @@ import kotlin.test.assertTrue
 
 class FriendActivityTrackerTest {
     @Test
+    fun socketPresenceIsRecordedBeforeFriendSnapshotIsAvailable() {
+        val result = FriendActivityTracker().observeSocketPresence(
+            friends = emptyList(),
+            event = FriendSocketPresenceEvent(
+                userId = "usr_friend",
+                type = FriendSocketPresenceType.Offline,
+                occurredAtMillis = 1_000L,
+            ),
+        )
+
+        assertEquals(1, result.events.size)
+        assertEquals("usr_friend", result.events.single().userId)
+        assertEquals(FriendActivityEventType.Offline, result.events.single().type)
+    }
+
+    @Test
+    fun snapshotPresenceChangesDoNotCreateSocketOnlyEvents() {
+        val tracker = FriendActivityTracker(derivePresenceEvents = false)
+        val friend = FriendActivityObservation(
+            userId = "usr_friend",
+            displayName = "Friend",
+            profileImageUrl = "",
+            location = "offline",
+            status = "offline",
+            statusDescription = "",
+            bio = "",
+            lastActivityAtMillis = 1_000L,
+        )
+        tracker.observe(listOf(friend), null, 1_000L)
+
+        val refreshed = tracker.observe(
+            listOf(friend.copy(location = "wrld_world:instance_a", status = "active")),
+            null,
+            2_000L,
+        )
+        val socket = tracker.observeSocketPresence(
+            friends = listOf(friend.copy(location = "wrld_world:instance_a", status = "active")),
+            event = FriendSocketPresenceEvent(
+                userId = friend.userId,
+                type = FriendSocketPresenceType.Online,
+                occurredAtMillis = 3_000L,
+            ),
+        )
+
+        assertTrue(refreshed.events.none { it.type == FriendActivityEventType.Online })
+        assertEquals(listOf(FriendActivityEventType.Online), socket.events.map { it.type })
+    }
+
+    @Test
     fun comingOnlineKeepsLocationAndCurrentStatusInOneEvent() {
         val tracker = FriendActivityTracker()
         val offlineFriend = FriendActivityObservation(
@@ -24,16 +73,19 @@ class FriendActivityTrackerTest {
             nowMillis = 1_000L,
         )
 
-        val result = tracker.observe(
-            friends = listOf(
-                offlineFriend.copy(
-                    location = "wrld_world:instance_a~friends(usr_owner)",
-                    status = "join me",
-                    statusDescription = "Come over",
-                )
+        val onlineFriend = offlineFriend.copy(
+            location = "wrld_world:instance_a~friends(usr_owner)",
+            status = "join me",
+            statusDescription = "Come over",
+        )
+        tracker.observe(listOf(onlineFriend), null, 2_000L)
+        val result = tracker.observeSocketPresence(
+            friends = listOf(onlineFriend),
+            event = FriendSocketPresenceEvent(
+                userId = onlineFriend.userId,
+                type = FriendSocketPresenceType.Online,
+                occurredAtMillis = 2_000L,
             ),
-            selfLocation = null,
-            nowMillis = 2_000L,
         )
 
         assertEquals(1, result.events.size)
@@ -62,16 +114,19 @@ class FriendActivityTrackerTest {
             nowMillis = 1_000L,
         )
 
-        val result = tracker.observe(
-            friends = listOf(
-                onlineFriend.copy(
-                    location = "offline",
-                    status = "offline",
-                    statusDescription = "",
-                )
+        val offlineFriend = onlineFriend.copy(
+            location = "offline",
+            status = "offline",
+            statusDescription = "",
+        )
+        tracker.observe(listOf(offlineFriend), null, 2_000L)
+        val result = tracker.observeSocketPresence(
+            friends = listOf(offlineFriend),
+            event = FriendSocketPresenceEvent(
+                userId = offlineFriend.userId,
+                type = FriendSocketPresenceType.Offline,
+                occurredAtMillis = 2_000L,
             ),
-            selfLocation = null,
-            nowMillis = 2_000L,
         )
 
         assertEquals(1, result.events.size)

--- a/composeApp/src/commonTest/kotlin/service/FriendActivityTrackingStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/FriendActivityTrackingStateTest.kt
@@ -1,24 +1,29 @@
 package io.github.vrcmteam.vrcm.service
 
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class FriendActivityTrackingStateTest {
     @Test
-    fun backgroundMonitorRestartResumesTrackingWhileAppRemainsStopped() {
+    fun backgroundMonitorRestartResumesTrackingWhileAppRemainsStopped() = runTest {
         val state = FriendActivityTrackingState()
 
-        assertEquals(FriendActivityTrackingControl.Resume, state.setAppForeground(true))
-        assertNull(state.setBackgroundMonitoring(true))
-        assertNull(state.setAppForeground(false))
+        state.setAppForeground(true)
+        state.setBackgroundMonitoring(true)
+        state.setAppForeground(false)
         assertTrue(state.isEnabled())
+        assertEquals(FriendActivityTrackingControl.Resume, state.controls.first())
 
-        assertEquals(FriendActivityTrackingControl.Stop, state.setBackgroundMonitoring(false))
+        state.setBackgroundMonitoring(false)
         assertFalse(state.isEnabled())
-        assertEquals(FriendActivityTrackingControl.Resume, state.setBackgroundMonitoring(true))
+        assertEquals(FriendActivityTrackingControl.Stop, state.controls.first())
+
+        state.setBackgroundMonitoring(true)
         assertTrue(state.isEnabled())
+        assertEquals(FriendActivityTrackingControl.Resume, state.controls.first())
     }
 }

--- a/composeApp/src/commonTest/kotlin/service/FriendActivityTrackingStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/FriendActivityTrackingStateTest.kt
@@ -1,0 +1,24 @@
+package io.github.vrcmteam.vrcm.service
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class FriendActivityTrackingStateTest {
+    @Test
+    fun backgroundMonitorRestartResumesTrackingWhileAppRemainsStopped() {
+        val state = FriendActivityTrackingState()
+
+        assertEquals(FriendActivityTrackingControl.Resume, state.setAppForeground(true))
+        assertNull(state.setBackgroundMonitoring(true))
+        assertNull(state.setAppForeground(false))
+        assertTrue(state.isEnabled())
+
+        assertEquals(FriendActivityTrackingControl.Stop, state.setBackgroundMonitoring(false))
+        assertFalse(state.isEnabled())
+        assertEquals(FriendActivityTrackingControl.Resume, state.setBackgroundMonitoring(true))
+        assertTrue(state.isEnabled())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/service/FriendActivityTrackingStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/FriendActivityTrackingStateTest.kt
@@ -10,20 +10,32 @@ import kotlin.test.assertTrue
 class FriendActivityTrackingStateTest {
     @Test
     fun backgroundMonitorRestartResumesTrackingWhileAppRemainsStopped() = runTest {
-        val state = FriendActivityTrackingState()
+        var nowMillis = 1_000L
+        val state = FriendActivityTrackingState { nowMillis }
 
         state.setAppForeground(true)
         state.setBackgroundMonitoring(true)
         state.setAppForeground(false)
         assertTrue(state.isEnabled())
-        assertEquals(FriendActivityTrackingControl.Resume, state.controls.first())
+        assertEquals(
+            FriendActivityTrackingTransition(1L, FriendActivityTrackingControl.Resume, 1_000L),
+            state.controls.first(),
+        )
 
+        nowMillis = 2_000L
         state.setBackgroundMonitoring(false)
         assertFalse(state.isEnabled())
-        assertEquals(FriendActivityTrackingControl.Stop, state.controls.first())
+        assertEquals(
+            FriendActivityTrackingTransition(2L, FriendActivityTrackingControl.Stop, 2_000L),
+            state.controls.first(),
+        )
 
+        nowMillis = 3_000L
         state.setBackgroundMonitoring(true)
         assertTrue(state.isEnabled())
-        assertEquals(FriendActivityTrackingControl.Resume, state.controls.first())
+        assertEquals(
+            FriendActivityTrackingTransition(3L, FriendActivityTrackingControl.Resume, 3_000L),
+            state.controls.first(),
+        )
     }
 }

--- a/composeApp/src/commonTest/kotlin/service/FriendOfflineLastActivityRefreshTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/FriendOfflineLastActivityRefreshTest.kt
@@ -1,0 +1,189 @@
+package io.github.vrcmteam.vrcm.service
+
+import com.russhwolf.settings.MapSettings
+import io.github.vrcmteam.vrcm.core.shared.AccountWebSocketEvent
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
+import io.github.vrcmteam.vrcm.di.supports.PersistentCookiesStorage
+import io.github.vrcmteam.vrcm.network.api.attributes.LocationType
+import io.github.vrcmteam.vrcm.network.api.attributes.UserStatus
+import io.github.vrcmteam.vrcm.network.api.auth.AuthApi
+import io.github.vrcmteam.vrcm.network.api.friends.FriendsApi
+import io.github.vrcmteam.vrcm.network.api.friends.date.FriendData
+import io.github.vrcmteam.vrcm.network.websocket.data.WebSocketEvent
+import io.github.vrcmteam.vrcm.network.websocket.data.content.FriendOfflineContent
+import io.github.vrcmteam.vrcm.network.websocket.data.type.FriendEvents
+import io.github.vrcmteam.vrcm.service.data.AccountDto
+import io.github.vrcmteam.vrcm.storage.AccountCacheManager
+import io.github.vrcmteam.vrcm.storage.AccountDao
+import io.github.vrcmteam.vrcm.storage.InMemoryFriendListCacheStore
+import io.github.vrcmteam.vrcm.storage.InMemorySecureStorage
+import io.github.vrcmteam.vrcm.storage.InMemoryUserProfileCacheStore
+import io.github.vrcmteam.vrcm.storage.NoOpFriendActivityCacheStore
+import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardAssetStore
+import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardConfigDao
+import io.github.vrcmteam.vrcm.testing.MainDispatcherTest
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.koin.core.logger.EmptyLogger
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FriendOfflineLastActivityRefreshTest : MainDispatcherTest() {
+    @Test
+    fun offlineSocketRefreshesLastActivityFromOfflineFriendsEndpoint() = runBlocking {
+        SharedFlowCentre.emitLogout()
+        val account = AccountDto(userId = "usr_owner", username = "owner")
+        SharedFlowCentre.emitAuthenticated(account)
+        val session = assertNotNull(SharedFlowCentre.currentSession.value)
+        val friend = friend()
+        val json = Json { ignoreUnknownKeys = true }
+        val serveUpdatedOfflineFriend = atomic(false)
+        val offlineRequestCount = atomic(0)
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.encodedPath) {
+                        "/auth/user/friends" -> {
+                            val offline = request.url.parameters["offline"] == "true"
+                            val offset = request.url.parameters["offset"]?.toIntOrNull() ?: 0
+                            if (offline) offlineRequestCount.incrementAndGet()
+                            val friends = when {
+                                offset > 0 -> emptyList()
+                                !offline -> listOf(friend)
+                                serveUpdatedOfflineFriend.value -> listOf(
+                                    friend.copy(
+                                        lastActivity = UPDATED_LAST_ACTIVITY,
+                                        location = LocationType.Offline.value,
+                                        status = UserStatus.Offline,
+                                    )
+                                )
+                                else -> emptyList()
+                            }
+                            respond(
+                                content = json.encodeToString(friends),
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                            )
+                        }
+                        "/auth/user" -> respond(
+                            content = "unavailable",
+                            status = HttpStatusCode.InternalServerError,
+                        )
+                        else -> error("Unexpected request: ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) { json(json) }
+        }
+        val accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also {
+            it.saveAccountInfo(account)
+        }
+        val friendListCacheStore = InMemoryFriendListCacheStore()
+        val cacheManager = AccountCacheManager(
+            friendListCacheStore = friendListCacheStore,
+            userProfileCacheStore = InMemoryUserProfileCacheStore(),
+            friendActivityStore = NoOpFriendActivityCacheStore,
+            meetupCardConfigDao = MeetupCardConfigDao(MapSettings()),
+            meetupCardAssetStore = MeetupCardAssetStore(
+                FakeFileSystem(),
+                "/meetup-assets".toPath(),
+            ),
+        )
+        val authService = AuthService(
+            authApi = AuthApi(client),
+            accountDao = accountDao,
+            cookiesStorage = PersistentCookiesStorage(EmptyLogger()),
+            accountCacheManager = cacheManager,
+        )
+        val friendService = FriendService(
+            friendsApi = FriendsApi(client),
+            authService = authService,
+            json = json,
+            friendListCacheStore = friendListCacheStore,
+            accountCacheManager = cacheManager,
+        )
+
+        try {
+            withTimeout(3_000L) {
+                while (!friendService.initialRefreshCompleted.value) yield()
+            }
+            assertEquals(UserStatus.Active, friendService.friendState.value.getValue(friend.id).status)
+            val initialOfflineRequestCount = offlineRequestCount.value
+            serveUpdatedOfflineFriend.value = true
+            val offlineEvent = AccountWebSocketEvent(
+                token = session.token,
+                event = WebSocketEvent(
+                    type = FriendEvents.FriendOffline.typeName,
+                    content = json.encodeToString(FriendOfflineContent(userId = friend.id)),
+                ),
+            )
+
+            SharedFlowCentre.emitWebSocket(offlineEvent)
+            withTimeout(3_000L) {
+                while (friendService.friendLastActivitySource.value
+                        ?.friends
+                        ?.firstOrNull { it.id == friend.id }
+                        ?.lastActivity != UPDATED_LAST_ACTIVITY
+                ) {
+                    yield()
+                }
+            }
+
+            assertTrue(offlineRequestCount.value > initialOfflineRequestCount)
+            assertEquals(
+                UserStatus.Offline,
+                friendService.friendLastActivitySource.value
+                    ?.friends
+                    ?.first { it.id == friend.id }
+                    ?.status,
+            )
+        } finally {
+            friendService.dispose()
+            SharedFlowCentre.emitLogout()
+            client.close()
+        }
+    }
+
+    private fun friend() = FriendData(
+        bio = null,
+        currentAvatarImageUrl = "",
+        currentAvatarThumbnailImageUrl = "",
+        developerType = "none",
+        displayName = "Friend",
+        friendKey = "",
+        id = "usr_friend",
+        imageUrl = "",
+        isFriend = true,
+        lastLogin = "",
+        lastActivity = "",
+        lastPlatform = "standalonewindows",
+        location = "wrld_world:instance_a",
+        profilePicOverride = "",
+        status = UserStatus.Active,
+        statusDescription = "",
+        userIcon = "",
+        pronouns = null,
+    )
+
+    private companion object {
+        const val UPDATED_LAST_ACTIVITY = "2026-08-10T17:15:00.000Z"
+    }
+}

--- a/composeApp/src/commonTest/kotlin/service/FriendOfflineLastActivityRefreshTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/FriendOfflineLastActivityRefreshTest.kt
@@ -34,7 +34,9 @@ import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
@@ -212,6 +214,103 @@ class FriendOfflineLastActivityRefreshTest : MainDispatcherTest() {
         }
     }
 
+    @Test
+    fun previousSessionRefreshCannotCommitWhileNewSessionCacheIsLoading() = runBlocking {
+        SharedFlowCentre.emitLogout()
+        val accountA = AccountDto(userId = "usr_owner_a", username = "owner-a")
+        val accountB = AccountDto(userId = "usr_owner_b", username = "owner-b")
+        SharedFlowCentre.emitAuthenticated(accountA)
+        val friendA = friend().copy(id = "usr_friend_a", displayName = "Friend A")
+        val friendB = friend().copy(id = "usr_friend_b", displayName = "Friend B")
+        val cacheStore = SwitchingFriendListCacheStore(blockedUserId = accountB.userId)
+        val json = Json { ignoreUnknownKeys = true }
+        val releaseAccountARefresh = CompletableDeferred<Unit>()
+        val accountBRefreshStarted = CompletableDeferred<Unit>()
+        val releaseAccountBRefresh = CompletableDeferred<Unit>()
+        val onlineRefreshCount = atomic(0)
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.encodedPath) {
+                        "/auth/user/friends" -> {
+                            val offline = request.url.parameters["offline"] == "true"
+                            val offset = request.url.parameters["offset"]?.toIntOrNull() ?: 0
+                            val friends = if (!offline && offset == 0) {
+                                when (onlineRefreshCount.incrementAndGet()) {
+                                    1 -> {
+                                        releaseAccountARefresh.await()
+                                        listOf(friendA)
+                                    }
+                                    2 -> {
+                                        accountBRefreshStarted.complete(Unit)
+                                        releaseAccountBRefresh.await()
+                                        listOf(friendB)
+                                    }
+                                    else -> listOf(friendB)
+                                }
+                            } else {
+                                emptyList()
+                            }
+                            respond(
+                                content = json.encodeToString(friends),
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                            )
+                        }
+                        "/auth/user" -> respond(
+                            content = "unavailable",
+                            status = HttpStatusCode.InternalServerError,
+                        )
+                        else -> error("Unexpected request: ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) { json(json) }
+        }
+        val friendService = createFriendService(accountA, client, json, cacheStore)
+        var accountBRefresh: Deferred<Boolean>? = null
+
+        try {
+            withTimeout(3_000L) {
+                while (onlineRefreshCount.value == 0) yield()
+            }
+            SharedFlowCentre.emitAuthenticated(accountB)
+            withTimeout(3_000L) { cacheStore.blockedLoadStarted.await() }
+            val refresh = async { friendService.refreshFriendList() }
+            accountBRefresh = refresh
+
+            releaseAccountARefresh.complete(Unit)
+            withTimeout(3_000L) { accountBRefreshStarted.await() }
+
+            assertTrue(friendService.friendState.value.values.none { it.id == friendA.id })
+            assertTrue(
+                friendService.friendActivitySource.value
+                    ?.friends
+                    .orEmpty()
+                    .none { it.id == friendA.id },
+            )
+            assertTrue(
+                friendService.friendLastActivitySource.value
+                    ?.friends
+                    .orEmpty()
+                    .none { it.id == friendA.id },
+            )
+            assertTrue(cacheStore.saved(accountB.userId)?.friends.orEmpty().none { it.id == friendA.id })
+
+            releaseAccountBRefresh.complete(Unit)
+            assertTrue(refresh.await())
+            assertEquals(friendB, friendService.friendState.value[friendB.id])
+        } finally {
+            releaseAccountARefresh.complete(Unit)
+            releaseAccountBRefresh.complete(Unit)
+            cacheStore.releaseBlockedLoad.complete(Unit)
+            accountBRefresh?.cancel()
+            friendService.dispose()
+            SharedFlowCentre.emitLogout()
+            client.close()
+        }
+    }
+
     private suspend fun createFriendService(
         account: AccountDto,
         client: HttpClient,
@@ -305,5 +404,36 @@ private class BlockingFriendListCacheStore(
 
     override suspend fun clearAll() {
         cache = null
+    }
+}
+
+private class SwitchingFriendListCacheStore(
+    private val blockedUserId: String,
+) : FriendListCacheStore {
+    val blockedLoadStarted = CompletableDeferred<Unit>()
+    val releaseBlockedLoad = CompletableDeferred<Unit>()
+    private val entries = atomic<Map<String, FriendListCache>>(emptyMap())
+
+    override suspend fun load(userId: String): FriendListCache? {
+        val result = entries.value[userId]
+        if (userId == blockedUserId) {
+            blockedLoadStarted.complete(Unit)
+            releaseBlockedLoad.await()
+        }
+        return result
+    }
+
+    override suspend fun save(userId: String, cache: FriendListCache) {
+        entries.value = entries.value + (userId to cache)
+    }
+
+    fun saved(userId: String): FriendListCache? = entries.value[userId]
+
+    override suspend fun clear(userId: String) {
+        entries.value = entries.value - userId
+    }
+
+    override suspend fun clearAll() {
+        entries.value = emptyMap()
     }
 }

--- a/composeApp/src/commonTest/kotlin/service/FriendOfflineLastActivityRefreshTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/FriendOfflineLastActivityRefreshTest.kt
@@ -15,10 +15,12 @@ import io.github.vrcmteam.vrcm.network.websocket.data.type.FriendEvents
 import io.github.vrcmteam.vrcm.service.data.AccountDto
 import io.github.vrcmteam.vrcm.storage.AccountCacheManager
 import io.github.vrcmteam.vrcm.storage.AccountDao
+import io.github.vrcmteam.vrcm.storage.FriendListCacheStore
 import io.github.vrcmteam.vrcm.storage.InMemoryFriendListCacheStore
 import io.github.vrcmteam.vrcm.storage.InMemorySecureStorage
 import io.github.vrcmteam.vrcm.storage.InMemoryUserProfileCacheStore
 import io.github.vrcmteam.vrcm.storage.NoOpFriendActivityCacheStore
+import io.github.vrcmteam.vrcm.storage.data.FriendListCache
 import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardAssetStore
 import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardConfigDao
 import io.github.vrcmteam.vrcm.testing.MainDispatcherTest
@@ -31,6 +33,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -93,33 +96,8 @@ class FriendOfflineLastActivityRefreshTest : MainDispatcherTest() {
             }
             install(ContentNegotiation) { json(json) }
         }
-        val accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also {
-            it.saveAccountInfo(account)
-        }
         val friendListCacheStore = InMemoryFriendListCacheStore()
-        val cacheManager = AccountCacheManager(
-            friendListCacheStore = friendListCacheStore,
-            userProfileCacheStore = InMemoryUserProfileCacheStore(),
-            friendActivityStore = NoOpFriendActivityCacheStore,
-            meetupCardConfigDao = MeetupCardConfigDao(MapSettings()),
-            meetupCardAssetStore = MeetupCardAssetStore(
-                FakeFileSystem(),
-                "/meetup-assets".toPath(),
-            ),
-        )
-        val authService = AuthService(
-            authApi = AuthApi(client),
-            accountDao = accountDao,
-            cookiesStorage = PersistentCookiesStorage(EmptyLogger()),
-            accountCacheManager = cacheManager,
-        )
-        val friendService = FriendService(
-            friendsApi = FriendsApi(client),
-            authService = authService,
-            json = json,
-            friendListCacheStore = friendListCacheStore,
-            accountCacheManager = cacheManager,
-        )
+        val friendService = createFriendService(account, client, json, friendListCacheStore)
 
         try {
             withTimeout(3_000L) {
@@ -162,6 +140,122 @@ class FriendOfflineLastActivityRefreshTest : MainDispatcherTest() {
         }
     }
 
+    @Test
+    fun completedRefreshRejectsCacheThatFinishesLater() = runBlocking {
+        SharedFlowCentre.emitLogout()
+        val account = AccountDto(userId = "usr_owner", username = "owner")
+        SharedFlowCentre.emitAuthenticated(account)
+        val liveFriend = friend()
+        val cachedFriend = liveFriend.copy(
+            displayName = "Cached Friend",
+            location = LocationType.Offline.value,
+            status = UserStatus.Offline,
+        )
+        val cacheStore = BlockingFriendListCacheStore(
+            FriendListCache(friends = listOf(cachedFriend)),
+        )
+        val json = Json { ignoreUnknownKeys = true }
+        val refreshAfterCacheStarted = CompletableDeferred<Unit>()
+        val releaseRefreshAfterCache = CompletableDeferred<Unit>()
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.encodedPath) {
+                        "/auth/user/friends" -> {
+                            val offline = request.url.parameters["offline"] == "true"
+                            val offset = request.url.parameters["offset"]?.toIntOrNull() ?: 0
+                            if (!offline && offset == 0 && cacheStore.releaseLoad.isCompleted) {
+                                refreshAfterCacheStarted.complete(Unit)
+                                releaseRefreshAfterCache.await()
+                            }
+                            respond(
+                                content = json.encodeToString(
+                                    if (!offline && offset == 0) listOf(liveFriend) else emptyList(),
+                                ),
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                            )
+                        }
+                        "/auth/user" -> respond(
+                            content = "unavailable",
+                            status = HttpStatusCode.InternalServerError,
+                        )
+                        else -> error("Unexpected request: ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) { json(json) }
+        }
+        val friendService = createFriendService(account, client, json, cacheStore)
+
+        try {
+            withTimeout(3_000L) { cacheStore.loadStarted.await() }
+            assertTrue(friendService.refreshFriendList())
+            assertLiveFriend(friendService, liveFriend)
+
+            cacheStore.releaseLoad.complete(Unit)
+            withTimeout(3_000L) { refreshAfterCacheStarted.await() }
+            assertLiveFriend(friendService, liveFriend)
+
+            releaseRefreshAfterCache.complete(Unit)
+            withTimeout(3_000L) {
+                while (friendService.friendState.value[liveFriend.id]?.status != UserStatus.Active) {
+                    yield()
+                }
+            }
+        } finally {
+            cacheStore.releaseLoad.complete(Unit)
+            releaseRefreshAfterCache.complete(Unit)
+            friendService.dispose()
+            SharedFlowCentre.emitLogout()
+            client.close()
+        }
+    }
+
+    private suspend fun createFriendService(
+        account: AccountDto,
+        client: HttpClient,
+        json: Json,
+        friendListCacheStore: FriendListCacheStore,
+    ): FriendService {
+        val accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also {
+            it.saveAccountInfo(account)
+        }
+        val cacheManager = AccountCacheManager(
+            friendListCacheStore = friendListCacheStore,
+            userProfileCacheStore = InMemoryUserProfileCacheStore(),
+            friendActivityStore = NoOpFriendActivityCacheStore,
+            meetupCardConfigDao = MeetupCardConfigDao(MapSettings()),
+            meetupCardAssetStore = MeetupCardAssetStore(
+                FakeFileSystem(),
+                "/meetup-assets".toPath(),
+            ),
+        )
+        val authService = AuthService(
+            authApi = AuthApi(client),
+            accountDao = accountDao,
+            cookiesStorage = PersistentCookiesStorage(EmptyLogger()),
+            accountCacheManager = cacheManager,
+        )
+        return FriendService(
+            friendsApi = FriendsApi(client),
+            authService = authService,
+            json = json,
+            friendListCacheStore = friendListCacheStore,
+            accountCacheManager = cacheManager,
+        )
+    }
+
+    private fun assertLiveFriend(friendService: FriendService, liveFriend: FriendData) {
+        assertEquals(liveFriend, friendService.friendState.value[liveFriend.id])
+        assertEquals(
+            liveFriend,
+            friendService.friendActivitySource.value
+                ?.friends
+                ?.single { it.id == liveFriend.id },
+        )
+    }
+
     private fun friend() = FriendData(
         bio = null,
         currentAvatarImageUrl = "",
@@ -185,5 +279,31 @@ class FriendOfflineLastActivityRefreshTest : MainDispatcherTest() {
 
     private companion object {
         const val UPDATED_LAST_ACTIVITY = "2026-08-10T17:15:00.000Z"
+    }
+}
+
+private class BlockingFriendListCacheStore(
+    private var cache: FriendListCache?,
+) : FriendListCacheStore {
+    val loadStarted = CompletableDeferred<Unit>()
+    val releaseLoad = CompletableDeferred<Unit>()
+
+    override suspend fun load(userId: String): FriendListCache? {
+        val result = cache
+        loadStarted.complete(Unit)
+        releaseLoad.await()
+        return result
+    }
+
+    override suspend fun save(userId: String, cache: FriendListCache) {
+        this.cache = cache
+    }
+
+    override suspend fun clear(userId: String) {
+        cache = null
+    }
+
+    override suspend fun clearAll() {
+        cache = null
     }
 }

--- a/composeApp/src/commonTest/kotlin/service/FriendOfflineLastActivityRefreshTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/FriendOfflineLastActivityRefreshTest.kt
@@ -311,6 +311,63 @@ class FriendOfflineLastActivityRefreshTest : MainDispatcherTest() {
         }
     }
 
+    @Test
+    fun cacheLoadFailureStillStartsInitialNetworkRefresh() = runBlocking {
+        SharedFlowCentre.emitLogout()
+        val account = AccountDto(userId = "usr_owner", username = "owner")
+        SharedFlowCentre.emitAuthenticated(account)
+        val liveFriend = friend()
+        val json = Json { ignoreUnknownKeys = true }
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.encodedPath) {
+                        "/auth/user/friends" -> {
+                            val offline = request.url.parameters["offline"] == "true"
+                            val offset = request.url.parameters["offset"]?.toIntOrNull() ?: 0
+                            respond(
+                                content = json.encodeToString(
+                                    if (!offline && offset == 0) listOf(liveFriend) else emptyList(),
+                                ),
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                            )
+                        }
+                        "/auth/user" -> respond(
+                            content = "unavailable",
+                            status = HttpStatusCode.InternalServerError,
+                        )
+                        else -> error("Unexpected request: ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) { json(json) }
+        }
+        val friendService = createFriendService(
+            account = account,
+            client = client,
+            json = json,
+            friendListCacheStore = ThrowingFriendListCacheStore,
+        )
+
+        try {
+            withTimeout(3_000L) {
+                while (!friendService.initialRefreshCompleted.value ||
+                    friendService.friendState.value[liveFriend.id] != liveFriend ||
+                    friendService.friendActivitySource.value
+                        ?.friends
+                        ?.singleOrNull { it.id == liveFriend.id } != liveFriend
+                ) {
+                    yield()
+                }
+            }
+        } finally {
+            friendService.dispose()
+            SharedFlowCentre.emitLogout()
+            client.close()
+        }
+    }
+
     private suspend fun createFriendService(
         account: AccountDto,
         client: HttpClient,
@@ -436,4 +493,15 @@ private class SwitchingFriendListCacheStore(
     override suspend fun clearAll() {
         entries.value = emptyMap()
     }
+}
+
+private object ThrowingFriendListCacheStore : FriendListCacheStore {
+    override suspend fun load(userId: String): FriendListCache =
+        error("cache read failed")
+
+    override suspend fun save(userId: String, cache: FriendListCache) = Unit
+
+    override suspend fun clear(userId: String) = Unit
+
+    override suspend fun clearAll() = Unit
 }

--- a/composeApp/src/commonTest/kotlin/service/FriendOfflineLastActivityRefreshTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/FriendOfflineLastActivityRefreshTest.kt
@@ -399,6 +399,7 @@ class FriendOfflineLastActivityRefreshTest : MainDispatcherTest() {
             json = json,
             friendListCacheStore = friendListCacheStore,
             accountCacheManager = cacheManager,
+            logger = EmptyLogger(),
         )
     }
 

--- a/composeApp/src/desktopTest/kotlin/storage/FriendActivityRoomStoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/storage/FriendActivityRoomStoreTest.kt
@@ -12,6 +12,7 @@ import io.github.vrcmteam.vrcm.service.FriendActivityInputSnapshot
 import io.github.vrcmteam.vrcm.service.FriendActivityObservation
 import io.github.vrcmteam.vrcm.service.FriendActivitySourceSnapshot
 import io.github.vrcmteam.vrcm.service.FriendActivityTrackingControl
+import io.github.vrcmteam.vrcm.service.FriendActivityTrackingState
 import io.github.vrcmteam.vrcm.service.FriendSocketPresenceEvent
 import io.github.vrcmteam.vrcm.service.FriendSocketPresenceType
 import io.github.vrcmteam.vrcm.service.FriendMeetingChange
@@ -27,6 +28,8 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import okio.Path.Companion.toPath
@@ -399,6 +402,38 @@ class FriendActivityRoomStoreTest {
             assertEquals(
                 listOf(5_000L, 1_000L),
                 store.sessions("usr_owner", friend.userId).map { it.startedAtMillis },
+            )
+        }
+    }
+
+    @Test
+    fun resumeBeforeCollectorSubscriptionIsReplayedAndStartsTracking() = runTest {
+        withStore { store ->
+            val session = AuthenticatedAccount(
+                account = AccountDto(userId = "usr_owner"),
+                token = AccountSessionToken(userId = "usr_owner", generation = 1L),
+            )
+            val friend = observation().copy(location = "wrld_world:instance_a")
+            val trackingState = FriendActivityTrackingState()
+            trackingState.setBackgroundMonitoring(true)
+
+            trackFriendActivity(
+                session = session,
+                snapshots = trackingState.controls.take(1).map { control ->
+                    FriendActivityInputSnapshot(
+                        token = session.token,
+                        friends = listOf(friend),
+                        selfLocation = friend.location,
+                        observedAtMillis = 1_000L,
+                        trackingControl = control,
+                    )
+                },
+                store = store,
+            )
+
+            assertEquals(
+                listOf(1_000L),
+                store.sessions(session.account.userId, friend.userId).map { it.startedAtMillis },
             )
         }
     }

--- a/composeApp/src/desktopTest/kotlin/storage/FriendActivityRoomStoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/storage/FriendActivityRoomStoreTest.kt
@@ -10,15 +10,20 @@ import io.github.vrcmteam.vrcm.service.FriendActivityBatch
 import io.github.vrcmteam.vrcm.service.FriendActivityEventType
 import io.github.vrcmteam.vrcm.service.FriendActivityInputSnapshot
 import io.github.vrcmteam.vrcm.service.FriendActivityObservation
+import io.github.vrcmteam.vrcm.service.FriendActivityTrackingControl
 import io.github.vrcmteam.vrcm.service.FriendMeetingChange
 import io.github.vrcmteam.vrcm.service.data.AccountDto
 import io.github.vrcmteam.vrcm.service.trackFriendActivity
 import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardAssetStore
 import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardConfigDao
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
@@ -28,7 +33,7 @@ import kotlin.test.assertNull
 
 class FriendActivityRoomStoreTest {
     @Test
-    fun restoreDropsIncompleteSessionWithoutAddingDuration() = runTest {
+    fun restoreFinalizesIncompleteSessionAtLastCheckpoint() = runTest {
         withStore { store ->
             val token = store.activateAccount("usr_owner")
             val observation = observation()
@@ -48,13 +53,28 @@ class FriendActivityRoomStoreTest {
                 ),
                 nowMillis = 1_000L,
             )
+            store.record(
+                token = token,
+                observations = listOf(observation),
+                batch = FriendActivityBatch(
+                    meetings = listOf(
+                        FriendMeetingChange.Checkpoint(
+                            userId = observation.userId,
+                            occurredAtMillis = 31_000L,
+                            durationMillis = 30_000L,
+                        )
+                    )
+                ),
+                nowMillis = 31_000L,
+            )
 
             store.discardIncompleteSessions("usr_owner")
 
             assertEquals(emptyList(), store.sessions("usr_owner", observation.userId))
             val summary = store.summary("usr_owner", observation.userId)
             assertEquals(0, summary?.meetingCount)
-            assertEquals(0L, summary?.togetherDurationMillis)
+            assertEquals(30_000L, summary?.togetherDurationMillis)
+            assertEquals(31_000L, summary?.lastSeenTogetherAtMillis)
         }
     }
 
@@ -79,6 +99,22 @@ class FriendActivityRoomStoreTest {
                 ),
                 nowMillis = 1_000L,
             )
+            assertNull(store.summary("usr_owner", observation.userId)?.lastSeenTogetherAtMillis)
+            store.record(
+                token = token,
+                observations = listOf(observation),
+                batch = FriendActivityBatch(
+                    meetings = listOf(
+                        FriendMeetingChange.Checkpoint(
+                            userId = observation.userId,
+                            occurredAtMillis = 31_000L,
+                            durationMillis = 30_000L,
+                        )
+                    )
+                ),
+                nowMillis = 31_000L,
+            )
+            assertNull(store.summary("usr_owner", observation.userId)?.lastSeenTogetherAtMillis)
             store.record(
                 token = token,
                 observations = listOf(observation),
@@ -177,6 +213,20 @@ class FriendActivityRoomStoreTest {
             )
             store.record(
                 token = token,
+                observations = listOf(older),
+                batch = FriendActivityBatch(
+                    meetings = listOf(
+                        FriendMeetingChange.Ended(
+                            userId = older.userId,
+                            occurredAtMillis = 1_500L,
+                            durationMillis = 500L,
+                        )
+                    )
+                ),
+                nowMillis = 1_500L,
+            )
+            store.record(
+                token = token,
                 observations = listOf(newer),
                 batch = FriendActivityBatch(
                     meetings = listOf(
@@ -190,6 +240,20 @@ class FriendActivityRoomStoreTest {
                     )
                 ),
                 nowMillis = 3_000L,
+            )
+            store.record(
+                token = token,
+                observations = listOf(newer),
+                batch = FriendActivityBatch(
+                    meetings = listOf(
+                        FriendMeetingChange.Ended(
+                            userId = newer.userId,
+                            occurredAtMillis = 3_500L,
+                            durationMillis = 500L,
+                        )
+                    )
+                ),
+                nowMillis = 3_500L,
             )
 
             val recent = store.observeRecentTogether(
@@ -233,15 +297,146 @@ class FriendActivityRoomStoreTest {
                         selfLocation = "wrld_world:instance_a",
                         observedAtMillis = 2_000L,
                     ),
+                    FriendActivityInputSnapshot(
+                        token = session.token,
+                        friends = listOf(friend.copy(location = "wrld_world:instance_a")),
+                        selfLocation = "wrld_world:instance_a",
+                        observedAtMillis = 3_000L,
+                        trackingControl = FriendActivityTrackingControl.Stop,
+                    ),
                 ),
                 store = store,
             )
 
             assertNull(store.summary("usr_owner", "usr_wrong"))
             assertEquals(
-                2_000L,
+                3_000L,
                 store.summary("usr_owner", friend.userId)?.lastSeenTogetherAtMillis,
             )
+        }
+    }
+
+    @Test
+    fun stoppedCollectorDoesNotRestartUntilResume() = runTest {
+        withStore { store ->
+            val session = AuthenticatedAccount(
+                account = AccountDto(userId = "usr_owner"),
+                token = AccountSessionToken(userId = "usr_owner", generation = 1L),
+            )
+            val friend = observation().copy(location = "wrld_world:instance_a")
+
+            trackFriendActivity(
+                session = session,
+                snapshots = flowOf(
+                    FriendActivityInputSnapshot(session.token, listOf(friend), friend.location, 1_000L),
+                    FriendActivityInputSnapshot(
+                        session.token,
+                        listOf(friend),
+                        friend.location,
+                        2_000L,
+                        trackingControl = FriendActivityTrackingControl.Stop,
+                    ),
+                    FriendActivityInputSnapshot(session.token, listOf(friend), friend.location, 3_000L),
+                    FriendActivityInputSnapshot(session.token, listOf(friend), friend.location, 4_000L),
+                    FriendActivityInputSnapshot(
+                        session.token,
+                        listOf(friend),
+                        friend.location,
+                        5_000L,
+                        trackingControl = FriendActivityTrackingControl.Resume,
+                    ),
+                    FriendActivityInputSnapshot(session.token, listOf(friend), friend.location, 6_000L),
+                    FriendActivityInputSnapshot(
+                        session.token,
+                        listOf(friend),
+                        friend.location,
+                        7_000L,
+                        trackingControl = FriendActivityTrackingControl.Stop,
+                    ),
+                ),
+                store = store,
+            )
+
+            val summary = store.summary("usr_owner", friend.userId)
+            assertEquals(3_000L, summary?.togetherDurationMillis)
+            assertEquals(7_000L, summary?.lastSeenTogetherAtMillis)
+            assertEquals(0, summary?.meetingCount)
+            assertEquals(
+                listOf(5_000L, 1_000L),
+                store.sessions("usr_owner", friend.userId).map { it.startedAtMillis },
+            )
+        }
+    }
+
+    @Test
+    fun cancellingCollectorCompletesActiveMeetingAtCancellationTime() = runTest {
+        withStore { store ->
+            val session = AuthenticatedAccount(
+                account = AccountDto(userId = "usr_owner"),
+                token = AccountSessionToken(userId = "usr_owner", generation = 1L),
+            )
+            val friend = observation().copy(location = "wrld_world:instance_a")
+            val baselineRecorded = CompletableDeferred<Unit>()
+
+            val collector = launch {
+                trackFriendActivity(
+                    session = session,
+                    snapshots = flow {
+                        emit(FriendActivityInputSnapshot(session.token, listOf(friend), friend.location, 1_000L))
+                        baselineRecorded.complete(Unit)
+                        awaitCancellation()
+                    },
+                    store = store,
+                    cancellationTimeMillis = { 5_000L },
+                )
+            }
+            baselineRecorded.await()
+            collector.cancelAndJoin()
+
+            val summary = store.summary("usr_owner", friend.userId)
+            assertEquals(4_000L, summary?.togetherDurationMillis)
+            assertEquals(5_000L, summary?.lastSeenTogetherAtMillis)
+            assertEquals(5_000L, store.sessions("usr_owner", friend.userId).single().endedAtMillis)
+        }
+    }
+
+    @Test
+    fun onlyApiRefreshSnapshotUpdatesLastActivity() = runTest {
+        withStore { store ->
+            val session = AuthenticatedAccount(
+                account = AccountDto(userId = "usr_owner"),
+                token = AccountSessionToken(userId = "usr_owner", generation = 1L),
+            )
+            val friend = observation().copy(location = "offline", status = "offline")
+
+            trackFriendActivity(
+                session = session,
+                snapshots = flowOf(
+                    FriendActivityInputSnapshot(
+                        session.token,
+                        listOf(friend.copy(lastActivityAtMillis = 900L)),
+                        null,
+                        1_000L,
+                        updateLastActivityOnly = true,
+                    ),
+                    FriendActivityInputSnapshot(
+                        session.token,
+                        listOf(friend.copy(lastActivityAtMillis = 1_900L)),
+                        null,
+                        2_000L,
+                    ),
+                    FriendActivityInputSnapshot(
+                        session.token,
+                        listOf(friend.copy(lastActivityAtMillis = 800L)),
+                        null,
+                        3_000L,
+                        updateLastActivityOnly = true,
+                    ),
+                ),
+                store = store,
+            )
+
+            assertEquals(900L, store.summary("usr_owner", friend.userId)?.lastActivityAtMillis)
         }
     }
 

--- a/composeApp/src/desktopTest/kotlin/storage/FriendActivityRoomStoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/storage/FriendActivityRoomStoreTest.kt
@@ -407,6 +407,44 @@ class FriendActivityRoomStoreTest {
     }
 
     @Test
+    fun firstKnownSelfLocationStartsUnannouncedMeeting() = runTest {
+        withStore { store ->
+            val session = AuthenticatedAccount(
+                account = AccountDto(userId = "usr_owner"),
+                token = AccountSessionToken(userId = "usr_owner", generation = 1L),
+            )
+            val friend = observation().copy(location = "wrld_world:instance_a")
+
+            trackFriendActivity(
+                session = session,
+                snapshots = flowOf(
+                    FriendActivityInputSnapshot(session.token, listOf(friend), null, 1_000L),
+                    FriendActivityInputSnapshot(session.token, listOf(friend), friend.location, 2_000L),
+                    FriendActivityInputSnapshot(
+                        session.token,
+                        listOf(friend),
+                        friend.location,
+                        3_000L,
+                        trackingControl = FriendActivityTrackingControl.Stop,
+                    ),
+                ),
+                store = store,
+            )
+
+            val summary = store.summary(session.account.userId, friend.userId)
+            assertEquals(0, summary?.meetingCount)
+            assertEquals(
+                emptyList(),
+                store.observeEvents(session.account.userId, friend.userId).first().map { it.type },
+            )
+            assertEquals(
+                listOf(false),
+                store.sessions(session.account.userId, friend.userId).map { it.announced },
+            )
+        }
+    }
+
+    @Test
     fun replayedResumeStartsTrackingAtCollectorSubscriptionTime() = runTest {
         withStore { store ->
             val session = AuthenticatedAccount(

--- a/composeApp/src/desktopTest/kotlin/storage/FriendActivityRoomStoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/storage/FriendActivityRoomStoreTest.kt
@@ -414,18 +414,18 @@ class FriendActivityRoomStoreTest {
                 token = AccountSessionToken(userId = "usr_owner", generation = 1L),
             )
             val friend = observation().copy(location = "wrld_world:instance_a")
-            val trackingState = FriendActivityTrackingState()
+            val trackingState = FriendActivityTrackingState { 1_000L }
             trackingState.setBackgroundMonitoring(true)
 
             trackFriendActivity(
                 session = session,
-                snapshots = trackingState.controls.take(1).map { control ->
+                snapshots = trackingState.controls.take(1).map { transition ->
                     FriendActivityInputSnapshot(
                         token = session.token,
                         friends = listOf(friend),
                         selfLocation = friend.location,
-                        observedAtMillis = 1_000L,
-                        trackingControl = control,
+                        observedAtMillis = transition.occurredAtMillis,
+                        trackingControl = transition.control,
                     )
                 },
                 store = store,
@@ -435,6 +435,70 @@ class FriendActivityRoomStoreTest {
                 listOf(1_000L),
                 store.sessions(session.account.userId, friend.userId).map { it.startedAtMillis },
             )
+        }
+    }
+
+    @Test
+    fun trackingTransitionsRetainOccurredTimesWhileCollectorIsBusy() = runTest {
+        withStore { store ->
+            val session = AuthenticatedAccount(
+                account = AccountDto(userId = "usr_owner"),
+                token = AccountSessionToken(userId = "usr_owner", generation = 1L),
+            )
+            val friend = observation().copy(location = "wrld_world:instance_a")
+            val baselineRecorded = CompletableDeferred<Unit>()
+            val stopDequeued = CompletableDeferred<Unit>()
+            val releaseStop = CompletableDeferred<Unit>()
+            var nowMillis = 0L
+            val trackingState = FriendActivityTrackingState { nowMillis }
+
+            nowMillis = 1_000L
+            trackingState.setAppForeground(true)
+            val collector = launch {
+                trackFriendActivity(
+                    session = session,
+                    snapshots = flow {
+                        trackingState.controls.take(4).collect { transition ->
+                            if (transition.sequence == 2L) {
+                                stopDequeued.complete(Unit)
+                                releaseStop.await()
+                            }
+                            emit(
+                                FriendActivityInputSnapshot(
+                                    token = session.token,
+                                    friends = listOf(friend),
+                                    selfLocation = friend.location,
+                                    observedAtMillis = transition.occurredAtMillis,
+                                    trackingControl = transition.control,
+                                )
+                            )
+                            if (transition.sequence == 1L) {
+                                baselineRecorded.complete(Unit)
+                            }
+                        }
+                    },
+                    store = store,
+                )
+            }
+
+            baselineRecorded.await()
+            nowMillis = 2_000L
+            trackingState.setAppForeground(false)
+            stopDequeued.await()
+            nowMillis = 5_000L
+            trackingState.setAppForeground(true)
+            nowMillis = 7_000L
+            trackingState.setAppForeground(false)
+            releaseStop.complete(Unit)
+            collector.join()
+
+            val sessions = store.sessions(session.account.userId, friend.userId)
+            assertEquals(
+                3_000L,
+                store.summary(session.account.userId, friend.userId)?.togetherDurationMillis,
+            )
+            assertEquals(listOf(5_000L, 1_000L), sessions.map { it.startedAtMillis })
+            assertEquals(listOf(7_000L, 2_000L), sessions.map { it.endedAtMillis })
         }
     }
 

--- a/composeApp/src/desktopTest/kotlin/storage/FriendActivityRoomStoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/storage/FriendActivityRoomStoreTest.kt
@@ -407,15 +407,17 @@ class FriendActivityRoomStoreTest {
     }
 
     @Test
-    fun resumeBeforeCollectorSubscriptionIsReplayedAndStartsTracking() = runTest {
+    fun replayedResumeStartsTrackingAtCollectorSubscriptionTime() = runTest {
         withStore { store ->
             val session = AuthenticatedAccount(
                 account = AccountDto(userId = "usr_owner"),
                 token = AccountSessionToken(userId = "usr_owner", generation = 1L),
             )
             val friend = observation().copy(location = "wrld_world:instance_a")
-            val trackingState = FriendActivityTrackingState { 1_000L }
+            var nowMillis = 1_000L
+            val trackingState = FriendActivityTrackingState { nowMillis }
             trackingState.setBackgroundMonitoring(true)
+            nowMillis = 5_000L
 
             trackFriendActivity(
                 session = session,
@@ -432,7 +434,7 @@ class FriendActivityRoomStoreTest {
             )
 
             assertEquals(
-                listOf(1_000L),
+                listOf(5_000L),
                 store.sessions(session.account.userId, friend.userId).map { it.startedAtMillis },
             )
         }

--- a/composeApp/src/desktopTest/kotlin/storage/FriendActivityRoomStoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/storage/FriendActivityRoomStoreTest.kt
@@ -10,9 +10,13 @@ import io.github.vrcmteam.vrcm.service.FriendActivityBatch
 import io.github.vrcmteam.vrcm.service.FriendActivityEventType
 import io.github.vrcmteam.vrcm.service.FriendActivityInputSnapshot
 import io.github.vrcmteam.vrcm.service.FriendActivityObservation
+import io.github.vrcmteam.vrcm.service.FriendActivitySourceSnapshot
 import io.github.vrcmteam.vrcm.service.FriendActivityTrackingControl
+import io.github.vrcmteam.vrcm.service.FriendSocketPresenceEvent
+import io.github.vrcmteam.vrcm.service.FriendSocketPresenceType
 import io.github.vrcmteam.vrcm.service.FriendMeetingChange
 import io.github.vrcmteam.vrcm.service.data.AccountDto
+import io.github.vrcmteam.vrcm.service.toSocketPresenceInputSnapshot
 import io.github.vrcmteam.vrcm.service.trackFriendActivity
 import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardAssetStore
 import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardConfigDao
@@ -313,6 +317,37 @@ class FriendActivityRoomStoreTest {
                 3_000L,
                 store.summary("usr_owner", friend.userId)?.lastSeenTogetherAtMillis,
             )
+        }
+    }
+
+    @Test
+    fun delayedSocketPresenceFromPreviousSessionIsRejectedAfterAccountSwitch() = runTest {
+        withStore { store ->
+            val currentSession = AuthenticatedAccount(
+                account = AccountDto(userId = "usr_current_owner"),
+                token = AccountSessionToken(userId = "usr_current_owner", generation = 2L),
+            )
+            val previousToken = AccountSessionToken(userId = "usr_previous_owner", generation = 1L)
+            val delayedInput = FriendActivitySourceSnapshot(
+                token = currentSession.token,
+                friends = emptyList(),
+                selfLocation = null,
+            ).toSocketPresenceInputSnapshot(
+                eventToken = previousToken,
+                presenceEvent = FriendSocketPresenceEvent(
+                    userId = "usr_previous_friend",
+                    type = FriendSocketPresenceType.Offline,
+                    occurredAtMillis = 1_000L,
+                ),
+            )
+
+            trackFriendActivity(
+                session = currentSession,
+                snapshots = flowOf(delayedInput),
+                store = store,
+            )
+
+            assertNull(store.summary(currentSession.account.userId, "usr_previous_friend"))
         }
     }
 

--- a/composeApp/src/desktopTest/kotlin/storage/FriendActivityRoomStoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/storage/FriendActivityRoomStoreTest.kt
@@ -532,47 +532,53 @@ class FriendActivityRoomStoreTest {
             val summary = store.summary("usr_owner", friend.userId)
             assertEquals(4_000L, summary?.togetherDurationMillis)
             assertEquals(5_000L, summary?.lastSeenTogetherAtMillis)
+            assertEquals(5_000L, summary?.lastActivityAtMillis)
             assertEquals(5_000L, store.sessions("usr_owner", friend.userId).single().endedAtMillis)
         }
     }
 
     @Test
-    fun onlyApiRefreshSnapshotUpdatesLastActivity() = runTest {
+    fun onlineSnapshotsAdvanceLastActivityAndOfflineSnapshotUsesApiTime() = runTest {
         withStore { store ->
             val session = AuthenticatedAccount(
                 account = AccountDto(userId = "usr_owner"),
                 token = AccountSessionToken(userId = "usr_owner", generation = 1L),
             )
-            val friend = observation().copy(location = "offline", status = "offline")
+            val friend = observation().copy(lastActivityAtMillis = null)
 
             trackFriendActivity(
                 session = session,
-                snapshots = flowOf(
-                    FriendActivityInputSnapshot(
-                        session.token,
-                        listOf(friend.copy(lastActivityAtMillis = 900L)),
-                        null,
+                snapshots = flow {
+                    emit(FriendActivityInputSnapshot(session.token, listOf(friend), null, 1_000L))
+                    assertEquals(
                         1_000L,
-                        updateLastActivityOnly = true,
-                    ),
-                    FriendActivityInputSnapshot(
-                        session.token,
-                        listOf(friend.copy(lastActivityAtMillis = 1_900L)),
-                        null,
+                        store.summary(session.account.userId, friend.userId)?.lastActivityAtMillis,
+                    )
+                    emit(FriendActivityInputSnapshot(session.token, listOf(friend), null, 2_000L))
+                    assertEquals(
                         2_000L,
-                    ),
-                    FriendActivityInputSnapshot(
-                        session.token,
-                        listOf(friend.copy(lastActivityAtMillis = 800L)),
-                        null,
-                        3_000L,
-                        updateLastActivityOnly = true,
-                    ),
-                ),
+                        store.summary(session.account.userId, friend.userId)?.lastActivityAtMillis,
+                    )
+                    emit(
+                        FriendActivityInputSnapshot(
+                            session.token,
+                            listOf(
+                                friend.copy(
+                                    location = "offline",
+                                    status = "offline",
+                                    lastActivityAtMillis = 2_500L,
+                                )
+                            ),
+                            null,
+                            3_000L,
+                            updateLastActivityOnly = true,
+                        )
+                    )
+                },
                 store = store,
             )
 
-            assertEquals(900L, store.summary("usr_owner", friend.userId)?.lastActivityAtMillis)
+            assertEquals(2_500L, store.summary("usr_owner", friend.userId)?.lastActivityAtMillis)
         }
     }
 


### PR DESCRIPTION
用户profile的好友活动的记录逻辑优化，上下线事件只记录socket通知的事件。好友不在线时，最后活动的时间应该从第二页tab的好友列表用的最后活动时间的api获取。共同游玩时长只有在应用运行期间才会产生记录，如果应用被关闭且没有后台监测就应停止记录时长，最后见面的时间以共同游玩时长停止时的时间为准。见面次数以进入了同一个房间的记录次数为准

## 实现假设清单

- 无未经验证的实现假设。
- 已确认边界：好友上下线记录仅由 Socket 通知触发，不根据好友快照推断。
- 已确认边界：离线好友的最后活动时间使用好友列表数据源返回的时间。
- 已确认边界：共同游玩时长只累计应用实际监测到的同房区间；监测停止时结束区间并以该时刻记录最后见面时间。

## 代码逻辑图

```mermaid
flowchart TD
    AppResume["App: 初次组合 / ON_RESUME"] -->|"onAppResumed()"| TrackingState
    AppStop["App: ON_STOP"] -->|"onAppStopped()"| TrackingState
    ServiceStart["FriendActivityForegroundService.onCreate"] -->|"onBackgroundMonitoringStarted()"| TrackingState
    ServiceStop["FriendActivityForegroundService.onDestroy"] -->|"onBackgroundMonitoringStopped()"| TrackingState
    ServiceStart -->|"setBackgroundMonitoringEnabled(true)"| WebSocket["WebSocketApi"]
    ServiceStop -->|"setBackgroundMonitoringEnabled(false)"| WebSocket

    TrackingState["FriendActivityTrackingState<br/>同步聚合来源位图<br/>App 前台 OR 后台监测"] -->|"跨越 enabled 边界<br/>记录 sequence + occurredAtMillis"| CurrentTransition["MutableStateFlow currentTransition<br/>保存最新 Stop / Resume"]
    TrackingState -->|"同一转换原子入队"| TransitionChannel["Channel.UNLIMITED<br/>保留转换时间与发生顺序"]
    CurrentTransition -->|"新 session 订阅时原子读取 sequence / control<br/>以订阅当前时间建立初始化基线"| Controls["controls<br/>先发送当前控制的初始化基线"]
    TransitionChannel -->|"过滤已被快照覆盖的 sequence<br/>后续转换保留源头 occurredAtMillis"| Controls

    Session["SharedFlowCentre.currentSession"] -->|"collectLatest<br/>切号取消旧收集器"| Collector["trackFriendActivity"]
    Session -->|"新账号"| CacheLoad["FriendListCacheStore.load"]
    CacheLoad --> CacheGate{"session 仍匹配<br/>且首次完整刷新未完成?"}
    CacheGate -->|"是"| CacheRestore["FriendStateStore.restore<br/>asCachedOffline 回退数据"]
    CacheGate -->|"否"| DropCache["丢弃迟到缓存"]
    CacheLoad -->|"异常：Logger.warn<br/>CancellationException 继续传播"| CacheError["记录内部诊断并继续刷新"]
    CacheRestore --> InitialRefresh["AccountBoundTask&lt;AccountSessionToken&gt;<br/>preloadFriendList / refreshFriendList()"]
    DropCache --> InitialRefresh
    CacheError --> InitialRefresh
    InitialRefresh --> RefreshSessionCheck{"请求开始与 commitRefresh 前<br/>sessionToken 仍为当前?"}
    RefreshSessionCheck -->|"否"| RejectRefresh["拒绝旧 session 刷新提交"]
    RefreshSessionCheck -->|"是：完整在线 + 离线分页提交<br/>initialRefreshCompleted = true"| ActivitySource["FriendService.friendActivitySource<br/>首次完整好友刷新后发布可信位置快照"]
    ActivitySource --> Merge["merge"]
    LastActivity["FriendService.friendLastActivitySource<br/>离线 API lastActivity"] --> Merge
    SocketUpdate["FriendService.friendUpdateFlow<br/>Online / Offline + sessionToken"] --> SocketInput["toSocketPresenceInputSnapshot"]
    SocketUpdate -->|"FriendOffline"| OfflineRefresh["AccountBoundTask&lt;OfflineLastActivityRefreshRequest&gt;<br/>新事件取消旧刷新并执行最新请求"]
    OfflineRefresh -->|"refreshFriendList(offline=true)"| FriendsApi["FriendsApi<br/>/auth/user/friends?offline=true"]
    FriendsApi --> LastActivity
    SocketInput -->|"source.token == eventToken<br/>复用好友快照"| Merge
    SocketInput -->|"token 不匹配<br/>保留 eventToken + 空好友快照"| Merge
    Checkpoint["15 秒 checkpoint"] --> Merge
    Controls -->|"Room 初始化后订阅仍获得当前状态<br/>后续 Stop / Resume 使用源头发生时间"| Merge
    Merge --> Input["FriendActivityInputSnapshot"]
    Input --> TokenCheck{"snapshot.token == session.token?"}
    TokenCheck -->|"否"| Reject["拒绝输入，不写当前账号"]
    TokenCheck -->|"是"| ActivityPolicy["在线观测：lastActivity = observedAtMillis<br/>离线刷新：lastActivity = API 时间"]
    ActivityPolicy --> Tracker["FriendActivityTracker"]
    ActivityPolicy --> Record["RoomFriendActivityStore.record"]

    Tracker -->|"初始好友快照或本人位置首次已知且已同房<br/>announce=false"| Started["FriendMeetingChange.Started"]
    Tracker -->|"已知本人位置后的新同房转换<br/>announce=true"| Started
    Started -->|"持续同一实例"| Checkpointed["FriendMeetingChange.Checkpoint"]
    Started -->|"离开 / Stop"| Ended["FriendMeetingChange.Ended"]
    Session -->|"旧收集器取消且仍在跟踪<br/>NonCancellable finish"| Ended

    Collector --> Activate["RoomFriendActivityStore.activateAccount"]
    Activate --> Recover["discardIncompleteSessions"]
    Recover -->|"使用最后 checkpoint<br/>更新 lastSeenTogetherAtMillis"| RecoveredSummary["summary"]
    Recover -->|"删除未完成 session"| Cleanup["incomplete sessions"]

    Tracker --> Events["Socket / 位置 / 状态 / Bio 事件"]
    Started --> Record
    Checkpointed --> Record
    Ended --> Record
    Events --> Record
    Record --> Database["Room: summaries / sessions / events"]
```