### PR TITLE
fix(notifications): 带头像的上下线提醒显示到达时间

### DIFF
--- a/composeApp/src/androidMain/kotlin/presentation/notifications/FriendOnlineNotifications.android.kt
+++ b/composeApp/src/androidMain/kotlin/presentation/notifications/FriendOnlineNotifications.android.kt
@@ -13,6 +13,7 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
 import android.os.Build
+import android.text.format.DateFormat
 import android.util.Log
 import androidx.core.content.ContextCompat
 import coil3.ImageLoader
@@ -27,6 +28,7 @@ import io.github.vrcmteam.vrcm.EXTRA_NOTIFICATION_DESTINATION
 import io.github.vrcmteam.vrcm.EXTRA_NOTIFICATION_TARGET_ID
 import io.github.vrcmteam.vrcm.network.api.friends.date.FriendData
 import io.github.vrcmteam.vrcm.service.NotificationLaunchDestination
+import java.util.Date
 import java.util.concurrent.ConcurrentHashMap
 
 private const val SOCIAL_CHANNEL = "friend_activity_alerts_v2"
@@ -64,18 +66,28 @@ class FriendNotificationFactory(private val context: Context) {
         destination: NotificationLaunchDestination,
         targetId: String,
         largeIcon: Bitmap? = null,
+        receivedAtMillis: Long = System.currentTimeMillis(),
+        showAvatarTimestamp: Boolean = false,
     ): Notification {
         val builder = builder(SOCIAL_CHANNEL, id, destination, targetId)
             .setContentTitle(title)
             .setContentText(message)
-            .setWhen(System.currentTimeMillis())
-            .setShowWhen(true)
+            .setWhen(receivedAtMillis)
             .setCategory(Notification.CATEGORY_SOCIAL)
             .setAutoCancel(true)
         if (message.length > LONG_MESSAGE_THRESHOLD) {
             builder.setStyle(Notification.BigTextStyle().bigText(message))
         }
-        largeIcon?.let(builder::setLargeIcon)
+        if (largeIcon == null || !showAvatarTimestamp) {
+            builder.setShowWhen(true)
+            largeIcon?.let(builder::setLargeIcon)
+        } else {
+            // Some OEM templates replace the system timestamp with a large icon.
+            builder
+                .setShowWhen(false)
+                .setSubText(DateFormat.getTimeFormat(context).format(Date(receivedAtMillis)))
+                .setLargeIcon(largeIcon)
+        }
         return builder.build()
     }
     fun serviceStatus(title: String, message: CharSequence): Notification =
@@ -132,6 +144,7 @@ class AndroidFriendOnlineNotifier(
             destination = NotificationLaunchDestination.UserProfile,
             targetId = friend.id,
             iconUrl = friend.iconUrl,
+            showAvatarTimestamp = true,
         )
     }
     override fun notifyOffline(friendId: String, displayName: String, iconUrl: String?) {
@@ -143,6 +156,7 @@ class AndroidFriendOnlineNotifier(
             destination = NotificationLaunchDestination.UserProfile,
             targetId = friendId,
             iconUrl = iconUrl,
+            showAvatarTimestamp = true,
         )
     }
 
@@ -153,8 +167,10 @@ class AndroidFriendOnlineNotifier(
         destination: NotificationLaunchDestination,
         targetId: String,
         iconUrl: String?,
+        showAvatarTimestamp: Boolean = false,
     ) {
         val requestToken = Any()
+        val receivedAtMillis = System.currentTimeMillis()
         latestAvatarRequests[id] = requestToken
         notificationManager.notify(
             id,
@@ -164,6 +180,8 @@ class AndroidFriendOnlineNotifier(
                 message = message,
                 destination = destination,
                 targetId = targetId,
+                receivedAtMillis = receivedAtMillis,
+                showAvatarTimestamp = showAvatarTimestamp,
             ),
         )
         val imageUrl = iconUrl?.trim()?.takeIf(String::isNotEmpty) ?: run {
@@ -193,6 +211,8 @@ class AndroidFriendOnlineNotifier(
                             destination = destination,
                             targetId = targetId,
                             largeIcon = notificationIcon(image.toBitmap()),
+                            receivedAtMillis = receivedAtMillis,
+                            showAvatarTimestamp = showAvatarTimestamp,
                         ),
                     )
                 },

--- a/composeApp/src/androidUnitTest/kotlin/presentation/notifications/FriendNotificationFactoryTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/presentation/notifications/FriendNotificationFactoryTest.kt
@@ -1,0 +1,57 @@
+package io.github.vrcmteam.vrcm.presentation.notifications
+
+import android.app.Application
+import android.app.Notification
+import android.graphics.Bitmap
+import android.text.format.DateFormat
+import io.github.vrcmteam.vrcm.service.NotificationLaunchDestination
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.util.Date
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [24])
+class FriendNotificationFactoryTest {
+    private val context = RuntimeEnvironment.getApplication() as Application
+    private val factory = FriendNotificationFactory(context)
+
+    @Test
+    fun avatarNotificationUsesSubTextForItsArrivalTime() {
+        val notification = factory.social(
+            id = 1,
+            title = "Friend online",
+            message = "Available",
+            destination = NotificationLaunchDestination.UserProfile,
+            targetId = "usr_friend",
+            largeIcon = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888),
+            showAvatarTimestamp = true,
+        )
+
+        assertFalse(notification.extras.getBoolean(Notification.EXTRA_SHOW_WHEN, true))
+        assertEquals(
+            DateFormat.getTimeFormat(context).format(Date(notification.`when`)),
+            notification.extras.getCharSequence(Notification.EXTRA_SUB_TEXT)?.toString(),
+        )
+    }
+
+    @Test
+    fun notificationWithoutAvatarKeepsTheSystemTimestamp() {
+        val notification = factory.social(
+            id = 2,
+            title = "Friend offline",
+            message = "",
+            destination = NotificationLaunchDestination.UserProfile,
+            targetId = "usr_friend",
+        )
+
+        assertTrue(notification.extras.getBoolean(Notification.EXTRA_SHOW_WHEN))
+        assertNull(notification.extras.getCharSequence(Notification.EXTRA_SUB_TEXT))
+    }
+}


### PR DESCRIPTION
关联 #78

## 实现思路
好友上线或下线通知没有头像时，继续使用系统原生时间；头像加载成功后，改用系统通知副文本显示同一个到达时刻，并关闭会与头像争用位置的原生时间槽。头像异步加载前后复用首次投递时间，避免通知刷新后时间向后跳。此行为只启用于好友上线和下线提醒，不改变好友请求、群组消息等其他提醒。

## 验收标准自查
- [x] 好友上线和下线通知显示头像时仍包含可见的到达时间。回归测试验证带头像通知关闭冲突的时间槽，并写入按设备格式生成的标准时间副文本。
- [x] 没有头像或头像加载失败时继续显示系统时间。回归测试验证无头像通知保留系统时间且不写入重复副文本。
- [x] 头像异步加载不会改变通知到达时刻。实现捕获首次投递时刻，并在头像加载后的同编号通知更新中复用。

## 自测结果
- 定向回归测试在修复前失败、修复后通过：FriendNotificationFactoryTest。
- ~/ai/bin/gradle-run.sh ./gradlew :composeApp:testDebugUnitTest :composeApp:assembleDebug：BUILD SUCCESSFUL。
- ~/ai/bin/check-gate.sh implement-issue 78：quality gate: pass，内部 assembleDebug 为 BUILD SUCCESSFUL。
- git diff --check：通过。

## 自评风险点
当前白名单真机只有 ColorOS，不能代表 Issue 所述的 HyperOS 3；同时该设备已有应用签名与本地构建不一致，未进行覆盖安装。自动化测试已验证 Android 标准通知数据契约，但 HyperOS 3 的最终排版仍需提出人在对应设备上复核。

## 代码逻辑图
本次无复杂代码逻辑，无需图示。

## 实现假设清单
- 假设 HyperOS 3 在大头像占用原生时间位置时仍会展示 Android 标准通知副文本。依据：Issue 截图确认只有大头像分支隐藏系统时间；Android 通知构建契约允许副文本与大图标同时存在。当前没有兼容的 HyperOS 3 白名单真机，尚未做目标系统截图验证。
- 设备的 12/24 小时制与区域格式应由系统时间格式决定。依据：实现使用 Android 提供的当前设备时间格式，不自行规定格式。

## 实现说明(供追问)
### 关键决策
使用系统通知副文本承载带头像时的时间，并关闭同一条通知的原生时间槽，从而保留头像、避免双重时间，也不引入难以适配不同系统的自定义通知布局。该处理只对好友上线和下线提醒启用。

### 覆盖的场景
覆盖好友上线、好友下线、头像加载成功、无头像、空头像地址、头像加载失败，以及头像加载完成后二次刷新通知的时间一致性。

### 明确未覆盖
不改变好友请求、群组消息、服务状态和后台监测提醒；不改变提醒开关、筛选或点击跳转。由于没有 HyperOS 3 白名单设备，本轮未提供该系统的真实通知截图。

### 关键假设
HyperOS 3 会按 Android 标准通知规则展示副文本；最终视觉位置由系统通知中心决定。