### PR TITLE
feat(settings): 添加剪贴板读取开关

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/compoments/OfficialLinkPrompt.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/OfficialLinkPrompt.kt
@@ -40,6 +40,7 @@ import io.github.vrcmteam.vrcm.presentation.screens.world.WorldProfileScreen
 import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
 import io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStrings
 import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
+import io.github.vrcmteam.vrcm.presentation.settings.LocalSettingsState
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
 import io.github.vrcmteam.vrcm.service.OfficialLinkContent
 import io.github.vrcmteam.vrcm.service.OfficialLinkInbox
@@ -63,6 +64,7 @@ internal fun OfficialLinkPrompt(
     val isAuthenticated = navigator.items.any { it is HomeScreen }
     val controller = rememberOfficialLinkPromptController(service, navigator, inbox)
     val promptState by controller.state.collectAsState()
+    val clipboardReadingEnabled = LocalSettingsState.current.value.clipboardReadingEnabled
 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         foregroundGeneration++
@@ -77,12 +79,14 @@ internal fun OfficialLinkPrompt(
         foregroundGeneration,
         isAuthenticated,
         incomingRequest?.id,
+        clipboardReadingEnabled,
     ) {
         if (
             !clipboardInspectionGate.shouldInspect(
                 foregroundGeneration = foregroundGeneration,
                 isAuthenticated = isAuthenticated,
                 hasExternalRequest = incomingRequest != null,
+                clipboardReadingEnabled = clipboardReadingEnabled,
             )
         ) {
             return@LaunchedEffect
@@ -118,12 +122,17 @@ internal fun OfficialLinkPrompt(
 /** Prevents an external link and a clipboard link from being handled in the same foreground event. */
 internal class OfficialLinkClipboardInspectionGate {
     private var handledForegroundGeneration = 0
+    private var wasClipboardReadingEnabled = false
 
     fun shouldInspect(
         foregroundGeneration: Int,
         isAuthenticated: Boolean,
         hasExternalRequest: Boolean,
+        clipboardReadingEnabled: Boolean,
     ): Boolean {
+        val wasJustEnabled = clipboardReadingEnabled && !wasClipboardReadingEnabled
+        wasClipboardReadingEnabled = clipboardReadingEnabled
+        if (!clipboardReadingEnabled) return false
         if (hasExternalRequest) {
             handledForegroundGeneration = foregroundGeneration
             return false
@@ -131,7 +140,7 @@ internal class OfficialLinkClipboardInspectionGate {
         if (
             foregroundGeneration == 0 ||
             !isAuthenticated ||
-            handledForegroundGeneration == foregroundGeneration
+            (!wasJustEnabled && handledForegroundGeneration == foregroundGeneration)
         ) {
             return false
         }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/sheet/SettingsBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/sheet/SettingsBottomSheet.kt
@@ -141,6 +141,14 @@ private inline fun ColumnScope.CustomBlock() {
                 }
             }
         }
+        HorizontalDivider(modifier = Modifier.padding(horizontal = 12.dp), thickness = 0.5.dp)
+        ToggleSettingsRow(
+            title = strings.stettingClipboardReading,
+            checked = currentSettings.clipboardReadingEnabled,
+            onCheckedChange = { enabled ->
+                currentSettings = currentSettings.copy(clipboardReadingEnabled = enabled)
+            },
+        )
     }
 
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/sheet/SettingsBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/sheet/SettingsBottomSheet.kt
@@ -141,25 +141,10 @@ private inline fun ColumnScope.CustomBlock() {
                 }
             }
         }
-        HorizontalDivider(modifier = Modifier.padding(horizontal = 12.dp), thickness = 0.5.dp)
-        ToggleSettingsRow(
-            title = strings.stettingClipboardReading,
-            checked = currentSettings.clipboardReadingEnabled,
-            onCheckedChange = { enabled ->
-                currentSettings = currentSettings.copy(clipboardReadingEnabled = enabled)
-            },
-        )
     }
 
 }
 
-@Composable
-private fun ToggleSettingsRow(title: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
-    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-        Text(title, modifier = Modifier.weight(1f))
-        Switch(checked = checked, onCheckedChange = onCheckedChange)
-    }
-}
 @Composable
 private fun AboutBlock(onDismissRequest: () -> Unit) {
     val versionService = koinInject<VersionService>()
@@ -196,30 +181,31 @@ private fun AboutBlock(onDismissRequest: () -> Unit) {
     }
     Column {
         val platform = koinInject<AppPlatform>()
-        // 通知相关的开关全部收进独立页面，设置面板里只留一个入口；不能投递通知的平台不显示。
-        if (platform.supportsFriendActivityNotifications) {
-            val navigator = LocalNavigator.currentOrThrow
-            Row(
-                modifier = Modifier.fillMaxWidth()
-                    .clickable {
-                        navigator push NotificationSettingsScreen
-                        // 设置面板是盖在内容之上的弹窗，不收起来会把刚推进去的页面挡住。
-                        onDismissRequest()
-                    }
-                    .padding(12.dp),
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(text = "${strings.stettingMoreSettings}:")
-                Spacer(modifier = Modifier.weight(1f))
-                Text(
-                    text = strings.notificationSettingsTitle,
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            HorizontalDivider(modifier = Modifier.padding(horizontal = 12.dp), thickness = 0.5.dp)
+        val navigator = LocalNavigator.currentOrThrow
+        Row(
+            modifier = Modifier.fillMaxWidth()
+                .clickable {
+                    navigator push NotificationSettingsScreen
+                    // 设置面板是盖在内容之上的弹窗，不收起来会把刚推进去的页面挡住。
+                    onDismissRequest()
+                }
+                .padding(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(text = "${strings.stettingMoreSettings}:")
+            Spacer(modifier = Modifier.weight(1f))
+            Text(
+                text = if (platform.supportsFriendActivityNotifications) {
+                    strings.notificationSettingsTitle
+                } else {
+                    strings.stettingClipboardReading
+                },
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
+        HorizontalDivider(modifier = Modifier.padding(horizontal = 12.dp), thickness = 0.5.dp)
         val diskCache = imageLoader.diskCache
         var size by remember(diskCache) { mutableStateOf(diskCache?.size ?: 0L) }
         var isClearingCache by remember { mutableStateOf(false) }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/settings/NotificationSettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/settings/NotificationSettingsScreen.kt
@@ -72,9 +72,9 @@ import kotlinx.serialization.Serializable
 import org.koin.compose.koinInject
 
 /**
- * 通知设置详情页。
+ * 更多设置详情页。
  *
- * 设置面板里只留一个入口，具体开关都收在这里；页面本身只在能真正投递通知的平台可达。
+ * Android 在这里显示通知设置，其余平台只显示可用的跨平台设置。
  */
 @Serializable
 object NotificationSettingsScreen : AppDetailRoute {
@@ -84,14 +84,23 @@ object NotificationSettingsScreen : AppDetailRoute {
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
         val platform = koinInject<AppPlatform>()
-        val favoriteService = koinInject<FavoriteService>()
-        val friendService = koinInject<FriendService>()
+        val supportsNotifications = platform.supportsFriendActivityNotifications
+        val favoriteService = if (supportsNotifications) koinInject<FavoriteService>() else null
+        val friendService = if (supportsNotifications) koinInject<FriendService>() else null
         var currentSettings by LocalSettingsState.current
         var showFriendOverrides by remember { mutableStateOf(false) }
 
-        LaunchedEffect(Unit) { favoriteService.loadFavoriteByGroup(FavoriteType.Friend) }
-        val favoriteGroups by favoriteService.favoritesByGroup(FavoriteType.Friend).collectAsState()
-        val friends by friendService.friendState.collectAsState()
+        LaunchedEffect(favoriteService) { favoriteService?.loadFavoriteByGroup(FavoriteType.Friend) }
+        val favoriteGroups = if (favoriteService != null) {
+            favoriteService.favoritesByGroup(FavoriteType.Friend).collectAsState().value
+        } else {
+            emptyMap()
+        }
+        val friends = if (friendService != null) {
+            friendService.friendState.collectAsState().value
+        } else {
+            emptyMap()
+        }
         val favoriteUserIds = remember(favoriteGroups) {
             favoriteGroups.values.flatten().map { it.favoriteId }.distinct()
         }
@@ -103,7 +112,7 @@ object NotificationSettingsScreen : AppDetailRoute {
             }
         }
 
-        if (showFriendOverrides) {
+        if (supportsNotifications && showFriendOverrides) {
             FriendOverridesBottomSheet(
                 friends = friendOverrideItems,
                 overrides = currentSettings.friendPresenceFilter.userOverrides,
@@ -123,7 +132,7 @@ object NotificationSettingsScreen : AppDetailRoute {
         Scaffold(
             topBar = {
                 CenterAlignedTopAppBar(
-                    title = { Text(strings.notificationSettingsTitle) },
+                    title = { Text(strings.stettingMoreSettings) },
                     navigationIcon = {
                         IconButton(onClick = { navigator.pop() }) {
                             Icon(
@@ -141,6 +150,18 @@ object NotificationSettingsScreen : AppDetailRoute {
                 contentPadding = androidx.compose.foundation.layout.PaddingValues(12.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
+                if (!supportsNotifications) {
+                    item {
+                        SettingsSwitchRow(
+                            title = strings.stettingClipboardReading,
+                            description = null,
+                            checked = currentSettings.clipboardReadingEnabled,
+                        ) { enabled ->
+                            currentSettings = currentSettings.copy(clipboardReadingEnabled = enabled)
+                        }
+                    }
+                    return@LazyColumn
+                }
                 item {
                     SectionTitle(strings.notificationSectionFriendPresence)
                 }
@@ -272,6 +293,16 @@ object NotificationSettingsScreen : AppDetailRoute {
                 if (platform.supportsBackgroundFriendMonitoring) {
                     item { HorizontalDivider() }
                     item { BackgroundMonitoringSection(platform) }
+                }
+                item { HorizontalDivider() }
+                item {
+                    SettingsSwitchRow(
+                        title = strings.stettingClipboardReading,
+                        description = null,
+                        checked = currentSettings.clipboardReadingEnabled,
+                    ) { enabled ->
+                        currentSettings = currentSettings.copy(clipboardReadingEnabled = enabled)
+                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/presentation/settings/SettingsModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/SettingsModel.kt
@@ -48,6 +48,7 @@ class SettingsModel(
                 vrchatStatusNotificationsEnabled = it.vrchatStatusNotificationsEnabled,
                 friendPresenceFilter = it.friendPresenceFilter,
                 backgroundFriendMonitoringEnabled = it.backgroundFriendMonitoringEnabled,
+                clipboardReadingEnabled = it.clipboardReadingEnabled,
             )
         }
     }
@@ -70,6 +71,7 @@ class SettingsModel(
                 vrchatStatusNotificationsEnabled = settings.vrchatStatusNotificationsEnabled,
                 friendPresenceFilter = settings.friendPresenceFilter,
                 backgroundFriendMonitoringEnabled = settings.backgroundFriendMonitoringEnabled,
+                clipboardReadingEnabled = settings.clipboardReadingEnabled,
             )
         }
 }

--- a/composeApp/src/commonMain/kotlin/presentation/settings/data/SettingsVo.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/data/SettingsVo.kt
@@ -16,5 +16,5 @@ data class SettingsVo(
     val vrchatStatusNotificationsEnabled: Boolean = false,
     val friendPresenceFilter: FriendPresenceFilter = FriendPresenceFilter.Default,
     val backgroundFriendMonitoringEnabled: Boolean = false,
-    val clipboardReadingEnabled: Boolean = false,
+    val clipboardReadingEnabled: Boolean = true,
 )

--- a/composeApp/src/commonMain/kotlin/presentation/settings/data/SettingsVo.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/data/SettingsVo.kt
@@ -16,4 +16,5 @@ data class SettingsVo(
     val vrchatStatusNotificationsEnabled: Boolean = false,
     val friendPresenceFilter: FriendPresenceFilter = FriendPresenceFilter.Default,
     val backgroundFriendMonitoringEnabled: Boolean = false,
+    val clipboardReadingEnabled: Boolean = false,
 )

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
@@ -49,6 +49,7 @@ sealed class LocaleStrings {
     open val stettingLightThemeMode: String = "Light"
     open val stettingDarkThemeMode: String = "Dark"
     open val stettingThemeColor: String = "ThemeColor"
+    open val stettingClipboardReading: String = "Read clipboard"
     open val stettingLogout: String = "Logout"
     open val stettingAbout: String = "About Application"
     open val stettingVersion: String = "Version"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
@@ -38,6 +38,7 @@ internal object LocaleStringsJa : LocaleStrings() {
     override val stettingLightThemeMode = "ライトモード"
     override val stettingDarkThemeMode = "ダークモード"
     override val stettingThemeColor = "テーマカラー"
+    override val stettingClipboardReading = "クリップボードを読み取る"
     override val stettingLogout = "ログアウト"
     override val stettingAbout = "アプリについて"
     override val stettingVersion = "バージョン"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
@@ -38,6 +38,7 @@ internal object LocaleStringsZhHans : LocaleStrings() {
     override val stettingLightThemeMode = "明亮主题"
     override val stettingDarkThemeMode = "深色主题"
     override val stettingThemeColor = "主题颜色"
+    override val stettingClipboardReading = "读取剪贴板"
     override val stettingLogout = "登出"
     override val stettingAbout = "关于APP"
     override val stettingVersion = "版本"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
@@ -38,6 +38,7 @@ internal object LocaleStringsZhHant : LocaleStrings() {
     override val stettingLightThemeMode = "明亮主題"
     override val stettingDarkThemeMode = "深色主題"
     override val stettingThemeColor = "主題顏色"
+    override val stettingClipboardReading = "讀取剪貼簿"
     override val stettingLogout = "登出"
     override val stettingAbout = "關於應用程序"
     override val stettingVersion = "版本"

--- a/composeApp/src/commonMain/kotlin/storage/DaoKeys.kt
+++ b/composeApp/src/commonMain/kotlin/storage/DaoKeys.kt
@@ -75,6 +75,7 @@ object DaoKeys{
         const val LAST_VRCHAT_STATUS_INDICATOR_KEY = "${PREFIX}.lastVrchatStatusIndicator"
         const val PRESENCE_FILTER_KEY = "${PREFIX}.friendPresenceFilter"
         const val BACKGROUND_FRIEND_MONITORING_ENABLED_KEY = "${PREFIX}.backgroundFriendMonitoringEnabled"
+        const val CLIPBOARD_READING_ENABLED_KEY = "${PREFIX}.clipboardReadingEnabled"
 
     }
 

--- a/composeApp/src/commonMain/kotlin/storage/SettingsDao.kt
+++ b/composeApp/src/commonMain/kotlin/storage/SettingsDao.kt
@@ -112,6 +112,6 @@ class SettingsDao(
         set(value) = settingsSettings.putBoolean(DaoKeys.Settings.BACKGROUND_FRIEND_MONITORING_ENABLED_KEY, value)
 
     var clipboardReadingEnabled: Boolean
-        get() = settingsSettings.getBoolean(DaoKeys.Settings.CLIPBOARD_READING_ENABLED_KEY, false)
+        get() = settingsSettings.getBoolean(DaoKeys.Settings.CLIPBOARD_READING_ENABLED_KEY, true)
         set(value) = settingsSettings.putBoolean(DaoKeys.Settings.CLIPBOARD_READING_ENABLED_KEY, value)
 }

--- a/composeApp/src/commonMain/kotlin/storage/SettingsDao.kt
+++ b/composeApp/src/commonMain/kotlin/storage/SettingsDao.kt
@@ -25,6 +25,7 @@ class SettingsDao(
                 vrchatStatusNotificationsEnabled = vrchatStatusNotificationsEnabled,
                 friendPresenceFilter = friendPresenceFilter,
                 backgroundFriendMonitoringEnabled = backgroundFriendMonitoringEnabled,
+                clipboardReadingEnabled = clipboardReadingEnabled,
             )
         }
         set(value) {
@@ -47,6 +48,7 @@ class SettingsDao(
             vrchatStatusNotificationsEnabled = value.vrchatStatusNotificationsEnabled
             friendPresenceFilter = value.friendPresenceFilter
             backgroundFriendMonitoringEnabled = value.backgroundFriendMonitoringEnabled
+            clipboardReadingEnabled = value.clipboardReadingEnabled
         }
 
     var rememberVersion: String?
@@ -108,4 +110,8 @@ class SettingsDao(
     var backgroundFriendMonitoringEnabled: Boolean
         get() = settingsSettings.getBoolean(DaoKeys.Settings.BACKGROUND_FRIEND_MONITORING_ENABLED_KEY, false)
         set(value) = settingsSettings.putBoolean(DaoKeys.Settings.BACKGROUND_FRIEND_MONITORING_ENABLED_KEY, value)
+
+    var clipboardReadingEnabled: Boolean
+        get() = settingsSettings.getBoolean(DaoKeys.Settings.CLIPBOARD_READING_ENABLED_KEY, false)
+        set(value) = settingsSettings.putBoolean(DaoKeys.Settings.CLIPBOARD_READING_ENABLED_KEY, value)
 }

--- a/composeApp/src/commonMain/kotlin/storage/data/SettingsData.kt
+++ b/composeApp/src/commonMain/kotlin/storage/data/SettingsData.kt
@@ -16,5 +16,5 @@ data class SettingsData(
     val vrchatStatusNotificationsEnabled: Boolean = false,
     val friendPresenceFilter: FriendPresenceFilter = FriendPresenceFilter.Default,
     val backgroundFriendMonitoringEnabled: Boolean = false,
-    val clipboardReadingEnabled: Boolean = false,
+    val clipboardReadingEnabled: Boolean = true,
 )

--- a/composeApp/src/commonMain/kotlin/storage/data/SettingsData.kt
+++ b/composeApp/src/commonMain/kotlin/storage/data/SettingsData.kt
@@ -16,4 +16,5 @@ data class SettingsData(
     val vrchatStatusNotificationsEnabled: Boolean = false,
     val friendPresenceFilter: FriendPresenceFilter = FriendPresenceFilter.Default,
     val backgroundFriendMonitoringEnabled: Boolean = false,
+    val clipboardReadingEnabled: Boolean = false,
 )

--- a/composeApp/src/commonTest/kotlin/presentation/compoments/OfficialLinkPromptControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/compoments/OfficialLinkPromptControllerTest.kt
@@ -50,6 +50,7 @@ class OfficialLinkPromptControllerTest {
                 foregroundGeneration = 1,
                 isAuthenticated = true,
                 hasExternalRequest = true,
+                clipboardReadingEnabled = true,
             ),
         )
         assertFalse(
@@ -57,6 +58,7 @@ class OfficialLinkPromptControllerTest {
                 foregroundGeneration = 1,
                 isAuthenticated = true,
                 hasExternalRequest = false,
+                clipboardReadingEnabled = true,
             ),
         )
         assertTrue(
@@ -64,6 +66,7 @@ class OfficialLinkPromptControllerTest {
                 foregroundGeneration = 2,
                 isAuthenticated = true,
                 hasExternalRequest = false,
+                clipboardReadingEnabled = true,
             ),
         )
     }
@@ -77,6 +80,7 @@ class OfficialLinkPromptControllerTest {
                 foregroundGeneration = 1,
                 isAuthenticated = false,
                 hasExternalRequest = false,
+                clipboardReadingEnabled = true,
             ),
         )
         assertTrue(
@@ -84,6 +88,7 @@ class OfficialLinkPromptControllerTest {
                 foregroundGeneration = 1,
                 isAuthenticated = true,
                 hasExternalRequest = false,
+                clipboardReadingEnabled = true,
             ),
         )
         assertFalse(
@@ -91,6 +96,45 @@ class OfficialLinkPromptControllerTest {
                 foregroundGeneration = 1,
                 isAuthenticated = true,
                 hasExternalRequest = false,
+                clipboardReadingEnabled = true,
+            ),
+        )
+    }
+
+    @Test
+    fun enablingClipboardReadingInspectsImmediatelyAndCanBeRepeatedInOneForeground() {
+        val gate = OfficialLinkClipboardInspectionGate()
+
+        assertFalse(
+            gate.shouldInspect(
+                foregroundGeneration = 1,
+                isAuthenticated = true,
+                hasExternalRequest = false,
+                clipboardReadingEnabled = false,
+            ),
+        )
+        assertTrue(
+            gate.shouldInspect(
+                foregroundGeneration = 1,
+                isAuthenticated = true,
+                hasExternalRequest = false,
+                clipboardReadingEnabled = true,
+            ),
+        )
+        assertFalse(
+            gate.shouldInspect(
+                foregroundGeneration = 1,
+                isAuthenticated = true,
+                hasExternalRequest = false,
+                clipboardReadingEnabled = false,
+            ),
+        )
+        assertTrue(
+            gate.shouldInspect(
+                foregroundGeneration = 1,
+                isAuthenticated = true,
+                hasExternalRequest = false,
+                clipboardReadingEnabled = true,
             ),
         )
     }

--- a/composeApp/src/commonTest/kotlin/presentation/settings/SettingsModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/settings/SettingsModelTest.kt
@@ -9,14 +9,14 @@ import kotlin.test.assertTrue
 
 class SettingsModelTest {
     @Test
-    fun clipboardReadingIsOptInAndPersistsAcrossModelInstances() {
+    fun clipboardReadingIsEnabledByDefaultAndOptOutPersistsAcrossModelInstances() {
         val settings = MapSettings()
         val firstModel = SettingsModel(SettingsDao(settings), listOf(ThemeColor.Default))
 
-        assertFalse(firstModel.settingsVo.clipboardReadingEnabled)
-        firstModel.saveSettings(firstModel.settingsVo.copy(clipboardReadingEnabled = true))
+        assertTrue(firstModel.settingsVo.clipboardReadingEnabled)
+        firstModel.saveSettings(firstModel.settingsVo.copy(clipboardReadingEnabled = false))
 
         val restoredModel = SettingsModel(SettingsDao(settings), listOf(ThemeColor.Default))
-        assertTrue(restoredModel.settingsVo.clipboardReadingEnabled)
+        assertFalse(restoredModel.settingsVo.clipboardReadingEnabled)
     }
 }

--- a/composeApp/src/commonTest/kotlin/presentation/settings/SettingsModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/settings/SettingsModelTest.kt
@@ -1,0 +1,22 @@
+package io.github.vrcmteam.vrcm.presentation.settings
+
+import com.russhwolf.settings.MapSettings
+import io.github.vrcmteam.vrcm.presentation.settings.theme.ThemeColor
+import io.github.vrcmteam.vrcm.storage.SettingsDao
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SettingsModelTest {
+    @Test
+    fun clipboardReadingIsOptInAndPersistsAcrossModelInstances() {
+        val settings = MapSettings()
+        val firstModel = SettingsModel(SettingsDao(settings), listOf(ThemeColor.Default))
+
+        assertFalse(firstModel.settingsVo.clipboardReadingEnabled)
+        firstModel.saveSettings(firstModel.settingsVo.copy(clipboardReadingEnabled = true))
+
+        val restoredModel = SettingsModel(SettingsDao(settings), listOf(ThemeColor.Default))
+        assertTrue(restoredModel.settingsVo.clipboardReadingEnabled)
+    }
+}


### PR DESCRIPTION
关联 #67

## 实现思路

在 Android、iOS 与 Desktop 的设置面板统一提供“更多设置”入口，并把默认开启且会持久保存用户选择的“读取剪贴板”开关放在该页面末尾。Android 继续显示原有通知设置，其他平台不加载也不显示通知功能。链接提示只在开关开启时读取剪贴板；用户从关闭切到开启时立即检测一次，之后仍按既有的应用回到前台事件检测。外部链接优先、登录门控、确认弹窗以及链接解析流程保持不变。

## 验收自查

- [x] Android、iOS 与 Desktop 都能从设置面板进入“更多设置”，读取剪贴板开关位于页面末尾。通过 Desktop/iOS 共享编译与 Android Debug 打包验证。
- [x] 通知功能仍仅在 Android 的“更多设置”中显示，iOS 与 Desktop 不加载或显示通知区块。通过平台能力分支与跨平台编译验证。
- [x] 没有已保存选择时开关默认开启；用户关闭后，应用启动和回到前台均不读取剪贴板，且关闭状态会保留。通过设置存储往返测试和门控测试验证。
- [x] 打开开关的瞬间立即检测剪贴板。通过同一前台代次内“关闭 → 开启”状态转换测试验证。
- [x] 开关保持开启后，应用每次重新回到前台检测一次。通过前台代次门控测试验证。
- [x] Android、iOS 与 Desktop 共用同一设置和读取门控。Android Debug APK 与 iOS Arm64 目标均编译成功。
- [x] 空内容、不支持内容、读取失败以及外部链接优先行为保持不变。读取仍沿用既有安全失败和解析流程，外部请求门控测试通过。
- [x] 英文、日文、简体中文与繁体中文文案齐全。语言目录结构测试通过。

## 自测结果

- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests io.github.vrcmteam.vrcm.presentation.compoments.OfficialLinkPromptControllerTest --tests io.github.vrcmteam.vrcm.presentation.settings.SettingsModelTest --tests io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStringsStructureTest --console=plain`：BUILD SUCCESSFUL。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:linkDebugFrameworkIosArm64 --console=plain`：BUILD SUCCESSFUL。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:assembleDebug --console=plain`：BUILD SUCCESSFUL。
- `~/ai/bin/check-gate.sh implement-issue 67`：quality gate: pass。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests io.github.vrcmteam.vrcm.presentation.settings.SettingsModelTest --tests io.github.vrcmteam.vrcm.presentation.compoments.OfficialLinkPromptControllerTest --console=plain`：BUILD SUCCESSFUL。
- `~/ai/bin/check-gate.sh fix-review 68`（提交 `ba1a3d5`）：quality gate: pass。
- 完整 `desktopTest` 共执行 687 项，仅仓库已知的无图形环境基线用例 `DesktopWindowTitleBarLocaleTest.windowControlLabelsUseTheLatestLanguage` 因 `HeadlessException` 失败；本次新增及相关测试均通过。
- `git diff --check`：通过。

## 自评风险点

- 已完成 Android 与 iOS 编译，但当前环境未在 iOS 真机上观察系统粘贴提示；仍需评审或验收时在 iOS 上确认：默认开启时按既有前台门控读取，关闭后不出现提示，重新打开时立即读取一次。
- iOS 与 Desktop 新增“更多设置”入口，Android 页面末尾新增开关；沿用现有自适应滚动布局，未做自动化视觉截图验证。

## 代码逻辑图

设置页面与平台分支：

```mermaid
flowchart TD
    Entry["SettingsBottomSheet: 更多设置入口"] --> Route["AppNavigator push NotificationSettingsScreen"]
    Route --> Capability{"AppPlatform.supportsFriendActivityNotifications?"}
    Capability -->|"是，Android"| Services["koinInject FavoriteService / FriendService"]
    Services --> Notifications["组合通知设置区块"]
    Capability -->|"否，iOS / Desktop"| Skip["跳过通知依赖和通知区块"]
    Notifications --> Clipboard["页面末尾 SettingsSwitchRow: 读取剪贴板"]
    Skip --> Clipboard
    Clipboard --> State["LocalSettingsState.clipboardReadingEnabled"]
    State --> Save["SettingsModel.saveSettings"]
    Save --> Dao["SettingsDao 持久化"]
```

剪贴板读取门控：

```mermaid
flowchart TD
    Resume["Lifecycle ON_RESUME"] --> Increment["OfficialLinkPrompt: foregroundGeneration++"]
    Increment --> Effect["LaunchedEffect 重新检查"]
    Toggle["LocalSettingsState: clipboardReadingEnabled 变化"] --> Effect
    Auth["AppNavigator: isAuthenticated 变化"] --> Effect
    Inbox["OfficialLinkInbox.pendingRequest 变化"] --> Effect
    Effect --> Gate["OfficialLinkClipboardInspectionGate.shouldInspect"]
    Gate --> Enabled{"clipboardReadingEnabled?"}
    Enabled -->|"否"| Stop["不读取剪贴板"]
    Enabled -->|"是"| External{"hasExternalRequest?"}
    External -->|"是"| Occupy["记录 handledForegroundGeneration，占用本代"]
    Occupy --> Stop
    External -->|"否"| Ready{"foregroundGeneration > 0 且已登录?"}
    Ready -->|"否，不消费本代"| Stop
    Ready -->|"是"| Edge{"刚由关闭切到开启?"}
    Edge -->|"是，立即触发"| Permit["记录当前代次并允许读取"]
    Edge -->|"否"| Once{"当前代次已处理?"}
    Once -->|"是"| Stop
    Once -->|"否"| Permit
    Permit --> Read["LocalClipboardManager.getText()"]
    Read --> Text{"读取成功且有文本?"}
    Text -->|"否"| End["结束，无提示"]
    Text -->|"是"| Inspect["OfficialLinkPromptController.inspectClipboard()"]
```

## 实现假设清单

- 无设置记录时（新安装或尚未保存该设置的升级用户）默认开启；用户明确关闭后仍保留关闭状态。依据：2026-08-18 人类评审评论明确要求“读取剪切板的开关应该默认打开”；保留用户的显式关闭选择沿用现有设置持久化合同。
- 三端都开放“更多设置”且通知功能仅 Android 显示，已由人类评审评论明确授权，不再属于未经验证假设。
- 假设开关开启后保留现有“每次重新回到前台检测一次”的能力。依据：Issue 要求“读取粘贴板可配置”，并特别补充开启瞬间立即检测，而非把功能改成仅手动检测一次。

## 实现说明(供追问)

### 关键决策

保留现有 `NotificationSettingsScreen` 路由类型以兼容已保存的导航栈，但将其展示为通用“更多设置”页面。页面先按平台通知能力分支：Android 继续加载通知服务和通知区块，iOS 与 Desktop 直接跳过；三端最后都使用同一剪贴板开关。开关接入现有设置单一来源并整体保存，避免界面显示和实际读取状态不一致。读取控制放在真正调用系统剪贴板之前，关闭时不会先读再丢弃。即时检测复用既有前台门控，并把“刚开启”作为一次明确触发，因此不新增后台监听或另一套链接处理流程。

### 覆盖的场景

覆盖三端进入“更多设置”、Android 保留通知功能、iOS 与 Desktop 隐藏通知功能、剪贴板开关位于页面末尾、无设置记录时默认开启、用户开启后立即检测、关闭后停止检测并保留关闭选择、同一前台反复开关、重新回到前台、应用同时收到外部链接、未登录、剪贴板为空或读取失败、设置跨重启恢复，以及四种界面语言。

### 明确未覆盖

未新增剪贴板历史、后台持续监听、自动打开剪贴板内容或新的链接类型。未在 iOS 真机上记录系统粘贴提示截图，因为当前执行环境只完成了 iOS 编译验证。

### 关键假设

无设置记录时默认开启，用户显式关闭后保留关闭状态；开启后继续沿用每次回到前台检测一次的既有行为。默认值、三端页面位置和 Android 通知隔离均已有明确人类授权，具体依据见“实现假设清单”。