### PR TITLE
feat(gallery): 自动裁剪拍立得下载白边

### DIFF
--- a/composeApp/src/commonMain/kotlin/di/modules/PresentationModule.kt
+++ b/composeApp/src/commonMain/kotlin/di/modules/PresentationModule.kt
@@ -110,6 +110,7 @@ val presentationModule: Module = module {
         PrintImageEditorScreenModel(
             source = session.source,
             prepared = session.prepared,
+            croppedSource = session.croppedSource,
             calculator = get(),
             processor = when (session.target) {
                 ImageEditorTarget.Print -> get()

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/GalleryTabPager.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/GalleryTabPager.kt
@@ -19,8 +19,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -28,7 +26,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -85,8 +82,6 @@ sealed class GalleryTabPager(private val tagType: FileTagType) {
         val isVrcPlus = galleryScreenModel.isVrcPlus
         val coroutineScope = rememberCoroutineScope()
         var isPreparing by remember { mutableStateOf(false) }
-        var cropDownloadedPrintBorder by remember { mutableStateOf(true) }
-        val currentCropDownloadedPrintBorder by rememberUpdatedState(cropDownloadedPrintBorder)
 
         LaunchedEffect(isPrint, editorSessionStore) {
             if (isPrint) {
@@ -166,11 +161,8 @@ sealed class GalleryTabPager(private val tagType: FileTagType) {
                             )
                             return@launch
                         }
-                        val preparedSource = printImageProcessor
-                            .preparePrint(
-                                source = source,
-                                cropDownloadedPrintBorder = currentCropDownloadedPrintBorder,
-                            )
+                        val preparedSources = printImageProcessor
+                            .preparePrint(source)
                             .getOrElse { failure ->
                                 if (failure is CancellationException) throw failure
                                 val message = (failure as? PrintImageFailure)
@@ -180,8 +172,9 @@ sealed class GalleryTabPager(private val tagType: FileTagType) {
                                 return@launch
                             }
                         handoffPreparedImageToEditor(
-                            source = preparedSource.source,
-                            prepared = preparedSource.prepared,
+                            source = preparedSources.original.source,
+                            prepared = preparedSources.original.prepared,
+                            croppedSource = preparedSources.cropped,
                             sessionStore = editorSessionStore,
                             push = { sessionId ->
                                 navigator.push(PrintImageEditorScreen(sessionId))
@@ -215,33 +208,6 @@ sealed class GalleryTabPager(private val tagType: FileTagType) {
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                if (isPrint && !hasSelection) {
-                    Surface(
-                        modifier = Modifier.weight(1f, fill = false),
-                        shape = MaterialTheme.shapes.small,
-                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                        tonalElevation = 6.dp,
-                        shadowElevation = 3.dp,
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(start = 12.dp, end = 8.dp),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Text(
-                                text = locale.galleryTabCropPrintBorder,
-                                modifier = Modifier.weight(1f, fill = false),
-                                style = MaterialTheme.typography.labelLarge,
-                            )
-                            Switch(
-                                checked = cropDownloadedPrintBorder,
-                                onCheckedChange = { cropDownloadedPrintBorder = it },
-                                enabled = isVrcPlus && !isPreparing,
-                            )
-                        }
-                    }
-                }
-
                 FloatingActionButton(
                     onClick = {
                         if (hasSelection) {

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/GalleryTabPager.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/GalleryTabPager.kt
@@ -161,17 +161,19 @@ sealed class GalleryTabPager(private val tagType: FileTagType) {
                             )
                             return@launch
                         }
-                        val prepared = printImageProcessor.prepare(source).getOrElse { failure ->
-                            if (failure is CancellationException) throw failure
-                            val message = (failure as? PrintImageFailure)
-                                ?.localizedMessage(locale)
-                                ?: locale.printEditorDecodeFailed
-                            SharedFlowCentre.toastText.emit(ToastText.Error(message))
-                            return@launch
-                        }
+                        val preparedSource = printImageProcessor
+                            .preparePrint(source)
+                            .getOrElse { failure ->
+                                if (failure is CancellationException) throw failure
+                                val message = (failure as? PrintImageFailure)
+                                    ?.localizedMessage(locale)
+                                    ?: locale.printEditorDecodeFailed
+                                SharedFlowCentre.toastText.emit(ToastText.Error(message))
+                                return@launch
+                            }
                         handoffPreparedImageToEditor(
-                            source = source,
-                            prepared = prepared,
+                            source = preparedSource.source,
+                            prepared = preparedSource.prepared,
                             sessionStore = editorSessionStore,
                             push = { sessionId ->
                                 navigator.push(PrintImageEditorScreen(sessionId))

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/GalleryTabPager.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/GalleryTabPager.kt
@@ -19,6 +19,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -26,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -82,6 +85,8 @@ sealed class GalleryTabPager(private val tagType: FileTagType) {
         val isVrcPlus = galleryScreenModel.isVrcPlus
         val coroutineScope = rememberCoroutineScope()
         var isPreparing by remember { mutableStateOf(false) }
+        var cropDownloadedPrintBorder by remember { mutableStateOf(true) }
+        val currentCropDownloadedPrintBorder by rememberUpdatedState(cropDownloadedPrintBorder)
 
         LaunchedEffect(isPrint, editorSessionStore) {
             if (isPrint) {
@@ -162,7 +167,10 @@ sealed class GalleryTabPager(private val tagType: FileTagType) {
                             return@launch
                         }
                         val preparedSource = printImageProcessor
-                            .preparePrint(source)
+                            .preparePrint(
+                                source = source,
+                                cropDownloadedPrintBorder = currentCropDownloadedPrintBorder,
+                            )
                             .getOrElse { failure ->
                                 if (failure is CancellationException) throw failure
                                 val message = (failure as? PrintImageFailure)
@@ -200,61 +208,93 @@ sealed class GalleryTabPager(private val tagType: FileTagType) {
 
             // 选中时为红色删除按钮，否则为上传按钮
             val hasSelection = galleryScreenModel.hasSelection(tagType)
-            FloatingActionButton(
-                onClick = {
-                    if (hasSelection) {
-                        // 删除选中项
-                        if (isPrint) {
-                            galleryScreenModel.deleteSelectedPrints(
-                                deletingMessage = locale.galleryTabDeleting,
-                                successMessage = locale.galleryTabDeleteSuccess,
-                                failedMessagePrefix = locale.galleryTabDeleteFailed,
-                            )
-                        } else {
-                            galleryScreenModel.deleteSelectedFiles(
-                                tagType = tagType,
-                                deletingMessage = locale.galleryTabDeleting,
-                                successMessage = locale.galleryTabDeleteSuccess,
-                                failedMessagePrefix = locale.galleryTabDeleteFailed,
-                            )
-                        }
-                    } else if (!isPreparing && isVrcPlus) {
-                        if (isPrint) printImagePicker.launch() else simpleImagePicker.launch()
-                    }
-                },
+            Row(
                 modifier = Modifier
                     .align(Alignment.BottomEnd)
                     .padding(16.dp),
-                containerColor = when {
-                    hasSelection -> MaterialTheme.colorScheme.error
-                    isVrcPlus -> MaterialTheme.colorScheme.primaryContainer
-                    else -> MaterialTheme.colorScheme.surfaceVariant
-                },
-                contentColor = when {
-                    hasSelection -> MaterialTheme.colorScheme.onError
-                    isVrcPlus -> MaterialTheme.colorScheme.onPrimaryContainer
-                    else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
-                },
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                if (isPreparing) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(24.dp),
-                        strokeWidth = 2.dp,
-                    )
-                } else if (hasSelection) {
-                    Icon(
-                        imageVector = Icons.Default.Delete,
-                        contentDescription = locale.galleryTabDelete,
-                    )
-                } else {
-                    Icon(
-                        imageVector = AppIcons.Publish,
-                        contentDescription = if (isVrcPlus) {
-                            locale.galleryTabUploadImage
-                        } else {
-                            locale.galleryTabVrcPlusRequired
-                        },
-                    )
+                if (isPrint && !hasSelection) {
+                    Surface(
+                        modifier = Modifier.weight(1f, fill = false),
+                        shape = MaterialTheme.shapes.small,
+                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        tonalElevation = 6.dp,
+                        shadowElevation = 3.dp,
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(start = 12.dp, end = 8.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = locale.galleryTabCropPrintBorder,
+                                modifier = Modifier.weight(1f, fill = false),
+                                style = MaterialTheme.typography.labelLarge,
+                            )
+                            Switch(
+                                checked = cropDownloadedPrintBorder,
+                                onCheckedChange = { cropDownloadedPrintBorder = it },
+                                enabled = isVrcPlus && !isPreparing,
+                            )
+                        }
+                    }
+                }
+
+                FloatingActionButton(
+                    onClick = {
+                        if (hasSelection) {
+                            // 删除选中项
+                            if (isPrint) {
+                                galleryScreenModel.deleteSelectedPrints(
+                                    deletingMessage = locale.galleryTabDeleting,
+                                    successMessage = locale.galleryTabDeleteSuccess,
+                                    failedMessagePrefix = locale.galleryTabDeleteFailed,
+                                )
+                            } else {
+                                galleryScreenModel.deleteSelectedFiles(
+                                    tagType = tagType,
+                                    deletingMessage = locale.galleryTabDeleting,
+                                    successMessage = locale.galleryTabDeleteSuccess,
+                                    failedMessagePrefix = locale.galleryTabDeleteFailed,
+                                )
+                            }
+                        } else if (!isPreparing && isVrcPlus) {
+                            if (isPrint) printImagePicker.launch() else simpleImagePicker.launch()
+                        }
+                    },
+                    containerColor = when {
+                        hasSelection -> MaterialTheme.colorScheme.error
+                        isVrcPlus -> MaterialTheme.colorScheme.primaryContainer
+                        else -> MaterialTheme.colorScheme.surfaceVariant
+                    },
+                    contentColor = when {
+                        hasSelection -> MaterialTheme.colorScheme.onError
+                        isVrcPlus -> MaterialTheme.colorScheme.onPrimaryContainer
+                        else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                    },
+                ) {
+                    if (isPreparing) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(24.dp),
+                            strokeWidth = 2.dp,
+                        )
+                    } else if (hasSelection) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = locale.galleryTabDelete,
+                        )
+                    } else {
+                        Icon(
+                            imageVector = AppIcons.Publish,
+                            contentDescription = if (isVrcPlus) {
+                                locale.galleryTabUploadImage
+                            } else {
+                                locale.galleryTabVrcPlusRequired
+                            },
+                        )
+                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PreviewBitmapReleaseController.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PreviewBitmapReleaseController.kt
@@ -3,9 +3,14 @@ package io.github.vrcmteam.vrcm.presentation.screens.gallery.editor
 import androidx.compose.ui.graphics.ImageBitmap
 
 internal class PreviewBitmapReleaseController(
-    private val bitmap: ImageBitmap,
+    bitmaps: List<ImageBitmap>,
     private val releaseBitmap: (ImageBitmap) -> Unit,
 ) {
+    private val bitmaps = buildList {
+        bitmaps.forEach { bitmap ->
+            if (none { it === bitmap }) add(bitmap)
+        }
+    }
     private var displayLeaseCount = 0
     private var disposalRequested = false
     private var released = false
@@ -30,6 +35,19 @@ internal class PreviewBitmapReleaseController(
     private fun releaseIfUnused() {
         if (!disposalRequested || displayLeaseCount != 0 || released) return
         released = true
-        releaseBitmap(bitmap)
+        var releaseFailure: Throwable? = null
+        bitmaps.forEach { bitmap ->
+            try {
+                releaseBitmap(bitmap)
+            } catch (cause: Throwable) {
+                val primaryFailure = releaseFailure
+                if (primaryFailure == null) {
+                    releaseFailure = cause
+                } else if (cause !== primaryFailure) {
+                    primaryFailure.addSuppressed(cause)
+                }
+            }
+        }
+        releaseFailure?.let { throw it }
     }
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorNavigation.kt
@@ -8,42 +8,78 @@ internal fun handoffPreparedImageToEditor(
     prepared: PreparedImage,
     sessionStore: PrintImageEditorSessionStore,
     target: ImageEditorTarget = ImageEditorTarget.Print,
+    croppedSource: PreparedImageSource? = null,
     releasePreview: (ImageBitmap) -> Unit = ::releasePlatformImageBitmap,
     push: (String) -> Unit,
 ) {
     var sessionId: String? = null
     try {
-        val createdSessionId = sessionStore.create(source, prepared, target)
+        val createdSessionId = sessionStore.create(
+            source = source,
+            prepared = prepared,
+            target = target,
+            croppedSource = croppedSource,
+        )
         sessionId = createdSessionId
         push(createdSessionId)
     } catch (cause: CancellationException) {
-        releaseFailedNavigationPreview(prepared, sessionId, sessionStore, cause, releasePreview)
+        releaseFailedNavigationPreviews(
+            prepared,
+            croppedSource,
+            sessionId,
+            sessionStore,
+            cause,
+            releasePreview,
+        )
         throw cause
     } catch (cause: Exception) {
-        releaseFailedNavigationPreview(prepared, sessionId, sessionStore, cause, releasePreview)
+        releaseFailedNavigationPreviews(
+            prepared,
+            croppedSource,
+            sessionId,
+            sessionStore,
+            cause,
+            releasePreview,
+        )
         throw cause
     } catch (cause: Error) {
-        releaseFailedNavigationPreview(prepared, sessionId, sessionStore, cause, releasePreview)
+        releaseFailedNavigationPreviews(
+            prepared,
+            croppedSource,
+            sessionId,
+            sessionStore,
+            cause,
+            releasePreview,
+        )
         throw cause
     }
 }
 
-private fun releaseFailedNavigationPreview(
+private fun releaseFailedNavigationPreviews(
     prepared: PreparedImage,
+    croppedSource: PreparedImageSource?,
     sessionId: String?,
     sessionStore: PrintImageEditorSessionStore,
     primaryFailure: Throwable,
     releasePreview: (ImageBitmap) -> Unit,
 ) {
     sessionId?.let(sessionStore::discard)
-    try {
-        releasePreview(prepared.preview)
-    } catch (releaseFailure: CancellationException) {
-        primaryFailure.addNavigationReleaseFailure(releaseFailure)
-    } catch (releaseFailure: Exception) {
-        primaryFailure.addNavigationReleaseFailure(releaseFailure)
-    } catch (releaseFailure: Error) {
-        primaryFailure.addNavigationReleaseFailure(releaseFailure)
+    val previews = buildList {
+        add(prepared.preview)
+        croppedSource?.prepared?.preview
+            ?.takeIf { it !== prepared.preview }
+            ?.let(::add)
+    }
+    previews.forEach { preview ->
+        try {
+            releasePreview(preview)
+        } catch (releaseFailure: CancellationException) {
+            primaryFailure.addNavigationReleaseFailure(releaseFailure)
+        } catch (releaseFailure: Exception) {
+            primaryFailure.addNavigationReleaseFailure(releaseFailure)
+        } catch (releaseFailure: Error) {
+            primaryFailure.addNavigationReleaseFailure(releaseFailure)
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreen.kt
@@ -213,6 +213,7 @@ class PrintImageEditorScreen(
                 onFlipHorizontal = screenModel::flipHorizontal,
                 onFlipVertical = screenModel::flipVertical,
                 onReset = screenModel::reset,
+                onCropDownloadedPrintBorderChange = screenModel::setCropDownloadedPrintBorder,
                 onFillWhiteBorderChange = screenModel::setFillWhiteBorder,
                 locale = locale,
                 uploadingText = uploadingText,
@@ -242,6 +243,7 @@ private fun PrintEditorContent(
     onFlipHorizontal: () -> Unit,
     onFlipVertical: () -> Unit,
     onReset: (ImageSize) -> Unit,
+    onCropDownloadedPrintBorderChange: (Boolean, ImageSize) -> Unit,
     onFillWhiteBorderChange: (Boolean, ImageSize) -> Unit,
     locale: LocaleStrings,
     uploadingText: String,
@@ -278,6 +280,7 @@ private fun PrintEditorContent(
             onFlipHorizontal = onFlipHorizontal,
             onFlipVertical = onFlipVertical,
             onReset = onReset,
+            onCropDownloadedPrintBorderChange = onCropDownloadedPrintBorderChange,
             onFillWhiteBorderChange = onFillWhiteBorderChange,
             locale = locale,
             fitModeLabel = fitModeLabel,
@@ -415,6 +418,7 @@ private fun PrintEditorControls(
     onFlipHorizontal: () -> Unit,
     onFlipVertical: () -> Unit,
     onReset: (ImageSize) -> Unit,
+    onCropDownloadedPrintBorderChange: (Boolean, ImageSize) -> Unit,
     onFillWhiteBorderChange: (Boolean, ImageSize) -> Unit,
     locale: LocaleStrings,
     fitModeLabel: String,
@@ -432,6 +436,29 @@ private fun PrintEditorControls(
                 Arrangement.spacedBy(10.dp)
             },
         ) {
+            if (state.canCropDownloadedPrintBorder) {
+                Row(
+                    modifier = Modifier
+                        .widthIn(max = 720.dp)
+                        .fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Text(
+                        text = locale.galleryTabCropPrintBorder,
+                        style = MaterialTheme.typography.labelLarge,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Switch(
+                        checked = state.cropDownloadedPrintBorder,
+                        onCheckedChange = {
+                            onCropDownloadedPrintBorderChange(it, viewport)
+                        },
+                        enabled = !state.isBusy && viewport.isValid(),
+                    )
+                }
+            }
+
             Row(
                 modifier = Modifier
                     .widthIn(max = 720.dp)

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreen.kt
@@ -436,29 +436,6 @@ private fun PrintEditorControls(
                 Arrangement.spacedBy(10.dp)
             },
         ) {
-            if (state.canCropDownloadedPrintBorder) {
-                Row(
-                    modifier = Modifier
-                        .widthIn(max = 720.dp)
-                        .fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    Text(
-                        text = locale.galleryTabCropPrintBorder,
-                        style = MaterialTheme.typography.labelLarge,
-                        modifier = Modifier.weight(1f),
-                    )
-                    Switch(
-                        checked = state.cropDownloadedPrintBorder,
-                        onCheckedChange = {
-                            onCropDownloadedPrintBorderChange(it, viewport)
-                        },
-                        enabled = !state.isBusy && viewport.isValid(),
-                    )
-                }
-            }
-
             Row(
                 modifier = Modifier
                     .widthIn(max = 720.dp)
@@ -512,6 +489,29 @@ private fun PrintEditorControls(
                     onCheckedChange = { onFillWhiteBorderChange(it, viewport) },
                     enabled = !state.isBusy && viewport.isValid(),
                 )
+            }
+
+            if (state.canCropDownloadedPrintBorder) {
+                Row(
+                    modifier = Modifier
+                        .widthIn(max = 720.dp)
+                        .fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Text(
+                        text = locale.galleryTabCropPrintBorder,
+                        style = MaterialTheme.typography.labelLarge,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Switch(
+                        checked = state.cropDownloadedPrintBorder,
+                        onCheckedChange = {
+                            onCropDownloadedPrintBorderChange(it, viewport)
+                        },
+                        enabled = !state.isBusy && viewport.isValid(),
+                    )
+                }
             }
 
             FlowRow(

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreenModel.kt
@@ -43,6 +43,8 @@ sealed interface EditorEvent {
 data class PrintImageEditorState(
     val prepared: PreparedImage,
     val transform: CropTransform = CropTransform(),
+    val canCropDownloadedPrintBorder: Boolean = false,
+    val cropDownloadedPrintBorder: Boolean = false,
     val fillWhiteBorder: Boolean = true,
     val phase: EditorPhase = EditorPhase.Ready,
     val error: EditorError? = null,
@@ -52,8 +54,9 @@ data class PrintImageEditorState(
 
 @OptIn(ExperimentalTime::class)
 class PrintImageEditorScreenModel(
-    private val source: SelectedImage,
+    source: SelectedImage,
     prepared: PreparedImage,
+    private val croppedSource: PreparedImageSource? = null,
     private val calculator: CropTransformCalculator,
     private val processor: PrintImageProcessor,
     private val submitter: ImageEditorSubmitter,
@@ -65,7 +68,15 @@ class PrintImageEditorScreenModel(
     private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
     private val releasePreview: (ImageBitmap) -> Unit = ::releasePlatformImageBitmap,
 ) : ViewModel() {
-    private val _state = MutableStateFlow(PrintImageEditorState(prepared = prepared))
+    private val originalSource = PreparedImageSource(source, prepared)
+    private val initialSource = croppedSource ?: originalSource
+    private val _state = MutableStateFlow(
+        PrintImageEditorState(
+            prepared = initialSource.prepared,
+            canCropDownloadedPrintBorder = croppedSource != null,
+            cropDownloadedPrintBorder = croppedSource != null,
+        ),
+    )
     val state: StateFlow<PrintImageEditorState> = _state.asStateFlow()
 
     private val _events = MutableSharedFlow<EditorEvent>(extraBufferCapacity = 1)
@@ -74,9 +85,15 @@ class PrintImageEditorScreenModel(
     private var cachedPng: ByteArray? = null
     private var cachedFileName: String? = null
     private val previewReleaseController = PreviewBitmapReleaseController(
-        bitmap = prepared.preview,
+        bitmaps = listOfNotNull(prepared.preview, croppedSource?.prepared?.preview),
         releaseBitmap = releasePreview,
     )
+
+    init {
+        require(croppedSource == null || target == ImageEditorTarget.Print) {
+            "Only Print editor sessions can provide a cropped source"
+        }
+    }
 
     override fun onCleared() {
         sessionStore.discard(sessionId)
@@ -132,6 +149,37 @@ class PrintImageEditorScreenModel(
         current.constrainToBorderMode(calculator.reset(), viewport)
     }
 
+    fun setCropDownloadedPrintBorder(enabled: Boolean, viewport: ImageSize) {
+        val current = _state.value
+        if (
+            current.isBusy ||
+            !current.canCropDownloadedPrintBorder ||
+            current.cropDownloadedPrintBorder == enabled ||
+            !viewport.isValid()
+        ) {
+            return
+        }
+
+        val nextSource = if (enabled) requireNotNull(croppedSource) else originalSource
+        val zoom = if (current.fillWhiteBorder) {
+            1f
+        } else {
+            calculator.zoomLimits(
+                source = nextSource.prepared.originalSize,
+                viewport = viewport,
+                quarterTurns = 0,
+            ).cover
+        }
+        cachedPng = null
+        cachedFileName = null
+        _state.value = current.copy(
+            prepared = nextSource.prepared,
+            transform = CropTransform(zoom = zoom),
+            cropDownloadedPrintBorder = enabled,
+            error = null,
+        )
+    }
+
     fun setFillWhiteBorder(enabled: Boolean, viewport: ImageSize) {
         val current = _state.value
         if (current.isBusy || !viewport.isValid()) return
@@ -164,6 +212,7 @@ class PrintImageEditorScreenModel(
     fun upload() {
         val current = _state.value
         if (current.isBusy) return
+        val currentSource = current.selectedSource()
 
         val existingPng = cachedPng
         _state.value = current.copy(
@@ -174,7 +223,7 @@ class PrintImageEditorScreenModel(
             var stage = if (existingPng == null) UploadStage.Processing else UploadStage.Uploading
             try {
                 val png = existingPng ?: processor.render(
-                    source = source,
+                    source = currentSource.source,
                     originalSize = current.prepared.originalSize,
                     transform = current.transform,
                     background = target.canvasBackground,
@@ -182,7 +231,10 @@ class PrintImageEditorScreenModel(
                     .getOrThrow()
                     .also {
                         cachedPng = it
-                        cachedFileName = target.uploadFileName(source.fileName, nowMillis())
+                        cachedFileName = target.uploadFileName(
+                            currentSource.source.fileName,
+                            nowMillis(),
+                        )
                     }
 
                 stage = UploadStage.Uploading
@@ -191,7 +243,7 @@ class PrintImageEditorScreenModel(
                     target = target,
                     imageBytes = png,
                     fileName = cachedFileName
-                        ?: target.uploadFileName(source.fileName, nowMillis()),
+                        ?: target.uploadFileName(currentSource.source.fileName, nowMillis()),
                 ).getOrThrow()
 
                 _state.update { it.copy(phase = EditorPhase.Ready, error = null) }
@@ -224,6 +276,9 @@ class PrintImageEditorScreenModel(
 
     private fun workerContext(): CoroutineContext =
         workerExceptionHandler?.let(workerDispatcher::plus) ?: workerDispatcher
+
+    private fun PrintImageEditorState.selectedSource(): PreparedImageSource =
+        if (cropDownloadedPrintBorder) requireNotNull(croppedSource) else originalSource
 
     private inline fun edit(
         viewport: ImageSize? = null,

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorSessionStore.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorSessionStore.kt
@@ -14,6 +14,7 @@ data class PrintImageEditorSession(
     val source: SelectedImage,
     val prepared: PreparedImage,
     val target: ImageEditorTarget,
+    val croppedSource: PreparedImageSource? = null,
 )
 
 class PrintImageEditorSessionStore {
@@ -32,9 +33,13 @@ class PrintImageEditorSessionStore {
         source: SelectedImage,
         prepared: PreparedImage,
         target: ImageEditorTarget = ImageEditorTarget.Print,
+        croppedSource: PreparedImageSource? = null,
     ): String {
+        require(croppedSource == null || target == ImageEditorTarget.Print) {
+            "Only Print editor sessions can provide a cropped source"
+        }
         val id = "image-editor-${nextSessionId++}"
-        sessions[id] = PrintImageEditorSession(source, prepared, target)
+        sessions[id] = PrintImageEditorSession(source, prepared, target, croppedSource)
         return id
     }
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageModels.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageModels.kt
@@ -93,6 +93,12 @@ data class PreparedImageSource(
     val prepared: PreparedImage,
 )
 
+/** Original Print image plus an optional border-cropped editing source. */
+data class PreparedPrintImageSources(
+    val original: PreparedImageSource,
+    val cropped: PreparedImageSource?,
+)
+
 /** Controls whether transparent pixels are preserved or composited onto white. */
 enum class CanvasBackground {
     Transparent,

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageModels.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageModels.kt
@@ -87,6 +87,12 @@ data class PreparedImage(
     val originalSize: ImageSize,
 )
 
+/** Source bytes and preview that use the same editable pixel coordinate space. */
+data class PreparedImageSource(
+    val source: SelectedImage,
+    val prepared: PreparedImage,
+)
+
 /** Controls whether transparent pixels are preserved or composited onto white. */
 enum class CanvasBackground {
     Transparent,

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageProcessor.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageProcessor.kt
@@ -15,12 +15,14 @@ import kotlin.math.roundToInt
 interface PrintImageProcessor {
     suspend fun prepare(source: SelectedImage): Result<PreparedImage>
 
-    /** Optionally removes the known frame from a downloaded Print before editing. */
-    suspend fun preparePrint(
-        source: SelectedImage,
-        cropDownloadedPrintBorder: Boolean = true,
-    ): Result<PreparedImageSource> =
-        prepare(source).map { PreparedImageSource(source, it) }
+    /** Prepares the original Print and, when recognized, a border-cropped editing source. */
+    suspend fun preparePrint(source: SelectedImage): Result<PreparedPrintImageSources> =
+        prepare(source).map {
+            PreparedPrintImageSources(
+                original = PreparedImageSource(source, it),
+                cropped = null,
+            )
+        }
 
     suspend fun render(
         source: SelectedImage,
@@ -42,17 +44,46 @@ class DefaultPrintImageProcessor(
     private val releaseBitmap: (ImageBitmap) -> Unit = ::releasePlatformImageBitmap,
 ) : PrintImageProcessor {
     override suspend fun prepare(source: SelectedImage): Result<PreparedImage> =
-        prepareSource(source, cropDownloadedPrintBorder = false).map(PreparedImageSource::prepared)
+        prepareOriginalSource(source).map(PreparedImageSource::prepared)
 
-    override suspend fun preparePrint(
-        source: SelectedImage,
-        cropDownloadedPrintBorder: Boolean,
-    ): Result<PreparedImageSource> =
-        prepareSource(source, cropDownloadedPrintBorder)
+    override suspend fun preparePrint(source: SelectedImage): Result<PreparedPrintImageSources> {
+        val original = prepareOriginalSource(source).getOrElse { failure ->
+            if (failure is CancellationException) throw failure
+            return Result.failure(failure)
+        }
+        if (original.prepared.originalSize != DownloadedPrintCanvasSize) {
+            return Result.success(
+                PreparedPrintImageSources(
+                    original = original,
+                    cropped = null,
+                ),
+            )
+        }
 
-    private suspend fun prepareSource(
+        return try {
+            Result.success(
+                PreparedPrintImageSources(
+                    original = original,
+                    cropped = cropDownloadedPrint(source, original.prepared.originalSize),
+                ),
+            )
+        } catch (cause: CancellationException) {
+            releaseAfterFailure(original.prepared.preview, cause)
+            throw cause
+        } catch (failure: PrintImageFailure) {
+            releaseAfterFailure(original.prepared.preview, failure)
+            Result.failure(failure)
+        } catch (cause: Exception) {
+            releaseAfterFailure(original.prepared.preview, cause)
+            Result.failure(PrintImageFailure.DecodeFailed(cause))
+        } catch (cause: Error) {
+            releaseAfterFailure(original.prepared.preview, cause)
+            throw cause
+        }
+    }
+
+    private suspend fun prepareOriginalSource(
         source: SelectedImage,
-        cropDownloadedPrintBorder: Boolean,
     ): Result<PreparedImageSource> = try {
         validateSource(source)
         val decoded = decodePreview(source.bytes)
@@ -69,22 +100,14 @@ class DefaultPrintImageProcessor(
             throw cause
         }
 
-        val preparedSource = if (
-            cropDownloadedPrintBorder &&
-            decoded.originalSize == DownloadedPrintCanvasSize
-        ) {
-            releaseBitmap(decoded.bitmap)
-            cropDownloadedPrint(source, decoded.originalSize)
-        } else {
-            handoffOwnedBitmap(decoded.bitmap) {
-                PreparedImageSource(
-                    source = source,
-                    prepared = PreparedImage(
-                        preview = decoded.bitmap,
-                        originalSize = decoded.originalSize,
-                    ),
-                )
-            }
+        val preparedSource = handoffOwnedBitmap(decoded.bitmap) {
+            PreparedImageSource(
+                source = source,
+                prepared = PreparedImage(
+                    preview = decoded.bitmap,
+                    originalSize = decoded.originalSize,
+                ),
+            )
         }
         Result.success(preparedSource)
     } catch (cause: CancellationException) {

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageProcessor.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageProcessor.kt
@@ -15,7 +15,11 @@ import kotlin.math.roundToInt
 interface PrintImageProcessor {
     suspend fun prepare(source: SelectedImage): Result<PreparedImage>
 
-    suspend fun preparePrint(source: SelectedImage): Result<PreparedImageSource> =
+    /** Optionally removes the known frame from a downloaded Print before editing. */
+    suspend fun preparePrint(
+        source: SelectedImage,
+        cropDownloadedPrintBorder: Boolean = true,
+    ): Result<PreparedImageSource> =
         prepare(source).map { PreparedImageSource(source, it) }
 
     suspend fun render(
@@ -40,8 +44,11 @@ class DefaultPrintImageProcessor(
     override suspend fun prepare(source: SelectedImage): Result<PreparedImage> =
         prepareSource(source, cropDownloadedPrintBorder = false).map(PreparedImageSource::prepared)
 
-    override suspend fun preparePrint(source: SelectedImage): Result<PreparedImageSource> =
-        prepareSource(source, cropDownloadedPrintBorder = true)
+    override suspend fun preparePrint(
+        source: SelectedImage,
+        cropDownloadedPrintBorder: Boolean,
+    ): Result<PreparedImageSource> =
+        prepareSource(source, cropDownloadedPrintBorder)
 
     private suspend fun prepareSource(
         source: SelectedImage,

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageProcessor.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageProcessor.kt
@@ -9,10 +9,14 @@ import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.CancellationException
+import kotlin.math.min
 import kotlin.math.roundToInt
 
 interface PrintImageProcessor {
     suspend fun prepare(source: SelectedImage): Result<PreparedImage>
+
+    suspend fun preparePrint(source: SelectedImage): Result<PreparedImageSource> =
+        prepare(source).map { PreparedImageSource(source, it) }
 
     suspend fun render(
         source: SelectedImage,
@@ -33,25 +37,89 @@ class DefaultPrintImageProcessor(
     private val cropRenderPlanner: CropRenderPlanner = CropRenderPlanner(),
     private val releaseBitmap: (ImageBitmap) -> Unit = ::releasePlatformImageBitmap,
 ) : PrintImageProcessor {
-    override suspend fun prepare(source: SelectedImage): Result<PreparedImage> = try {
+    override suspend fun prepare(source: SelectedImage): Result<PreparedImage> =
+        prepareSource(source, cropDownloadedPrintBorder = false).map(PreparedImageSource::prepared)
+
+    override suspend fun preparePrint(source: SelectedImage): Result<PreparedImageSource> =
+        prepareSource(source, cropDownloadedPrintBorder = true)
+
+    private suspend fun prepareSource(
+        source: SelectedImage,
+        cropDownloadedPrintBorder: Boolean,
+    ): Result<PreparedImageSource> = try {
         validateSource(source)
         val decoded = decodePreview(source.bytes)
-        val prepared = handoffOwnedBitmap(decoded.bitmap) {
+        try {
             validateDimensions(decoded.originalSize)
-            PreparedImage(
-                preview = decoded.bitmap,
-                originalSize = decoded.originalSize,
-            )
+        } catch (cause: CancellationException) {
+            releaseAfterFailure(decoded.bitmap, cause)
+            throw cause
+        } catch (cause: Exception) {
+            releaseAfterFailure(decoded.bitmap, cause)
+            throw cause
+        } catch (cause: Error) {
+            releaseAfterFailure(decoded.bitmap, cause)
+            throw cause
         }
-        Result.success(
-            prepared,
-        )
+
+        val preparedSource = if (
+            cropDownloadedPrintBorder &&
+            decoded.originalSize == DownloadedPrintCanvasSize
+        ) {
+            releaseBitmap(decoded.bitmap)
+            cropDownloadedPrint(source, decoded.originalSize)
+        } else {
+            handoffOwnedBitmap(decoded.bitmap) {
+                PreparedImageSource(
+                    source = source,
+                    prepared = PreparedImage(
+                        preview = decoded.bitmap,
+                        originalSize = decoded.originalSize,
+                    ),
+                )
+            }
+        }
+        Result.success(preparedSource)
     } catch (cause: CancellationException) {
         throw cause
     } catch (failure: PrintImageFailure) {
         Result.failure(failure)
     } catch (cause: Exception) {
         Result.failure(PrintImageFailure.DecodeFailed(cause))
+    }
+
+    private suspend fun cropDownloadedPrint(
+        source: SelectedImage,
+        originalSize: ImageSize,
+    ): PreparedImageSource {
+        val cropped = renderCrop(
+            bytes = source.bytes,
+            originalSize = originalSize,
+            transform = DownloadedPrintCanvasSpec.cropToContentTransform(),
+            renderSpec = DownloadedPrintCanvasSpec,
+        )
+        return handoffOwnedBitmap(cropped) {
+            val contentSize = DownloadedPrintCanvasSpec.contentSize
+            if (ImageSize(cropped.width, cropped.height) != contentSize) {
+                throw PrintImageFailure.RenderFailed(
+                    IllegalStateException(
+                        "Downloaded Print crop returned ${cropped.width}x${cropped.height}; " +
+                                "expected ${contentSize.width}x${contentSize.height}",
+                    ),
+                )
+            }
+            val croppedBytes = encodePng(cropped)
+            if (!hasExpectedPngHeader(croppedBytes, contentSize.width, contentSize.height)) {
+                throw PrintImageFailure.EncodeFailed()
+            }
+            PreparedImageSource(
+                source = source.copy(bytes = croppedBytes),
+                prepared = PreparedImage(
+                    preview = cropped,
+                    originalSize = contentSize,
+                ),
+            )
+        }
     }
 
     override suspend fun render(
@@ -412,4 +480,30 @@ class DefaultPrintImageProcessor(
         )
         val IHDR = byteArrayOf(0x49, 0x48, 0x44, 0x52)
     }
+}
+
+private val DownloadedPrintCanvasSpec = PrintCanvasSpec()
+private val DownloadedPrintCanvasSize = ImageSize(
+    width = DownloadedPrintCanvasSpec.canvasWidth,
+    height = DownloadedPrintCanvasSpec.canvasHeight,
+)
+
+private val PrintCanvasSpec.contentSize: ImageSize
+    get() = ImageSize(contentWidth, contentHeight)
+
+private fun PrintCanvasSpec.cropToContentTransform(): CropTransform {
+    // Map the known inner photo rectangle onto the crop output without duplicating its offsets.
+    val fitScale = min(
+        contentWidth.toFloat() / canvasWidth,
+        contentHeight.toFloat() / canvasHeight,
+    )
+    val sourceCenterX = canvasWidth / 2f
+    val sourceCenterY = canvasHeight / 2f
+    val contentCenterX = contentOffsetX + contentWidth / 2f
+    val contentCenterY = contentOffsetY + contentHeight / 2f
+    return CropTransform(
+        centerOffsetX = (sourceCenterX - contentCenterX) / contentWidth,
+        centerOffsetY = (sourceCenterY - contentCenterY) / contentHeight,
+        zoom = 1f / fitScale,
+    )
 }

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
@@ -239,6 +239,7 @@ sealed class LocaleStrings {
     open val galleryTabDeleting: String = "Deleting..."
     open val galleryTabDeleteSuccess: String = "Deleted successfully"
     open val galleryTabDeleteFailed: String = "Delete failed"
+    open val galleryTabCropPrintBorder: String = "Crop Print border"
     // Print image editor
     open val printEditorTitle: String = "Edit Print"
     open val printEditorBack: String = "Back"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
@@ -224,6 +224,7 @@ internal object LocaleStringsJa : LocaleStrings() {
     override val galleryTabDeleting = "削除中..."
     override val galleryTabDeleteSuccess = "削除しました"
     override val galleryTabDeleteFailed = "削除に失敗しました"
+    override val galleryTabCropPrintBorder = "プリントの外枠をトリミング"
     // Print image editor
     override val printEditorTitle = "プリントを編集"
     override val printEditorBack = "戻る"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
@@ -223,6 +223,7 @@ internal object LocaleStringsZhHans : LocaleStrings() {
     override val galleryTabDeleting = "正在删除..."
     override val galleryTabDeleteSuccess = "删除成功"
     override val galleryTabDeleteFailed = "删除失败"
+    override val galleryTabCropPrintBorder = "裁剪拍立得白边"
     // Print image editor
     override val printEditorTitle = "编辑拍立得"
     override val printEditorBack = "返回"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
@@ -223,6 +223,7 @@ internal object LocaleStringsZhHant : LocaleStrings() {
     override val galleryTabDeleting = "正在刪除..."
     override val galleryTabDeleteSuccess = "刪除成功"
     override val galleryTabDeleteFailed = "刪除失敗"
+    override val galleryTabCropPrintBorder = "裁剪拍立得白邊"
     // Print image editor
     override val printEditorTitle = "編輯拍立得"
     override val printEditorBack = "返回"

--- a/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/PrintImageEditorNavigationTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/PrintImageEditorNavigationTest.kt
@@ -24,6 +24,10 @@ class PrintImageEditorNavigationTest {
             handoffPreparedImageToEditor(
                 source = SelectedImage("photo.png", byteArrayOf(1)),
                 prepared = PreparedImage(NavigationTestBitmap, ImageSize(16, 9)),
+                croppedSource = PreparedImageSource(
+                    SelectedImage("photo.png", byteArrayOf(2)),
+                    PreparedImage(CroppedNavigationTestBitmap, ImageSize(16, 9)),
+                ),
                 sessionStore = store,
                 releasePreview = {
                     released += it
@@ -35,7 +39,10 @@ class PrintImageEditorNavigationTest {
 
         assertSame(failure, thrown)
         assertTrue(releaseFailure in thrown.suppressedExceptions)
-        assertEquals(listOf<ImageBitmap>(NavigationTestBitmap), released)
+        assertEquals(
+            listOf<ImageBitmap>(NavigationTestBitmap, CroppedNavigationTestBitmap),
+            released,
+        )
         assertNull(store.get("image-editor-0"))
     }
 
@@ -69,6 +76,10 @@ class PrintImageEditorNavigationTest {
         handoffPreparedImageToEditor(
             source = SelectedImage("photo.png", byteArrayOf(1)),
             prepared = PreparedImage(NavigationTestBitmap, ImageSize(16, 9)),
+            croppedSource = PreparedImageSource(
+                SelectedImage("photo.png", byteArrayOf(2)),
+                PreparedImage(CroppedNavigationTestBitmap, ImageSize(16, 9)),
+            ),
             sessionStore = store,
             releasePreview = released::add,
             push = { pushedSessionId = it },
@@ -76,10 +87,34 @@ class PrintImageEditorNavigationTest {
 
         assertEquals(emptyList(), released)
         assertSame(NavigationTestBitmap, store.get(requireNotNull(pushedSessionId))?.prepared?.preview)
+        assertSame(
+            CroppedNavigationTestBitmap,
+            store.get(requireNotNull(pushedSessionId))?.croppedSource?.prepared?.preview,
+        )
     }
 }
 
 private data object NavigationTestBitmap : ImageBitmap {
+    override val width: Int = 16
+    override val height: Int = 9
+    override val colorSpace: ColorSpace = ColorSpaces.Srgb
+    override val hasAlpha: Boolean = true
+    override val config: ImageBitmapConfig = ImageBitmapConfig.Argb8888
+
+    override fun readPixels(
+        buffer: IntArray,
+        startX: Int,
+        startY: Int,
+        width: Int,
+        height: Int,
+        bufferOffset: Int,
+        stride: Int,
+    ) = Unit
+
+    override fun prepareToDraw() = Unit
+}
+
+private data object CroppedNavigationTestBitmap : ImageBitmap {
     override val width: Int = 16
     override val height: Int = 9
     override val colorSpace: ColorSpace = ColorSpaces.Srgb

--- a/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreenModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreenModelTest.kt
@@ -23,10 +23,12 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.yield
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class PrintImageEditorScreenModelTest : MainDispatcherTest() {
@@ -177,6 +179,69 @@ class PrintImageEditorScreenModelTest : MainDispatcherTest() {
     }
 
     @Test
+    fun downloadedPrintCropSwitchChangesPreviewImmediatelyAndResetsTransform() {
+        val processor = FakePrintImageProcessor { _, _, _ -> Result.success(PNG_BYTES) }
+        val uploader = FakePrintUploader { _, _ -> Result.success(PrintData("print")) }
+        val croppedSource = PreparedImageSource(
+            source = SelectedImage("source.jpg", byteArrayOf(9)),
+            prepared = PreparedImage(CroppedTestImageBitmap, ImageSize(1_920, 1_080)),
+        )
+        val model = createModel(
+            processor,
+            uploader,
+            originalSize = ImageSize(2_048, 1_440),
+            croppedSource = croppedSource,
+        )
+
+        assertTrue(model.state.value.canCropDownloadedPrintBorder)
+        assertTrue(model.state.value.cropDownloadedPrintBorder)
+        assertSame(CroppedTestImageBitmap, model.state.value.prepared.preview)
+
+        model.panAndZoom(VIEWPORT, panX = 40f, panY = 0f, zoomChange = 1.5f)
+        model.setCropDownloadedPrintBorder(false, VIEWPORT)
+
+        assertFalse(model.state.value.cropDownloadedPrintBorder)
+        assertSame(TestImageBitmap, model.state.value.prepared.preview)
+        assertEquals(CropTransform(), model.state.value.transform)
+
+        model.setCropDownloadedPrintBorder(true, VIEWPORT)
+
+        assertTrue(model.state.value.cropDownloadedPrintBorder)
+        assertSame(CroppedTestImageBitmap, model.state.value.prepared.preview)
+        assertEquals(CropTransform(), model.state.value.transform)
+    }
+
+    @Test
+    fun cropSwitchInvalidatesRenderedPngAndUploadsTheSelectedSource() = runBlocking {
+        val processor = FakePrintImageProcessor { _, _, _ -> Result.success(PNG_BYTES) }
+        val uploader = FakePrintUploader { _, _ -> Result.failure(IllegalStateException("offline")) }
+        val croppedSource = PreparedImageSource(
+            source = SelectedImage("source.jpg", byteArrayOf(9)),
+            prepared = PreparedImage(CroppedTestImageBitmap, ImageSize(1_920, 1_080)),
+        )
+        val model = createModel(
+            processor,
+            uploader,
+            originalSize = ImageSize(2_048, 1_440),
+            croppedSource = croppedSource,
+        )
+
+        model.upload()
+        yield()
+        model.setCropDownloadedPrintBorder(false, VIEWPORT)
+        model.upload()
+        yield()
+
+        assertEquals(2, processor.renderCount)
+        assertContentEquals(byteArrayOf(9), processor.sources[0].bytes)
+        assertContentEquals(byteArrayOf(1), processor.sources[1].bytes)
+        assertEquals(
+            listOf(ImageSize(1_920, 1_080), ImageSize(2_048, 1_440)),
+            processor.originalSizes,
+        )
+    }
+
+    @Test
     fun disablingWhiteBorderUsesCoverAsTheMinimumZoom() {
         val processor = FakePrintImageProcessor { _, _, _ -> Result.success(PNG_BYTES) }
         val uploader = FakePrintUploader { _, _ -> Result.success(PrintData("print")) }
@@ -314,11 +379,16 @@ class PrintImageEditorScreenModelTest : MainDispatcherTest() {
         val store = PrintImageEditorSessionStore()
         val source = SelectedImage("source.jpg", byteArrayOf(1))
         val prepared = PreparedImage(TestImageBitmap, ImageSize(1_920, 1_080))
+        val croppedSource = PreparedImageSource(
+            source.copy(bytes = byteArrayOf(9)),
+            PreparedImage(CroppedTestImageBitmap, ImageSize(1_920, 1_080)),
+        )
         val released = mutableListOf<ImageBitmap>()
-        val sessionId = store.create(source, prepared)
+        val sessionId = store.create(source, prepared, croppedSource = croppedSource)
         val model = PrintImageEditorScreenModel(
             source = source,
             prepared = prepared,
+            croppedSource = croppedSource,
             calculator = CropTransformCalculator(),
             processor = FakePrintImageProcessor { _, _, _ -> Result.success(PNG_BYTES) },
             submitter = PrintUploaderSubmitter(
@@ -336,15 +406,20 @@ class PrintImageEditorScreenModelTest : MainDispatcherTest() {
         clearViewModel(model)
 
         assertNull(store.get(sessionId))
-        assertEquals(listOf<ImageBitmap>(TestImageBitmap), released)
+        assertEquals(listOf<ImageBitmap>(TestImageBitmap, CroppedTestImageBitmap), released)
     }
 
     @Test
     fun disposingEditorDefersPreviewReleaseUntilExitFrameIsGone() {
         val released = mutableListOf<ImageBitmap>()
+        val croppedSource = PreparedImageSource(
+            SelectedImage("source.jpg", byteArrayOf(9)),
+            PreparedImage(CroppedTestImageBitmap, ImageSize(1_920, 1_080)),
+        )
         val model = PrintImageEditorScreenModel(
             source = SelectedImage("source.jpg", byteArrayOf(1)),
             prepared = PreparedImage(TestImageBitmap, ImageSize(1_920, 1_080)),
+            croppedSource = croppedSource,
             calculator = CropTransformCalculator(),
             processor = FakePrintImageProcessor { _, _, _ -> Result.success(PNG_BYTES) },
             submitter = PrintUploaderSubmitter(
@@ -362,7 +437,7 @@ class PrintImageEditorScreenModelTest : MainDispatcherTest() {
 
         assertEquals(emptyList(), released)
         model.releasePreviewDisplayLease()
-        assertEquals(listOf<ImageBitmap>(TestImageBitmap), released)
+        assertEquals(listOf<ImageBitmap>(TestImageBitmap, CroppedTestImageBitmap), released)
     }
 
     @Test
@@ -414,11 +489,13 @@ class PrintImageEditorScreenModelTest : MainDispatcherTest() {
         processor: PrintImageProcessor,
         uploader: PrintUploader,
         originalSize: ImageSize = ImageSize(1_920, 1_080),
+        croppedSource: PreparedImageSource? = null,
         workerDispatcher: CoroutineDispatcher = Dispatchers.Unconfined,
         workerExceptionHandler: CoroutineExceptionHandler? = null,
     ) = PrintImageEditorScreenModel(
         source = SelectedImage("source.jpg", byteArrayOf(1)),
         prepared = PreparedImage(TestImageBitmap, originalSize),
+        croppedSource = croppedSource,
         calculator = CropTransformCalculator(),
         processor = processor,
         submitter = PrintUploaderSubmitter(uploader),
@@ -464,10 +541,31 @@ private data object TestImageBitmap : ImageBitmap {
     override fun prepareToDraw() = Unit
 }
 
+private data object CroppedTestImageBitmap : ImageBitmap {
+    override val width: Int = 16
+    override val height: Int = 9
+    override val colorSpace: ColorSpace = ColorSpaces.Srgb
+    override val hasAlpha: Boolean = true
+    override val config: ImageBitmapConfig = ImageBitmapConfig.Argb8888
+
+    override fun readPixels(
+        buffer: IntArray,
+        startX: Int,
+        startY: Int,
+        width: Int,
+        height: Int,
+        bufferOffset: Int,
+        stride: Int,
+    ) = error("The editor state-machine tests do not read preview pixels")
+
+    override fun prepareToDraw() = Unit
+}
+
 private class FakePrintImageProcessor(
     private val renderBlock: suspend (SelectedImage, ImageSize, CropTransform) -> Result<ByteArray>,
 ) : PrintImageProcessor {
     var renderCount = 0
+    val sources = mutableListOf<SelectedImage>()
     val originalSizes = mutableListOf<ImageSize>()
     val backgrounds = mutableListOf<CanvasBackground>()
 
@@ -481,6 +579,7 @@ private class FakePrintImageProcessor(
         background: CanvasBackground,
     ): Result<ByteArray> {
         renderCount++
+        sources += source
         originalSizes += originalSize
         backgrounds += background
         return renderBlock(source, originalSize, transform)

--- a/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/PrintImageEditorSessionStoreTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/PrintImageEditorSessionStoreTest.kt
@@ -19,11 +19,16 @@ class PrintImageEditorSessionStoreTest {
         val store = PrintImageEditorSessionStore()
         val source = SelectedImage("source.jpg", byteArrayOf(1, 2, 3))
         val prepared = PreparedImage(SessionTestImageBitmap, ImageSize(16, 9))
+        val croppedSource = PreparedImageSource(
+            source.copy(bytes = byteArrayOf(4, 5, 6)),
+            PreparedImage(CroppedSessionTestImageBitmap, ImageSize(12, 9)),
+        )
 
-        val id = store.create(source, prepared)
+        val id = store.create(source, prepared, croppedSource = croppedSource)
 
         assertEquals(source, store.get(id)?.source)
         assertEquals(prepared, store.get(id)?.prepared)
+        assertEquals(croppedSource, store.get(id)?.croppedSource)
         store.discard(id)
         assertNull(store.get(id))
     }
@@ -85,6 +90,26 @@ class PrintImageEditorSessionStoreTest {
 
 private data object SessionTestImageBitmap : ImageBitmap {
     override val width: Int = 16
+    override val height: Int = 9
+    override val colorSpace: ColorSpace = ColorSpaces.Srgb
+    override val hasAlpha: Boolean = true
+    override val config: ImageBitmapConfig = ImageBitmapConfig.Argb8888
+
+    override fun readPixels(
+        buffer: IntArray,
+        startX: Int,
+        startY: Int,
+        width: Int,
+        height: Int,
+        bufferOffset: Int,
+        stride: Int,
+    ) = error("Session store tests do not read preview pixels")
+
+    override fun prepareToDraw() = Unit
+}
+
+private data object CroppedSessionTestImageBitmap : ImageBitmap {
+    override val width: Int = 12
     override val height: Int = 9
     override val colorSpace: ColorSpace = ColorSpaces.Srgb
     override val hasAlpha: Boolean = true

--- a/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/PrintImageProcessorTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/PrintImageProcessorTest.kt
@@ -18,6 +18,7 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
@@ -124,42 +125,19 @@ abstract class PrintImageProcessorContractTest {
             releaseBitmap = released::add,
         )
 
-        val preparedSource = processor.preparePrint(source).getOrThrow()
+        val preparedSources = processor.preparePrint(source).getOrThrow()
+        val cropped = requireNotNull(preparedSources.cropped)
 
-        assertContentEquals(croppedBytes, preparedSource.source.bytes)
-        assertEquals(ImageSize(1_920, 1_080), preparedSource.prepared.originalSize)
+        assertSame(source, preparedSources.original.source)
+        assertSame(PreviewOwnershipTestBitmap, preparedSources.original.prepared.preview)
+        assertEquals(ImageSize(2_048, 1_440), preparedSources.original.prepared.originalSize)
+        assertContentEquals(croppedBytes, cropped.source.bytes)
+        assertEquals(ImageSize(1_920, 1_080), cropped.prepared.originalSize)
         assertEquals(ImageSize(1_920, 1_080), codec.encodedSize)
         assertEquals(
             PixelRect(left = 64, top = 69, right = 1_984, bottom = 1_149),
             CropRenderPlanner().plan(codec.cropRequests.single()).visibleSourceBounds,
         )
-        assertEquals(listOf<ImageBitmap>(PreviewOwnershipTestBitmap), released)
-    }
-
-    @Test
-    fun disabledDownloadedPrintBorderCropKeepsOriginalForEditing() = runBlocking {
-        val source = SelectedImage("downloaded-print.png", byteArrayOf(1))
-        val released = mutableListOf<ImageBitmap>()
-        val codec = FakePlatformImageCodec(
-            originalSize = ImageSize(2_048, 1_440),
-            allowDecode = true,
-            decodedBitmap = PreviewOwnershipTestBitmap,
-        )
-        val processor = DefaultPrintImageProcessor(
-            codec = codec,
-            releaseBitmap = released::add,
-        )
-
-        val preparedSource = processor.preparePrint(
-            source = source,
-            cropDownloadedPrintBorder = false,
-        ).getOrThrow()
-
-        assertSame(source, preparedSource.source)
-        assertSame(PreviewOwnershipTestBitmap, preparedSource.prepared.preview)
-        assertEquals(ImageSize(2_048, 1_440), preparedSource.prepared.originalSize)
-        assertEquals(emptyList(), codec.cropRequests)
-        assertEquals(emptyList(), codec.encodeLimits)
         assertEquals(emptyList(), released)
     }
 
@@ -173,11 +151,12 @@ abstract class PrintImageProcessorContractTest {
         )
         val processor = DefaultPrintImageProcessor(codec = codec)
 
-        val preparedSource = processor.preparePrint(source).getOrThrow()
+        val preparedSources = processor.preparePrint(source).getOrThrow()
 
-        assertSame(source, preparedSource.source)
-        assertSame(PreviewOwnershipTestBitmap, preparedSource.prepared.preview)
-        assertEquals(ImageSize(2_047, 1_440), preparedSource.prepared.originalSize)
+        assertSame(source, preparedSources.original.source)
+        assertSame(PreviewOwnershipTestBitmap, preparedSources.original.prepared.preview)
+        assertEquals(ImageSize(2_047, 1_440), preparedSources.original.prepared.originalSize)
+        assertNull(preparedSources.cropped)
         assertEquals(emptyList(), codec.cropRequests)
         assertEquals(emptyList(), codec.encodeLimits)
     }

--- a/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/PrintImageProcessorTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/PrintImageProcessorTest.kt
@@ -137,6 +137,33 @@ abstract class PrintImageProcessorContractTest {
     }
 
     @Test
+    fun disabledDownloadedPrintBorderCropKeepsOriginalForEditing() = runBlocking {
+        val source = SelectedImage("downloaded-print.png", byteArrayOf(1))
+        val released = mutableListOf<ImageBitmap>()
+        val codec = FakePlatformImageCodec(
+            originalSize = ImageSize(2_048, 1_440),
+            allowDecode = true,
+            decodedBitmap = PreviewOwnershipTestBitmap,
+        )
+        val processor = DefaultPrintImageProcessor(
+            codec = codec,
+            releaseBitmap = released::add,
+        )
+
+        val preparedSource = processor.preparePrint(
+            source = source,
+            cropDownloadedPrintBorder = false,
+        ).getOrThrow()
+
+        assertSame(source, preparedSource.source)
+        assertSame(PreviewOwnershipTestBitmap, preparedSource.prepared.preview)
+        assertEquals(ImageSize(2_048, 1_440), preparedSource.prepared.originalSize)
+        assertEquals(emptyList(), codec.cropRequests)
+        assertEquals(emptyList(), codec.encodeLimits)
+        assertEquals(emptyList(), released)
+    }
+
+    @Test
     fun nonPrintDimensionsEnterTheEditorUnchanged() = runBlocking {
         val source = SelectedImage("regular-photo.png", byteArrayOf(1))
         val codec = FakePlatformImageCodec(

--- a/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/PrintImageProcessorTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/PrintImageProcessorTest.kt
@@ -14,6 +14,7 @@ import io.github.vrcmteam.vrcm.network.api.files.data.FileTagType
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
@@ -105,6 +106,74 @@ abstract class PrintImageProcessorContractTest {
 
         assertSame(PreviewOwnershipTestBitmap, prepared.preview)
         assertEquals(emptyList(), released)
+    }
+
+    @Test
+    fun downloadedPrintBorderIsRemovedBeforeEditing() = runBlocking {
+        val source = SelectedImage("downloaded-print.png", byteArrayOf(1))
+        val croppedBytes = pngHeader(width = 1_920, height = 1_080)
+        val released = mutableListOf<ImageBitmap>()
+        val codec = FakePlatformImageCodec(
+            originalSize = ImageSize(2_048, 1_440),
+            encodedBytes = croppedBytes,
+            allowDecode = true,
+            decodedBitmap = PreviewOwnershipTestBitmap,
+        )
+        val processor = DefaultPrintImageProcessor(
+            codec = codec,
+            releaseBitmap = released::add,
+        )
+
+        val preparedSource = processor.preparePrint(source).getOrThrow()
+
+        assertContentEquals(croppedBytes, preparedSource.source.bytes)
+        assertEquals(ImageSize(1_920, 1_080), preparedSource.prepared.originalSize)
+        assertEquals(ImageSize(1_920, 1_080), codec.encodedSize)
+        assertEquals(
+            PixelRect(left = 64, top = 69, right = 1_984, bottom = 1_149),
+            CropRenderPlanner().plan(codec.cropRequests.single()).visibleSourceBounds,
+        )
+        assertEquals(listOf<ImageBitmap>(PreviewOwnershipTestBitmap), released)
+    }
+
+    @Test
+    fun nonPrintDimensionsEnterTheEditorUnchanged() = runBlocking {
+        val source = SelectedImage("regular-photo.png", byteArrayOf(1))
+        val codec = FakePlatformImageCodec(
+            originalSize = ImageSize(2_047, 1_440),
+            allowDecode = true,
+            decodedBitmap = PreviewOwnershipTestBitmap,
+        )
+        val processor = DefaultPrintImageProcessor(codec = codec)
+
+        val preparedSource = processor.preparePrint(source).getOrThrow()
+
+        assertSame(source, preparedSource.source)
+        assertSame(PreviewOwnershipTestBitmap, preparedSource.prepared.preview)
+        assertEquals(ImageSize(2_047, 1_440), preparedSource.prepared.originalSize)
+        assertEquals(emptyList(), codec.cropRequests)
+        assertEquals(emptyList(), codec.encodeLimits)
+    }
+
+    @Test
+    fun downloadedPrintCropFailureReleasesDecodedPreview() = runBlocking {
+        val failure = PrintImageFailure.RenderFailed(IllegalStateException("crop"))
+        val released = mutableListOf<ImageBitmap>()
+        val codec = FakePlatformImageCodec(
+            originalSize = ImageSize(2_048, 1_440),
+            allowDecode = true,
+            decodedBitmap = PreviewOwnershipTestBitmap,
+            renderFailure = failure,
+        )
+        val processor = DefaultPrintImageProcessor(
+            codec = codec,
+            releaseBitmap = released::add,
+        )
+
+        val result = processor.preparePrint(SelectedImage("downloaded-print.png", byteArrayOf(1)))
+
+        assertSame(failure, result.exceptionOrNull())
+        assertEquals(listOf<ImageBitmap>(PreviewOwnershipTestBitmap), released)
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/presentation/screens/gallery/editor/PrintImageProcessorTest.kt
+++ b/composeApp/src/desktopTest/kotlin/presentation/screens/gallery/editor/PrintImageProcessorTest.kt
@@ -31,13 +31,15 @@ class PrintImageProcessorTest : PrintImageProcessorContractTest() {
             releasePlatformImageBitmap(downloadedPrint)
         }
 
-        val preparedSource = DefaultPrintImageProcessor(codec)
+        val preparedSources = DefaultPrintImageProcessor(codec)
             .preparePrint(SelectedImage("downloaded-print.png", sourceBytes))
             .getOrThrow()
+        val preparedSource = requireNotNull(preparedSources.cropped)
         val previewPixels = try {
             preparedSource.prepared.preview.toPixelMap()
         } finally {
             releasePlatformImageBitmap(preparedSource.prepared.preview)
+            releasePlatformImageBitmap(preparedSources.original.prepared.preview)
         }
         val decodedSource = codec.decode(
             preparedSource.source.bytes,

--- a/composeApp/src/desktopTest/kotlin/presentation/screens/gallery/editor/PrintImageProcessorTest.kt
+++ b/composeApp/src/desktopTest/kotlin/presentation/screens/gallery/editor/PrintImageProcessorTest.kt
@@ -12,6 +12,54 @@ import kotlin.test.assertEquals
 
 class PrintImageProcessorTest : PrintImageProcessorContractTest() {
     @Test
+    fun downloadedPrintUsesTheInnerPhotoForPreviewAndSourceBytes() = runBlocking {
+        val codec = DesktopPlatformImageCodec()
+        val downloadedPrint = ImageBitmap(width = 2_048, height = 1_440, hasAlpha = false)
+        Canvas(downloadedPrint).apply {
+            drawRect(
+                rect = Rect(0f, 0f, 2_048f, 1_440f),
+                paint = Paint().apply { color = Color.White },
+            )
+            drawRect(
+                rect = Rect(64f, 69f, 1_984f, 1_149f),
+                paint = Paint().apply { color = Color.Red },
+            )
+        }
+        val sourceBytes = try {
+            codec.encodePng(downloadedPrint)
+        } finally {
+            releasePlatformImageBitmap(downloadedPrint)
+        }
+
+        val preparedSource = DefaultPrintImageProcessor(codec)
+            .preparePrint(SelectedImage("downloaded-print.png", sourceBytes))
+            .getOrThrow()
+        val previewPixels = try {
+            preparedSource.prepared.preview.toPixelMap()
+        } finally {
+            releasePlatformImageBitmap(preparedSource.prepared.preview)
+        }
+        val decodedSource = codec.decode(
+            preparedSource.source.bytes,
+            DecodeRequest(maxDimension = 2_048, maxPixels = 4_000_000L),
+        )
+        val sourcePixels = try {
+            decodedSource.bitmap.toPixelMap()
+        } finally {
+            releasePlatformImageBitmap(decodedSource.bitmap)
+        }
+
+        assertEquals(ImageSize(1_920, 1_080), preparedSource.prepared.originalSize)
+        assertEquals(ImageSize(1_920, 1_080), decodedSource.originalSize)
+        listOf(previewPixels, sourcePixels).forEach { pixels ->
+            assertOpaqueRed(pixels[0, 0])
+            assertOpaqueRed(pixels[1_919, 0])
+            assertOpaqueRed(pixels[0, 1_079])
+            assertOpaqueRed(pixels[1_919, 1_079])
+        }
+    }
+
+    @Test
     fun portraitImageIsCenteredWithOpaqueWhiteSidePadding() = runBlocking {
         val codec = DesktopPlatformImageCodec()
         val source = ImageBitmap(width = 9, height = 16, hasAlpha = false)


### PR DESCRIPTION
关联 #76

## 实现思路

Print 图片选择后会同时准备原图和（仅在尺寸恰好为 2048×1440 时）去掉白边的 1920×1080 图片。进入上传照片的编辑页面后，编辑器在“自动填充白边”下方显示“裁剪拍立得白边”开关，默认开启；用户切换开关时，预览会立即在原图和裁后图之间切换，当前编辑会重置为居中适配，避免把一种尺寸的缩放和平移套到另一种尺寸。最终上传使用当前开关选中的图片和编辑结果。

其他尺寸没有第二份裁剪源，编辑器不显示该开关，继续沿用原图和现有预览，不影响 Gallery、Icon、Emoji、Sticker 或头像封面。两份预览由同一套生命周期规则管理，页面退出或导航失败时都会在安全时机释放。

## 验收自查

- [x] 2048×1440 的拍立得下载图片会自动去掉外圈白边，只保留 1920×1080 内容区。共享合同测试验证实际读取范围为 (64,69)-(1984,1149)。
- [x] 编辑器中提供“裁剪拍立得白边”开关，位置在“自动填充白边”下方，默认开启；切换时实时更换预览源。
- [x] 编辑预览、缩放、旋转、翻转和最终上传使用同一份当前选定图片。Desktop 真实编解码测试同时检查裁后预览像素和裁后 PNG。
- [x] 非拍立得尺寸不会误裁剪，也不会显示裁剪开关。合同测试使用 2047×1440 图片确认不触发裁剪或重新编码。
- [x] 切换图片源会按关联 issue 提出人确认的 A 行为，丢弃已有旋转、镜像、缩放和平移并重置居中适配，同时使旧上传缓存失效；后续上传使用新的源图和尺寸。编辑器状态测试覆盖了重置与两次上传的源选择。
- [x] 裁剪失败时停止进入编辑器并释放已解码预览；原图和裁后图在页面销毁、退出动画结束及导航失败时均正确释放。
- [x] 非 Print 图片入口保持原有行为。

## 自测结果

- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PrintImageProcessorTest --tests io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PrintImageEditorScreenModelTest --tests io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PrintImageEditorNavigationTest --tests io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PrintImageEditorSessionStoreTest --tests io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStringsStructureTest --console=plain`：BUILD SUCCESSFUL。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:testDebugUnitTest --tests io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PrintImageProcessorTest --tests io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PrintImageEditorScreenModelTest --tests io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PrintImageEditorNavigationTest --tests io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PrintImageEditorSessionStoreTest --console=plain`：首次执行达到 10 分钟门限且停在增量编译，原样重跑后 BUILD SUCCESSFUL。
- 开关位置调整后重跑上述两条定向命令（Desktop 与 Android Debug 单元测试）：均为 BUILD SUCCESSFUL。
- `~/ai/bin/check-gate.sh fix-review 83`：最终提交 08fae57 返回 quality gate: pass，Android assembleDebug 为 BUILD SUCCESSFUL。
- `git diff --check`：通过。
- 本轮未执行真实 VRChat 账号上传、Android/iOS 真机或自动截图验证；完整 Desktop 套件的既有无图形环境 HeadlessException 仍未作为本轮定向证据。控件排列顺序属于视觉改动，窄屏与大字体下的最终观感仍需人工验收。

## 自评风险点

- 识别依据是精确尺寸，不扫描白色像素。因此即使不是拍立得下载格式，只要图片恰好为 2048×1440 且开关开启，也会按同一区域裁剪；用户可以在编辑器中即时关闭并继续使用原图。
- 标准拍立得进入编辑器前会额外保留一份原图预览和一份裁后预览，短时间内内存占用高于普通图片；现有文件、像素和输出限制仍会先行生效。
- 本轮没有真实账号线上上传、Android/iOS 真机或自动截图证据；窄屏和大字体的最终视觉效果仍需人工验收。

## 代码逻辑图

```mermaid
sequenceDiagram
    participant Picker as GalleryTabPager Print 选择器
    participant Processor as DefaultPrintImageProcessor
    participant Store as PrintImageEditorSessionStore
    participant Editor as PrintImageEditorScreenModel
    participant Submit as ImageEditorSubmitter
    Picker->>Processor: preparePrint(source)
    Processor-->>Picker: original + optional cropped source
    Picker->>Store: 创建编辑 session（保留两份源）
    Store-->>Editor: 注入原图与裁后图
    Editor->>Editor: 默认选择裁后图（仅标准拍立得）
    Editor->>Editor: 切换开关，替换 preview/source，重置 transform，清除缓存
    Editor->>Processor: render(当前选定 source, transform)
    Processor-->>Editor: PNG
    Editor->>Submit: 上传当前编辑结果
```

## 实现假设清单

- 关联 issue 提出者 @yourmoln 在人审评论中明确要求：开关放在上传照片的编辑页面，并可实时切换裁剪前后图片；据此改变首次送审的无开关行为。其后续评论进一步要求把该开关放到“自动填充白边”下方，当前实现按此排列。
- 开关默认开启的依据是 VRCX 当前实现中 `printCropBorder` 初始值为 true；裁剪尺寸和坐标由 VRCX `CropPrint` 与 VRCM 现有 `PrintCanvasSpec` 共同核实。
- “实时切换”按无需重新选择文件、切换后立即更新编辑器预览理解。关联 issue 提出人 @yourmoln 随后明确选择 A：切换时不保留已有编辑，因此实现会丢弃旋转、镜像、缩放和平移并重置为居中适配；该确认不改变裁剪范围或上传合同。
- 本次无其他未经验证假设。

## 实现说明(供追问)

### 关键决策

在进入编辑器前同时准备原图和裁后图，在编辑器内切换源。这样开关位置符合最新人审要求，且切换无需重新解码或重新选择文件。切换源时按关联 issue 提出人 @yourmoln 确认的 A 行为丢弃全部已有编辑并重置居中适配。原图是 2048×1440、裁后图是 1920×1080；清空旋转、镜像、缩放和平移可让每次切换后的画面回到一致、可预期的初始状态。

识别方式继续沿用 VRCX 的精确尺寸规则，并复用项目现有拍立得画布规格；没有扫描白色像素，避免把照片内容误当边框。

### 覆盖的场景

覆盖标准 2048×1440 拍立得默认裁后、编辑器内关闭和重新开启、非匹配尺寸不显示开关、编辑操作后切换、上传缓存失效、裁剪/编码失败、页面退出动画位图释放和导航失败释放，以及普通 Gallery/头像入口保持原流程。

### 明确未覆盖

不识别其他尺寸或颜色近似的白边，不增加手动坐标调整或持久化开关设置，不改变下载、删除或非 Print 图片流程。本轮未执行真实账号线上上传、真机操作与自动截图验收。

### 关键假设

需求授权来自关联 issue 提出者 @yourmoln 的人审评论；其后续回复“A，不保留”明确授权切换源图时丢弃已有编辑。VRCX 的默认值和现有 PrintCanvasSpec 的尺寸/偏移可作为裁剪合同依据。
