### PR TITLE
fix(home): 修复房间卡片收起动画卡顿

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/compoments/LocationCard.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/LocationCard.kt
@@ -52,11 +52,10 @@ fun LocationCard(
         tonalElevation = (-2).dp,
         shape = MaterialTheme.shapes.large
     ) {
-        Box(modifier = Modifier.animateContentSize()) {
+        Box {
             Column(
                 modifier = Modifier.padding(8.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
             Row(
                 modifier = Modifier
@@ -143,7 +142,13 @@ fun LocationCard(
                 }
             }
             AnimatedVisibility(isSelected) {
-                content(friendList)
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp),
+                ) {
+                    content(friendList)
+                }
             }
             }
             if (isCurrentUserLocation) {


### PR DESCRIPTION
关联 #72

## 实现思路

房间卡片原先由展开内容自身的收起动画和外层高度动画同时处理同一次高度变化。展开内容缩到零后，它与主卡片之间的间距才退出，外层动画因此又补做一小段收缩，形成末尾停顿。

本次移除外层重复的高度动画，并把展开区域上方的间距放进展开内容内部。收起时，好友列表和间距会由同一段动画一起缩到零，卡片高度一次恢复到折叠状态。卡片内容、样式、数据刷新和点击行为均未调整。

## 验收标准自查

- [x] 首页“处于房间内”的卡片展开后再次收起时，高度连续、一次恢复到折叠状态，不再在末尾等待第二段高度收缩。验证方式：展开内容及其上方间距现由同一个收起过程控制，外层重复高度动画已移除。
- [x] 卡片原有展开内容、折叠内容、“我的位置”标记和点击行为保持不变。验证方式：最终差异仅调整展开区域的布局动画边界，两个调用页面的状态和回调均未改动。
- [x] 相同房间卡片在个人资料页保持一致的收起行为。验证方式：首页与个人资料页继续复用同一个房间卡片组件。

## 自测结果

- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:compileKotlinDesktop`：`BUILD SUCCESSFUL`。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:assembleDebug`：在隔离 worktree 补齐被 Git 忽略的本机 SDK 路径后，`BUILD SUCCESSFUL`。
- `ANDROID_HOME=/home/ubuntu/Android/Sdk ~/ai/bin/check-gate.sh implement-issue 72`：最终提交 `a553a8d` 返回 `quality gate: pass`，其中 Android Debug 打包成功。
- `git diff --check`：通过。
- 未新增测试：这是纯视觉布局动画调整，仓库规范不允许用仅复述框架动画或样式数值的低价值测试代替真实行为验证。

## 自评风险点

本轮未在已登录真机上安装并录制收起动画，肉眼流畅度仍需评审者在有房间好友数据的首页实际展开、收起卡片确认。修改位于首页与个人资料页共用的卡片，因此两处都会获得相同修复；这是预期行为，但也请一并观察资料页卡片。

## 代码逻辑图

本次无复杂代码逻辑，无需图示。

## 实现假设清单

本次无未经验证假设。首页与个人资料页复用同一房间卡片的事实已从现有调用代码核实；动画尾段由两层高度处理和独立间距退出共同造成，可由当前布局结构直接确认。

## 实现说明(供追问)

### 关键决策

让展开内容和它上方的间距由同一段收起动画控制，并移除处理同一高度变化的外层动画。没有通过缩短时长、增加延迟或硬编码高度掩盖停顿，因为这些做法仍会保留两段式变化。

### 覆盖的场景

覆盖首页和个人资料页的房间卡片；房间内有一位或多位好友、卡片带“我的位置”标记，以及用户连续点击后以最新展开状态重新执行动画的情况，都继续使用同一套现有状态逻辑。

### 明确未覆盖

未调整卡片文案、颜色、尺寸、圆角、好友排序、房间数据刷新、页面跳转和其他首页卡片。未执行登录态真机视觉录屏，自动化验证范围为 Desktop 编译、Android Debug 完整打包和强制质量门禁。

### 关键假设

无。