### PR TITLE
fix(update): 保留本次运行的公告忽略状态

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/screens/auth/StartupAnimeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/auth/StartupAnimeScreen.kt
@@ -89,6 +89,7 @@ fun VersionDialog() {
     UpdateDialog(
         version = version,
         onDismissRequest = {
+            versionService.dismissVersionForSession(version.tagName)
             version = VersionVo()
         },
         onRememberVersion = versionService::rememberVersion

--- a/composeApp/src/commonMain/kotlin/service/VersionService.kt
+++ b/composeApp/src/commonMain/kotlin/service/VersionService.kt
@@ -4,11 +4,13 @@ import io.github.vrcmteam.vrcm.core.shared.AppConst
 import io.github.vrcmteam.vrcm.network.api.github.GitHubApi
 import io.github.vrcmteam.vrcm.service.data.VersionDto
 import io.github.vrcmteam.vrcm.storage.SettingsDao
+import kotlinx.atomicfu.atomic
 
 class VersionService(
     private val gitHubApi: GitHubApi,
     private val settingsDao: SettingsDao,
 ) {
+    private val dismissedVersion = atomic<String?>(null)
 
     /**
      * 获取最新的版本号,和版本链接
@@ -22,9 +24,11 @@ class VersionService(
                     val releaseData = it.getOrNull()!!
                     val tagName = releaseData.tagName
                     val downloadUrl = releaseData.assets.map { asset -> asset.browserDownloadUrl }
-                    if (AppConst.APP_VERSION == tagName
-                        || (checkRemember && settingsDao.rememberVersion == tagName)
-                    ) {
+                    val isIgnored = checkRemember && (
+                        settingsDao.rememberVersion == tagName
+                            || dismissedVersion.value == tagName
+                    )
+                    if (AppConst.APP_VERSION == tagName || isIgnored) {
                         // 当前版本是最新版本
                         Result.success(VersionDto(tagName, releaseData.htmlUrl, releaseData.body, false,downloadUrl))
                     } else {
@@ -39,6 +43,12 @@ class VersionService(
 
     fun rememberVersion(version: String?) {
         settingsDao.rememberVersion = version
+    }
+
+    fun dismissVersionForSession(version: String) {
+        if (version.isNotEmpty()) {
+            dismissedVersion.value = version
+        }
     }
 
 }

--- a/composeApp/src/commonTest/kotlin/service/VersionServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/VersionServiceTest.kt
@@ -1,0 +1,98 @@
+package io.github.vrcmteam.vrcm.service
+
+import com.russhwolf.settings.MapSettings
+import io.github.vrcmteam.vrcm.network.api.github.GitHubApi
+import io.github.vrcmteam.vrcm.storage.SettingsDao
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class VersionServiceTest {
+    @Test
+    fun dismissedStartupVersionStaysHiddenOnlyForCurrentSession() = runTest {
+        val client = HttpClient(MockEngine) {
+            engine {
+                repeat(3) {
+                    addHandler {
+                        respond(
+                            content = releaseJson,
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                        )
+                    }
+                }
+            }
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+        val settingsDao = SettingsDao(MapSettings())
+        val service = VersionService(GitHubApi(client), settingsDao)
+
+        try {
+            assertTrue(service.checkVersion(checkRemember = true).getOrThrow().hasNewVersion)
+
+            service.dismissVersionForSession(RELEASE_TAG)
+
+            assertFalse(service.checkVersion(checkRemember = true).getOrThrow().hasNewVersion)
+            assertTrue(service.checkVersion(checkRemember = false).getOrThrow().hasNewVersion)
+            assertNull(settingsDao.rememberVersion)
+        } finally {
+            client.close()
+        }
+    }
+
+    private companion object {
+        const val RELEASE_TAG = "v99.0.0"
+        val releaseJson = """{
+            "assets": [],
+            "assets_url": "https://example.com/assets",
+            "author": {
+                "avatar_url": "",
+                "events_url": "",
+                "followers_url": "",
+                "following_url": "",
+                "gists_url": "",
+                "gravatar_id": "",
+                "html_url": "",
+                "id": 1,
+                "login": "tester",
+                "node_id": "author",
+                "organizations_url": "",
+                "received_events_url": "",
+                "repos_url": "",
+                "site_admin": false,
+                "starred_url": "",
+                "subscriptions_url": "",
+                "type": "User",
+                "url": ""
+            },
+            "body": "Release notes",
+            "created_at": "2026-08-11T00:00:00Z",
+            "draft": false,
+            "html_url": "https://example.com/release",
+            "id": 1,
+            "name": "Release",
+            "node_id": "release",
+            "prerelease": false,
+            "published_at": "2026-08-11T00:00:00Z",
+            "tag_name": "$RELEASE_TAG",
+            "tarball_url": "",
+            "target_commitish": "main",
+            "upload_url": "",
+            "zipball_url": "",
+            "url": ""
+        }"""
+    }
+}


### PR DESCRIPTION
关联 #58

## 实现思路

启动公告被关闭时，记录当前版本在本次应用运行中已经忽略。屏幕旋转虽然会重建页面并重新检查版本，但同一应用运行中的忽略记录仍然存在，因此不会再次显示；设置页的手动检查继续忽略这条临时记录，用户仍可主动查看更新。

## 验收标准自查

- [x] 正常启动发现新版本时仍显示更新公告。验证：`VersionServiceTest` 首次自动检查确认仍返回有新版本。
- [x] 点击“忽略”后，从竖屏切换到横屏不再弹出公告。验证：回归测试在关闭后再次执行启动检查，确认同一运行期间不再返回需要展示的更新。
- [x] 再从横屏切回竖屏仍不重复弹出。验证：忽略状态由应用运行期间的单一状态持有，不依赖当前页面或方向；设置页手动检查后也不会清除该状态。
- [x] 设置页仍可手动检查被临时忽略的版本。验证：回归测试确认手动检查仍返回有新版本。
- [x] 普通“忽略”不会变成跨启动的长期忽略。验证：回归测试确认长期设置未被写入。

## 自测结果

- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests io.github.vrcmteam.vrcm.service.VersionServiceTest`：通过。该测试在修复前先确认失败，修复后通过。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:assembleDebug`：通过，生成真实 Android Debug 包。
- `ANDROID_HOME=/home/ubuntu/Android/Sdk ~/ai/bin/check-gate.sh implement-issue 58`：`quality gate: pass`。
- 完整 `:composeApp:desktopTest`：执行 655 项，654 项通过；唯一失败为仓库已知的无图形环境基线项 `DesktopWindowTitleBarLocaleTest`，失败原因为 `HeadlessException`，与本次改动无关。
- 真机：白名单设备 PKV110 在线，但保留数据覆盖安装时返回 `INSTALL_FAILED_UPDATE_INCOMPATIBLE`，现有应用与本次 Debug 包签名不同。按测试纪律未卸载应用、未清数据、未修改包名，因此未完成真机旋转验收。

## 自评风险点

- 普通忽略状态只存在于当前应用进程，进程结束后会恢复提示；这与现有“忽略此次版本更新”复选框负责长期忽略的分工一致。
- 真机双向旋转尚未执行，剩余风险集中在设备级 Activity 重建集成；自动化测试已覆盖重建后会触发的重复版本检查及其状态契约。
- 会话状态使用跨线程原子值，避免版本检查返回与关闭操作交错时读到不一致状态。

## 代码逻辑图

本次无复杂代码逻辑，无需图示。

## 实现假设清单

本次无未经验证假设。普通忽略不写入长期设置的依据是现有界面已经单独提供“忽略此次版本更新”选项；版本服务为应用级单例以及 Android 旋转会重建 Activity 的行为均已从现有依赖装配和 Activity 实现中核实。

## 实现说明(供追问)

### 关键决策

普通“忽略”只记到本次应用运行结束，不写入长期设置。这样既能跨过横竖屏切换，又不会取代用户主动勾选的“忽略此次版本更新”。设置页的手动检查保留最高优先级，即使启动公告本次已忽略，也仍能由用户主动打开。

### 覆盖的场景

覆盖首次启动发现更新、普通关闭后重复启动检查、连续横竖屏重建、手动检查被临时忽略的版本、长期忽略设置不被普通关闭污染，以及版本检查与关闭操作可能交错的场景。

### 明确未覆盖

未改变版本比较、公告内容、下载链接、更新按钮和长期忽略规则。由于白名单设备上现有应用签名不同，本次没有执行真实设备上的双向旋转操作；没有通过卸载、清数据或改包名绕过这一限制。

### 关键假设

无。