### PR TITLE
fix(profile): 缓存回填资料页时保留实时在线状态

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreenModel.kt
@@ -316,7 +316,8 @@ class UserProfileScreenModel(
             }
         }
         viewModelScope.launch {
-            // Room 读取是挂起的，缓存会比首帧稍晚一点到；只在网络结果尚未覆盖时回填。
+            // Room 读取是挂起的，缓存会比首帧稍晚一点到；只回填静态资料，
+            // 在线状态一律沿用内存里的实时来源，不被上次运行的历史值压回离线。
             userProfileCacheStore.load(cacheOwnerUserId, userProfileVO.id)
                 ?.let(::restoreCachedProfile)
         }
@@ -351,14 +352,11 @@ class UserProfileScreenModel(
 
     private fun restoreCachedProfile(cache: UserProfileCache) {
         cachedUserData = cache.user
-        val cachedUser = cache.user.asCachedOffline()
-        val profile = UserProfileVo(cachedUser)
-            .withSelfIdentity()
-            .let { restored ->
-                friendService.friendState.value[cache.user.id]
-                    ?.let(restored::withCurrentFriendPresence)
-                    ?: restored
-            }
+        val profile = mergeCachedProfile(
+            cachedUser = cache.user,
+            livePresence = _userState.value,
+            currentFriend = friendService.friendState.value[cache.user.id],
+        ).withSelfIdentity()
         _userState.value = profile
         computeFriendLocation(profile.location)
         _userGroups.value = visibleUserGroups(cache.groups, profile.isSelf)
@@ -868,3 +866,24 @@ internal fun UserProfileVo.withCurrentFriendPresence(friend: FriendData): UserPr
     lastLogin = friend.lastLogin,
     lastPlatform = friend.lastPlatform,
 )
+
+/**
+ * 用缓存回填页面资料：静态信息来自缓存，在线状态只能来自实时来源。
+ *
+ * 缓存里的在线状态是上次运行留下的历史值（[asCachedOffline] 会先抹成离线），
+ * 直接发布就会把页面已有的实时状态压回离线，等网络结果到达后再跳回去。
+ * 因此这里保留 [livePresence]（导航入参 / 当前账号 / 已到达的网络结果）的在线状态，
+ * 好友快照 [currentFriend] 更新则继续覆盖它。
+ */
+internal fun mergeCachedProfile(
+    cachedUser: UserData,
+    livePresence: UserProfileVo,
+    currentFriend: FriendData?,
+): UserProfileVo {
+    val restored = UserProfileVo(cachedUser.asCachedOffline()).copy(
+        status = livePresence.status,
+        statusDescription = livePresence.statusDescription,
+        location = livePresence.location,
+    )
+    return currentFriend?.let(restored::withCurrentFriendPresence) ?: restored
+}

--- a/composeApp/src/commonTest/kotlin/presentation/screens/user/UserProfileCachedPresenceTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/user/UserProfileCachedPresenceTest.kt
@@ -41,6 +41,49 @@ class UserProfileCachedPresenceTest {
         assertEquals("android", profile.lastPlatform)
     }
 
+    @Test
+    fun cachedRestoreKeepsLivePresenceWhenUserIsNotInFriendMap() {
+        // 自己的资料页在好友表里没有条目，缓存回填不能把页面上的实时状态压回离线。
+        val livePresence = UserProfileVo(
+            id = "usr_friend",
+            status = UserStatus.Active,
+            statusDescription = "Live status",
+            location = LocationType.Offline.value,
+        )
+
+        val profile = mergeCachedProfile(
+            cachedUser = onlineUser(),
+            livePresence = livePresence,
+            currentFriend = null,
+        )
+
+        assertEquals(UserStatus.Active, profile.status)
+        assertEquals("Live status", profile.statusDescription)
+        assertEquals(LocationType.Offline.value, profile.location)
+        // 静态资料仍然由缓存回填。
+        assertEquals("Bio", profile.bio)
+    }
+
+    @Test
+    fun cachedRestorePrefersFriendSnapshotOverNavigationPresence() {
+        val livePresence = UserProfileVo(
+            id = "usr_friend",
+            status = UserStatus.Active,
+            statusDescription = "Stale status",
+            location = LocationType.Offline.value,
+        )
+
+        val profile = mergeCachedProfile(
+            cachedUser = onlineUser(),
+            livePresence = livePresence,
+            currentFriend = friend(location = "wrld_current:2"),
+        )
+
+        assertEquals(UserStatus.JoinMe, profile.status)
+        assertEquals("Current status", profile.statusDescription)
+        assertEquals("wrld_current:2", profile.location)
+    }
+
     private fun onlineUser() = UserData(
         ageVerificationStatus = AgeVerificationStatus.Verified,
         allowAvatarCopying = true,


### PR DESCRIPTION
关联 #74

## 问题与根因

资料页在打开时会并行做几件事:先用上一页面传来的实时状态直接显示,再从本地 Room 缓存回填上次看过的资料,同时向服务器请求最新资料。

问题出在缓存回填这一步。缓存里的在线状态是上次运行留下的历史值,为了不把旧位置当成实时信息,读取时会被 `asCachedOffline` 统一抹成离线;但 `restoreCachedProfile` 把这份抹成离线的快照整份发布到了页面状态上,直接盖掉了页面已经拿到的实时状态。

对好友来说,这一步紧接着会用 `friendService.friendState` 里的实时好友快照纠正回来,所以看不出问题;而自己的资料页(以及任何不在好友表里的用户)没有这条纠正路径,只能等 `/users/{id}` 返回才恢复,于是就出现 issue 描述的现象:在线圆点先闪一下灰色实心圆(离线),等接口回来才跳回网页端在线的空心圆。

该行为由 cf7dcb3 引入:它给缓存加了 presence 降级和好友快照纠正,但没有保留更早版本中对自己资料页的保护分支。

## 实现思路

新增纯函数 `mergeCachedProfile`,把缓存回填明确定义成:静态资料(简介、头像、群组、世界等)来自缓存,在线状态只能来自实时来源。

- 缓存快照仍然先经 `asCachedOffline` 抹掉历史 presence,不会把上次的位置当成实时信息;
- `status` / `statusDescription` / `location` 三项改为沿用页面当前已有的实时来源(导航入参、当前账号状态,或已经到达的网络结果);
- 好友快照存在时,继续按原有优先级覆盖上述三项,顺序不变。

这样缓存永远不会把在线状态往回压,闪烁的来源被消除,而不是靠延迟或补一次刷新遮住。

## 验收标准自查

issue 用自然语言描述,未使用 checklist,按描述拆条自查:

- [x] 首页显示为网页端在线的用户,打开其资料页后在线状态圆点不再先变成灰色实心圆 —— 缓存回填不再发布离线 presence;新增单元测试 `cachedRestoreKeepsLivePresenceWhenUserIsNotInFriendMap` 复现该场景,修复前断言失败(实际得到 Offline),修复后通过。
- [x] 圆点稳定显示为网页端在线的空心圆 —— 空心与否由 `status != Offline 且 location 为 offline` 判定,修复后这两个字段在缓存回填前后保持不变。
- [x] 好友资料页原有的实时状态覆盖不受影响 —— 新增 `cachedRestorePrefersFriendSnapshotOverNavigationPresence` 断言好友快照仍优先于导航入参;原有 `currentFriendSnapshotOverridesCachedOfflinePresence`、`cachedProfileClearsHistoricalPresence` 全部保留并通过。
- [x] 不把上次运行的历史位置当成实时状态显示 —— `asCachedOffline` 保持不变,缓存自身的 presence 依旧被丢弃。
- [x] 状态圆点的颜色、实心/空心画法与其它页面的状态显示不变 —— 未改动 `UserStateIcon` / `UserStatusRow` 及任何 UI 组件,本次改动只落在资料页的状态合并逻辑与其单元测试。

## 自测结果

- `:composeApp:desktopTest --tests ...UserProfileCachedPresenceTest`(修复前):`cachedRestoreKeepsLivePresenceWhenUserIsNotInFriendMap` FAILED,确认新增测试能复现缺陷。
- `:composeApp:desktopTest --tests io.github.vrcmteam.vrcm.presentation.screens.user.*`:BUILD SUCCESSFUL。
- `:composeApp:desktopTest`(全量):688 个用例,仅 `DesktopWindowTitleBarLocaleTest.windowControlLabelsUseTheLatestLanguage` 失败,是本机无图形会话导致的 HeadlessException,与本次改动无关(项目知识库已记录)。
- `:composeApp:testDebugUnitTest`:BUILD SUCCESSFUL(commonTest 由 Android 目标共享,需一并跑)。
- 强制门禁 `check-gate.sh implement-issue 74`:quality gate: pass。

## 代码逻辑图

资料页在线状态的多来源写入顺序(节点为真实类与状态):

```mermaid
sequenceDiagram
    participant Nav as 上一页面导航入参
    participant VM as UserProfileScreenModel
    participant Auth as AuthService.currentUserState
    participant Cache as UserProfileCacheStore
    participant Friend as FriendService.friendState
    participant Api as UsersApi
    Nav->>VM: userProfileVO 携带点击瞬间的实时 presence
    VM->>VM: _userState 初始化
    Auth-->>VM: CurrentUserData 快照, 仅自己的资料页
    VM->>VM: _userState 更新为当前账号 presence
    Cache-->>VM: UserProfileCache 静态资料, presence 已被抹成离线
    VM->>VM: mergeCachedProfile 保留 _userState 现有 presence
    Friend-->>VM: FriendData 实时快照
    VM->>VM: withCurrentFriendPresence 覆盖 presence
    Api-->>VM: UserData 网络结果
    VM->>VM: _userState 更新为网络结果
```

## 实现假设清单

- 假设:issue 描述的闪烁出现在该资料页此前已被访问过、本地存有缓存的情况下;首次访问没有缓存时不会闪。依据:缓存只在 `refreshUser` 成功后由 `saveCache` 写入,回填走 `UserProfileCacheStore.load`,无缓存则整段逻辑不执行。
- 假设:VRChat 的 `/users/{id}` 对网页端在线用户返回 state=active、location=offline,因此网络结果不会把状态重新判成离线。依据:issue 描述最终稳定显示为空心圆,且 `UserProfileVo(UserData)` 只在 state=offline 时降级为 Offline;这两点互相印证。
- 假设:导航入参携带的在线状态不会比本地缓存更旧。依据:各入口的 `UserProfileVo` 均由 `friendState` 或 `currentUserState` 的实时快照构造(HomeScreen.kt:151、FriendLocationPager.kt:118 等);没有实时来源的入口(深链、世界页作者等)传入的本就是默认离线,与缓存抹离线后的表现一致,不构成回退。
- 假设:`_userState` 在缓存回填协程执行时已被当前账号状态填充。依据:`viewModelScope` 使用 Main.immediate,`currentUserState` 是 StateFlow,订阅即刻拿到当前值,而缓存读取要经过 Room 挂起调用,必定更晚返回。

## 实现说明(供追问)

### 关键决策

- 选择在缓存合并处把在线状态排除出去,而不是给自己的资料页单独加一个跳过分支(历史上曾经这么做过,后来在重构中丢失)。前者是一条对所有用户都成立的规则:缓存只负责静态资料,在线状态只认实时来源;后者只堵住自己这一种情况,换个不在好友表里的用户又会重现。
- 没有用延迟回填、二次刷新或忽略首帧之类的办法遮盖,那样只会把闪烁挪到别的时机。
- 合并逻辑抽成纯函数 `mergeCachedProfile`,与文件里既有的 `asCachedOffline`、`withCurrentFriendPresence`、`resolveFriendLocation` 保持同一种写法,并使既有的单元测试文件能直接覆盖这条规则。

### 覆盖的场景

- 自己的资料页:重复进入(有缓存)时在线状态不再回退成离线。
- 好友资料页:好友实时快照仍然优先,行为与修复前一致。
- 不在好友表里的普通用户:进入时若已有实时状态则保留,没有则维持离线直到接口返回。
- 缓存中的历史位置依旧被丢弃,不会被当成实时位置展示。
- 网络失败时页面保留进入时已知的状态,不会因为读缓存而显示成离线。

### 明确未覆盖

- 缓存回填与网络结果之间的先后竞争:如果网络结果先到、Room 缓存后到,简介、群组、世界等静态字段仍会被缓存覆盖一次。本次只保证在线状态不被覆盖(网络结果的 presence 会被保留)。实际时序里 Room 读取远快于一次 HTTP 请求,这种竞争基本不会发生,补上它需要额外的跨线程标志,超出本 issue 范围。
- 真机验证:本仓库白名单真机上已安装的 debug 包签名与本地构建产物不一致,无法在保留登录态的前提下覆盖安装,而该缺陷必须登录且处于网页端在线状态才能复现,因此本次没有真机截图,仅有单元测试与代码时序分析。
- 首次打开、没有本地缓存时的表现不在本次改动范围内(本来就不会闪)。
- 其它页面(首页、好友列表、位置页)的状态显示未做任何改动。

### 关键假设

见上方实现假设清单。