### PR TITLE
fix(websocket): 后台监测开启时保留实时连接

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <application

--- a/composeApp/src/androidMain/kotlin/presentation/notifications/FriendOnlineNotifications.android.kt
+++ b/composeApp/src/androidMain/kotlin/presentation/notifications/FriendOnlineNotifications.android.kt
@@ -20,11 +20,25 @@ private const val MONITOR_CHANNEL = "friend_activity_monitor"
 class FriendNotificationFactory(private val context: Context) {
     private val manager = context.getSystemService(NotificationManager::class.java)
     init { channels() }
-    fun monitoringNotification(): Notification = builder(MONITOR_CHANNEL, 1)
-        .setContentTitle(context.getString(R.string.friend_monitor_title))
-        .setContentText(context.getString(R.string.friend_monitor_message))
-        .setCategory(Notification.CATEGORY_SERVICE)
-        .setOngoing(true).setOnlyAlertOnce(true).build()
+    fun monitoringNotification(
+        startedAtMillis: Long,
+        restoreIntent: PendingIntent,
+    ): Notification {
+        val builder = builder(MONITOR_CHANNEL, 1)
+            .setContentTitle(context.getString(R.string.friend_monitor_title))
+            .setContentText(context.getString(R.string.friend_monitor_message))
+            .setCategory(Notification.CATEGORY_SERVICE)
+            .setWhen(startedAtMillis)
+            .setShowWhen(true)
+            .setUsesChronometer(true)
+            .setDeleteIntent(restoreIntent)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            builder.setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE)
+        }
+        return builder.build()
+    }
     fun social(id: Int, title: String, message: CharSequence): Notification = builder(SOCIAL_CHANNEL, id)
         .setContentTitle(title).setContentText(message).setStyle(Notification.BigTextStyle().bigText(message))
         .setCategory(Notification.CATEGORY_SOCIAL).setAutoCancel(true).build()

--- a/composeApp/src/androidMain/kotlin/service/BackgroundNetworkWakeLock.kt
+++ b/composeApp/src/androidMain/kotlin/service/BackgroundNetworkWakeLock.kt
@@ -1,0 +1,24 @@
+package io.github.vrcmteam.vrcm.service
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.PowerManager
+
+/** Keeps background monitoring work scheduled for exactly the foreground-service lifetime. */
+@SuppressLint("WakelockTimeout")
+internal class BackgroundNetworkWakeLock(context: Context) : AutoCloseable {
+    private val wakeLock = context.getSystemService(PowerManager::class.java).newWakeLock(
+        PowerManager.PARTIAL_WAKE_LOCK,
+        "${context.packageName}:friend-activity-monitor",
+    ).apply {
+        setReferenceCounted(false)
+        acquire()
+    }
+
+    val isHeld: Boolean
+        get() = wakeLock.isHeld
+
+    override fun close() {
+        if (wakeLock.isHeld) wakeLock.release()
+    }
+}

--- a/composeApp/src/androidMain/kotlin/service/FriendActivityForegroundService.kt
+++ b/composeApp/src/androidMain/kotlin/service/FriendActivityForegroundService.kt
@@ -1,5 +1,6 @@
 package io.github.vrcmteam.vrcm.service
 
+import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
 import android.os.IBinder
@@ -26,10 +27,12 @@ import org.koin.core.context.GlobalContext
 class FriendActivityForegroundService : Service() {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var networkWakeLock: BackgroundNetworkWakeLock? = null
+    private var monitoringStartedAtMillis = 0L
 
     override fun onCreate() {
         super.onCreate()
-        startForeground(MONITOR_ID, FriendNotificationFactory(this).monitoringNotification())
+        monitoringStartedAtMillis = System.currentTimeMillis()
+        showMonitoringNotification()
         networkWakeLock = BackgroundNetworkWakeLock(this)
         val koin = GlobalContext.get()
         koin.get<WebSocketApi>().setBackgroundMonitoringEnabled(true)
@@ -47,7 +50,11 @@ class FriendActivityForegroundService : Service() {
         }
         scope.launch { SharedFlowCentre.logout.collect { stopSelf() } }
     }
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int) = START_STICKY
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_RESTORE_MONITOR_NOTIFICATION) showMonitoringNotification()
+        return START_STICKY
+    }
+
     override fun onDestroy() {
         GlobalContext.getOrNull()?.get<WebSocketApi>()?.setBackgroundMonitoringEnabled(false)
         scope.cancel()
@@ -57,7 +64,27 @@ class FriendActivityForegroundService : Service() {
         super.onDestroy()
     }
     override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun showMonitoringNotification() {
+        val restoreIntent = PendingIntent.getService(
+            this,
+            MONITOR_ID,
+            Intent(this, FriendActivityForegroundService::class.java)
+                .setAction(ACTION_RESTORE_MONITOR_NOTIFICATION),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        startForeground(
+            MONITOR_ID,
+            FriendNotificationFactory(this).monitoringNotification(
+                startedAtMillis = monitoringStartedAtMillis,
+                restoreIntent = restoreIntent,
+            ),
+        )
+    }
+
     private companion object {
+        const val ACTION_RESTORE_MONITOR_NOTIFICATION =
+            "io.github.vrcmteam.vrcm.action.RESTORE_MONITOR_NOTIFICATION"
         const val MONITOR_ID = 0x5652434d
         const val FALLBACK_REFRESH_INTERVAL_MILLIS = 15 * 60 * 1_000L
     }

--- a/composeApp/src/androidMain/kotlin/service/FriendActivityForegroundService.kt
+++ b/composeApp/src/androidMain/kotlin/service/FriendActivityForegroundService.kt
@@ -25,9 +25,12 @@ import org.koin.core.context.GlobalContext
  */
 class FriendActivityForegroundService : Service() {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var networkWakeLock: BackgroundNetworkWakeLock? = null
+
     override fun onCreate() {
         super.onCreate()
         startForeground(MONITOR_ID, FriendNotificationFactory(this).monitoringNotification())
+        networkWakeLock = BackgroundNetworkWakeLock(this)
         val koin = GlobalContext.get()
         koin.get<WebSocketApi>().setBackgroundMonitoringEnabled(true)
         val friendService = koin.get<FriendService>()
@@ -48,6 +51,8 @@ class FriendActivityForegroundService : Service() {
     override fun onDestroy() {
         GlobalContext.getOrNull()?.get<WebSocketApi>()?.setBackgroundMonitoringEnabled(false)
         scope.cancel()
+        networkWakeLock?.close()
+        networkWakeLock = null
         stopForeground(STOP_FOREGROUND_REMOVE)
         super.onDestroy()
     }

--- a/composeApp/src/androidUnitTest/kotlin/service/BackgroundNetworkWakeLockTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/service/BackgroundNetworkWakeLockTest.kt
@@ -1,0 +1,26 @@
+package io.github.vrcmteam.vrcm.service
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [24])
+class BackgroundNetworkWakeLockTest {
+    @Test
+    fun holdsCpuUntilForegroundServiceLeaseCloses() {
+        val wakeLock = BackgroundNetworkWakeLock(RuntimeEnvironment.getApplication())
+        try {
+            assertTrue(wakeLock.isHeld)
+        } finally {
+            wakeLock.close()
+        }
+
+        assertFalse(wakeLock.isHeld)
+        wakeLock.close()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -52,6 +54,7 @@ import io.github.vrcmteam.vrcm.presentation.screens.meetup.MeetupCardEditorRoute
 import io.github.vrcmteam.vrcm.presentation.screens.user.UserProfileScreen
 import io.github.vrcmteam.vrcm.presentation.screens.world.WorldProfileScreen
 import io.github.vrcmteam.vrcm.presentation.screens.home.pager.FriendLocationPagerModel
+import io.github.vrcmteam.vrcm.presentation.settings.LocalSettingsState
 import io.github.vrcmteam.vrcm.presentation.settings.SettingsProvider
 import io.github.vrcmteam.vrcm.network.websocket.WebSocketApi
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.AvatarProfileScreen
@@ -79,19 +82,22 @@ fun App(
         val webSocketApi = koinInject<WebSocketApi>()
         val friendLocationPagerModel = koinInject<FriendLocationPagerModel>()
         koinInject<FriendActivityService>()
-        LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
-            if (lifecycleEventGate.onStop(isConfigurationChange())) {
-                friendLocationPagerModel.onBackground()
-                webSocketApi.onBackground()
-            }
-        }
-        LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
-            if (lifecycleEventGate.onResume()) {
-                webSocketApi.onForeground()
-                friendLocationPagerModel.onForeground()
-            }
-        }
         SettingsProvider {
+            val backgroundMonitoringEnabled by rememberUpdatedState(
+                LocalSettingsState.current.value.backgroundFriendMonitoringEnabled
+            )
+            LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
+                if (lifecycleEventGate.onStop(isConfigurationChange())) {
+                    friendLocationPagerModel.onBackground()
+                    webSocketApi.onBackground(backgroundMonitoringEnabled)
+                }
+            }
+            LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+                if (lifecycleEventGate.onResume()) {
+                    webSocketApi.onForeground()
+                    friendLocationPagerModel.onForeground()
+                }
+            }
             Column(Modifier.fillMaxSize()) {
                 windowChrome()
                 BoxWithConstraints(

--- a/composeApp/src/commonMain/kotlin/network/websocket/WebSocketApi.kt
+++ b/composeApp/src/commonMain/kotlin/network/websocket/WebSocketApi.kt
@@ -81,7 +81,7 @@ class WebSocketApi(
         retryWebSocketConnection(
             maxRetryDelayMillis = MAX_RETRY_DELAY_MILLIS,
             onFailure = ::reportConnectionFailure,
-        ) {
+        ) { markConnected ->
             val authResponse = apiClient.get(AUTH_API_PREFIX)
             check(authResponse.status == HttpStatusCode.OK) {
                 "WebSocket auth failed with HTTP ${authResponse.status.value}"
@@ -95,6 +95,7 @@ class WebSocketApi(
                     parameter("auth", token)
                 }) {
                 connectedSessionToken.value = sessionToken
+                markConnected()
                 try {
                     while (true) {
                         val othersMessage = receiveDeserialized<WebSocketEvent>()
@@ -156,7 +157,7 @@ internal suspend fun retryWebSocketConnection(
     retryDelayMillis: Long = 5_000L,
     maxRetryDelayMillis: Long = retryDelayMillis,
     onFailure: suspend (Exception, consecutiveFailures: Int) -> Unit,
-    connect: suspend () -> Unit,
+    connect: suspend (markConnected: () -> Unit) -> Unit,
 ) {
     require(retryDelayMillis > 0) { "retryDelayMillis must be positive" }
     require(maxRetryDelayMillis >= retryDelayMillis) { "maxRetryDelayMillis must not be lower than retryDelayMillis" }
@@ -164,7 +165,7 @@ internal suspend fun retryWebSocketConnection(
     var consecutiveFailures = 0
     while (currentCoroutineContext().isActive) {
         try {
-            connect()
+            connect { consecutiveFailures = 0 }
             consecutiveFailures = 0
         } catch (e: CancellationException) {
             throw e

--- a/composeApp/src/commonMain/kotlin/network/websocket/WebSocketApi.kt
+++ b/composeApp/src/commonMain/kotlin/network/websocket/WebSocketApi.kt
@@ -27,14 +27,13 @@ class WebSocketApi(
     private var currentJob: Job? = null
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val connectionLock = SynchronizedObject()
-    private val isForeground = atomic(true)
-    private val backgroundMonitoringEnabled = atomic(false)
+    private val connectionPolicy = WebSocketConnectionPolicy()
     private val connectedSessionToken = atomic<AccountSessionToken?>(null)
 
     init {
         scope.launch {
             SharedFlowCentre.authed.collect { session ->
-                if (isForeground.value || backgroundMonitoringEnabled.value) replaceConnection(session.token)
+                if (connectionPolicy.shouldKeepConnection) replaceConnection(session.token)
             }
         }
         scope.launch {
@@ -44,13 +43,13 @@ class WebSocketApi(
         }
     }
 
-    fun onBackground() {
-        isForeground.value = false
-        if (!backgroundMonitoringEnabled.value) replaceConnection(null)
+    fun onBackground(backgroundMonitoringConfigured: Boolean) {
+        connectionPolicy.onBackground(backgroundMonitoringConfigured)
+        if (!connectionPolicy.shouldKeepConnection) replaceConnection(null)
     }
 
     fun onForeground() {
-        if (isForeground.getAndSet(true)) return
+        if (!connectionPolicy.onForeground()) return
         replaceConnection(SharedFlowCentre.currentSession.value?.token)
     }
 
@@ -61,8 +60,13 @@ class WebSocketApi(
     }
 
     fun setBackgroundMonitoringEnabled(enabled: Boolean) {
-        backgroundMonitoringEnabled.value = enabled
-        if (enabled || !isForeground.value) replaceConnection(SharedFlowCentre.currentSession.value?.token.takeIf { enabled || isForeground.value })
+        connectionPolicy.setBackgroundServiceActive(enabled)
+        if (enabled || !connectionPolicy.isForeground) {
+            replaceConnection(
+                SharedFlowCentre.currentSession.value?.token
+                    .takeIf { connectionPolicy.shouldKeepConnection }
+            )
+        }
     }
 
     private fun replaceConnection(sessionToken: AccountSessionToken?) = synchronized(connectionLock) {
@@ -122,6 +126,29 @@ class WebSocketApi(
     private companion object {
         const val USER_NOTICE_INTERVAL = 12
         const val MAX_RETRY_DELAY_MILLIS = 5 * 60 * 1_000L
+    }
+}
+
+internal class WebSocketConnectionPolicy {
+    private val foreground = atomic(true)
+    private val monitoringConfigured = atomic(false)
+    private val backgroundServiceActive = atomic(false)
+
+    val isForeground: Boolean
+        get() = foreground.value
+
+    val shouldKeepConnection: Boolean
+        get() = foreground.value || monitoringConfigured.value || backgroundServiceActive.value
+
+    fun onBackground(isMonitoringConfigured: Boolean) {
+        monitoringConfigured.value = isMonitoringConfigured
+        foreground.value = false
+    }
+
+    fun onForeground(): Boolean = !foreground.getAndSet(true)
+
+    fun setBackgroundServiceActive(active: Boolean) {
+        backgroundServiceActive.value = active
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/network/websocket/WebSocketConnectionPolicyTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/websocket/WebSocketConnectionPolicyTest.kt
@@ -1,0 +1,34 @@
+package io.github.vrcmteam.vrcm.network.websocket
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WebSocketConnectionPolicyTest {
+    @Test
+    fun configuredMonitoringKeepsConnectionBeforeServiceStartCompletes() {
+        val policy = WebSocketConnectionPolicy()
+
+        policy.onBackground(isMonitoringConfigured = true)
+
+        assertTrue(policy.shouldKeepConnection)
+    }
+
+    @Test
+    fun backgroundConnectionStopsOnlyWhenMonitoringIsNeitherConfiguredNorActive() {
+        val policy = WebSocketConnectionPolicy()
+
+        policy.onBackground(isMonitoringConfigured = false)
+        assertFalse(policy.shouldKeepConnection)
+
+        policy.setBackgroundServiceActive(true)
+        assertTrue(policy.shouldKeepConnection)
+
+        policy.setBackgroundServiceActive(false)
+        assertFalse(policy.shouldKeepConnection)
+
+        assertTrue(policy.onForeground())
+        assertTrue(policy.shouldKeepConnection)
+        assertFalse(policy.onForeground())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/network/websocket/WebSocketRetryTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/websocket/WebSocketRetryTest.kt
@@ -22,7 +22,7 @@ class WebSocketRetryTest {
                 onFailure = { error, consecutiveFailures ->
                     failures += consecutiveFailures to error.message
                 },
-                connect = {
+                connect = { _ ->
                     attempts++
                     if (attempts == 1) error("network changed")
                     awaitCancellation()
@@ -49,7 +49,7 @@ class WebSocketRetryTest {
             retryWebSocketConnection(
                 retryDelayMillis = 100,
                 onFailure = { _, _ -> },
-                connect = {
+                connect = { _ ->
                     attempts++
                     // The first call returns normally, which resets the failure counter.
                     if (attempts >= 2) awaitCancellation()
@@ -62,6 +62,51 @@ class WebSocketRetryTest {
         advanceTimeBy(100)
         runCurrent()
         assertEquals(2, attempts)
+
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun establishedConnectionResetsFailuresBeforeItLaterDisconnects() = runTest {
+        var attempts = 0
+        val failures = mutableListOf<Pair<Int, String?>>()
+        val job = launch {
+            retryWebSocketConnection(
+                retryDelayMillis = 100,
+                maxRetryDelayMillis = 800,
+                onFailure = { error, consecutiveFailures ->
+                    failures += consecutiveFailures to error.message
+                },
+                connect = { markConnected ->
+                    attempts++
+                    when (attempts) {
+                        1 -> error("initial failure")
+                        2 -> {
+                            markConnected()
+                            error("dropped after handshake")
+                        }
+                        else -> awaitCancellation()
+                    }
+                },
+            )
+        }
+
+        runCurrent()
+        assertEquals(listOf<Pair<Int, String?>>(1 to "initial failure"), failures)
+
+        advanceTimeBy(100)
+        runCurrent()
+        assertEquals(
+            listOf<Pair<Int, String?>>(
+                1 to "initial failure",
+                1 to "dropped after handshake",
+            ),
+            failures,
+        )
+
+        advanceTimeBy(100)
+        runCurrent()
+        assertEquals(3, attempts, "a dropped established connection must use the base retry delay")
 
         job.cancelAndJoin()
     }


### PR DESCRIPTION
关联 #56

## 实现思路
应用进入后台时，直接读取用户当前看到的“后台监测”开关状态，并把它与 Android 前台监测服务的运行状态共同交给实时连接策略判断。这样即使前台服务仍在异步启动，只要用户已经开启后台监测，应用也不会先主动关闭连接。

Android 前台监测服务在自身生命周期内持有部分唤醒锁，并通过 ongoing 通知证明服务正在运行。通知使用系统计时器实时展示本次运行时长；Android 12 及以上请求立即显示。如果厂商系统允许移除 ongoing 通知，删除回调会重新调用同一服务并发布通知；服务被系统重建时，现有 START_STICKY 路径也会重新发布。

WebSocket 未完成握手的连续失败继续指数退避；一旦连接完成握手，连续失败次数立即清零。之后这条已建立的长连接再断开时，会从基础 5 秒间隔开始重连，不会继承数小时前的失败次数逐步等待到 5 分钟。

## 验收自查
- [x] Android 开启后台监测后切到后台，不再由应用生命周期主动断开好友实时连接。验证：状态转换测试覆盖“开关已开启、前台服务尚未确认启动”的竞态。
- [x] 后台监测服务运行时保持 CPU 调度。验证：前台服务持有部分唤醒锁，Android 平台测试确认租约期间持有、关闭后释放。
- [x] 通知栏能看到后台监测持续运行时间。验证：前台服务通知设置启动时间和系统 chronometer，并在 Android 12 及以上请求立即展示。
- [x] 厂商系统允许移除监测通知时会重新发布。验证：通知删除回调携带恢复 action 回到现有服务，onStartCommand 重新调用 startForeground；服务重建则由 onCreate 发布。
- [x] 已建立的连接后来断开时及时重连。验证：新增测试确认握手成功后失败序号重新从 1 开始，并在基础退避时间触发下一次连接。
- [x] 完全无法建连时仍保留指数退避，避免永久高频请求。验证：原有连续失败测试保持通过。
- [x] 退出登录或关闭后台监测后不为后台状态保留连接、通知或唤醒锁。验证：登出仍停止前台服务；服务 onDestroy 对称清理连接、唤醒锁和前台通知。

## 自测结果
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests io.github.vrcmteam.vrcm.network.websocket.WebSocketRetryTest`：首次因新增断言的 nullable 泛型推断失败，显式标注类型后原样重跑，`BUILD SUCCESSFUL`。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:testDebugUnitTest :composeApp:assembleDebug`：`BUILD SUCCESSFUL`。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:assembleDebug`：`BUILD SUCCESSFUL`，验证前台服务通知 API。
- 完整 `:composeApp:desktopTest`：643 项中 642 项通过；唯一失败是无图形环境下既有的 `DesktopWindowTitleBarLocaleTest` 抛出 `HeadlessException`，与本 PR 改动无关。
- `~/ai/bin/check-gate.sh fix-review 57`：`quality gate: pass`。
- `git diff --check`：通过。
- 真机入口检查：仓库返回 `device_test is not enabled for vrcm-team_VRCM`，因此本环境仍无法完成鸿蒙 4.2 真机复测。

## 自评风险点
- 部分唤醒锁会增加耗电，但只在用户显式开启后台监测且前台服务实际存活时持有；关闭开关或退出登录后立即释放。
- ongoing 通知在标准 Android 上通常不可侧滑删除；恢复回调主要覆盖允许删除此类通知的厂商实现。用户通过系统任务管理器明确停止应用时不会绕过该决定。
- 自动化测试能确认应用生命周期、服务资源租约、通知构建路径和重连策略，但鸿蒙 4.2 的通知删除行为及厂商后台限制仍需提出人在原设备上验证。
- 用户强制停止应用、系统终止进程或设备完全断网不属于本次可保证的保活范围。

## 代码逻辑图
```mermaid
flowchart TD
    Stop["App LifecycleEventEffect: ON_STOP"] --> Setting["LocalSettingsState.backgroundFriendMonitoringEnabled"]
    Setting --> Policy["WebSocketConnectionPolicy.onBackground"]
    Policy --> Keep{"设置已开启或后台服务运行?"}
    Keep -->|"是"| Socket["WebSocketApi 保留连接"]
    Keep -->|"否"| Disconnect["WebSocketApi 取消连接"]

    ServiceStart["FriendActivityForegroundService.onCreate"] --> Notify["FriendNotificationFactory.monitoringNotification"]
    Notify --> Chronometer["系统 chronometer 显示持续时间"]
    Notify --> Immediate["Android 12+: FOREGROUND_SERVICE_IMMEDIATE"]
    Notify --> Foreground["startForeground"]
    Foreground --> Acquire["BackgroundNetworkWakeLock acquire"]
    Acquire --> ServiceActive["WebSocketApi.setBackgroundMonitoringEnabled true"]
    ServiceActive --> Socket

    NotificationDeleted["厂商系统移除 ongoing 通知"] --> DeleteIntent["PendingIntent: RESTORE_MONITOR_NOTIFICATION"]
    DeleteIntent --> StartCommand["FriendActivityForegroundService.onStartCommand"]
    StartCommand --> Notify

    Socket --> Handshake["Ktor WebSocket 握手成功"]
    Handshake --> Reset["retryWebSocketConnection 清零连续失败"]
    Reset --> Receive["接收好友实时事件"]
    Receive --> Failure["连接异常断开"]
    Failure --> FailureOne["按第 1 次失败计算基础 5 秒退避"]
    FailureOne --> Socket
    Socket --> PreHandshakeFailure["握手前失败"]
    PreHandshakeFailure --> Backoff["连续失败指数退避"]
    Backoff --> Socket

    ServiceStop["FriendActivityForegroundService.onDestroy"] --> ServiceInactive["WebSocketApi.setBackgroundMonitoringEnabled false"]
    ServiceStop --> Release["BackgroundNetworkWakeLock.close"]
    ServiceStop --> Remove["stopForeground 移除通知"]
    Logout["SharedFlowCentre.logout"] --> ServiceStop
    Logout --> Disconnect
```

## 实现假设清单
本次无未经验证假设。开关状态来自现有界面单一数据源；前台服务、系统 chronometer、通知删除回调和部分唤醒锁均使用 Android 平台 API；连接握手点来自 Ktor WebSocket 会话块实际进入的位置。退避重置行为由定向测试覆盖。

## 实现说明(供追问)

### 关键决策
把用户当前的后台监测设置与前台服务运行状态作为两个独立依据，消除服务异步启动时的误断窗口。使用系统 chronometer 展示运行时间，不启动每秒更新通知的额外任务。通知恢复通过系统 deleteIntent 回到同一服务，不增加常驻轮询。

重连方面没有取消指数退避；只把“连接成功”的判断提前到 WebSocket 握手完成。这样无网络时仍节制请求，而曾经成功建立的连接后来断开时能快速恢复。

### 覆盖的场景
覆盖已开启监测后立即切后台、服务随后才启动、通知实时显示运行时长、厂商允许删除通知后恢复、服务 START_STICKY 重建、设备休眠期间继续调度、握手失败连续退避、已建立连接断开后从基础间隔重连、关闭监测和退出登录。

### 明确未覆盖
不处理用户通过系统任务管理器明确停止应用、系统杀死进程、完全断网以及厂商系统无视前台服务、唤醒锁和电池设置继续限制网络的情况。鸿蒙 4.2 原设备上的系统级表现因仓库未开放真机入口，留待人工验证。

### 关键假设
无。