### PR TITLE
fix(friends): 优化好友收藏页的排序顺序

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
@@ -536,7 +536,13 @@ internal fun Iterable<FriendData>.sortedUserByStatus() = sortedByDescending {
     val isOffline = it.status == UserStatus.Offline
     val locationType = LocationType.fromValue(it.location)
     buildString {
-        append(if (isOffline) "0" else "1")
+        append(
+            when {
+                isOffline -> "0"
+                locationType == LocationType.Offline || locationType == LocationType.Web -> "1"
+                else -> "2"
+            }
+        )
         append('-')
         append(
             when (locationType) {

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListSortTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListSortTest.kt
@@ -8,6 +8,37 @@ import kotlin.test.assertEquals
 
 class FriendListSortTest {
     @Test
+    fun inGameFriendsComeBeforeWebAndOfflineFriends() {
+        val offline = friend(
+            id = "usr_offline",
+            status = UserStatus.Offline,
+            location = LocationType.Offline.value,
+        )
+        val legacyWeb = friend(
+            id = "usr_legacy_web",
+            status = UserStatus.Active,
+            location = LocationType.Offline.value,
+        )
+        val web = friend(
+            id = "usr_web",
+            status = UserStatus.Active,
+            location = LocationType.Web.value,
+        )
+        val inGame = friend(
+            id = "usr_in_game",
+            status = UserStatus.Active,
+            location = "wrld_world:instance",
+        )
+
+        val sorted = listOf(offline, legacyWeb, web, inGame).sortedUserByStatus()
+
+        assertEquals(
+            listOf("usr_in_game", "usr_web", "usr_legacy_web", "usr_offline"),
+            sorted.map(FriendData::id),
+        )
+    }
+
+    @Test
     fun offlineFriendsFallBackToLastLoginWhenLastActivityIsMissing() {
         val older = friend(
             id = "usr_older",
@@ -25,7 +56,13 @@ class FriendListSortTest {
         assertEquals(listOf("usr_newer", "usr_older"), sorted.map(FriendData::id))
     }
 
-    private fun friend(id: String, lastActivity: String, lastLogin: String) = FriendData(
+    private fun friend(
+        id: String,
+        lastActivity: String = "",
+        lastLogin: String = "",
+        status: UserStatus = UserStatus.Offline,
+        location: String = LocationType.Offline.value,
+    ) = FriendData(
         bio = null,
         currentAvatarImageUrl = "",
         currentAvatarThumbnailImageUrl = "",
@@ -38,9 +75,9 @@ class FriendListSortTest {
         lastActivity = lastActivity,
         lastLogin = lastLogin,
         lastPlatform = "standalonewindows",
-        location = LocationType.Offline.value,
+        location = location,
         profilePicOverride = "",
-        status = UserStatus.Offline,
+        status = status,
         statusDescription = "",
         userIcon = "",
         pronouns = null,


### PR DESCRIPTION
现在web在线会排在游戏在线后面