### PR TITLE
feat(favorites): 补齐模型与隐藏世界收藏管理

### DIFF
--- a/composeApp/src/commonMain/kotlin/di/modules/PresentationModule.kt
+++ b/composeApp/src/commonMain/kotlin/di/modules/PresentationModule.kt
@@ -7,6 +7,8 @@ import coil3.network.ktor3.KtorNetworkFetcherFactory
 import coil3.request.crossfade
 import coil3.util.DebugLogger
 import io.github.vrcmteam.vrcm.presentation.screens.auth.AuthScreenModel
+import io.github.vrcmteam.vrcm.presentation.favorites.AuthenticatedFavoriteEntrySource
+import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntrySource
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.AvatarProfileScreenModel
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.AvatarCoverLimits
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.AvatarEditor
@@ -133,10 +135,11 @@ val presentationModule: Module = module {
     viewModelOf(::SearchListPagerModel)
     viewModelOf(::WorldProfileScreenModel)
     viewModelOf(::GroupProfileScreenModel)
+    singleOf(::AuthenticatedFavoriteEntrySource) bind FavoriteEntrySource::class
     singleOf(::NetworkAvatarProfileLoader) bind AvatarProfileLoader::class
     singleOf(::NetworkAvatarSelector) bind AvatarSelector::class
     singleOf(::NetworkAvatarEditor) bind AvatarEditor::class
-    viewModel { AvatarProfileScreenModel(get(), get(), avatarEditor = get()) }
+    viewModel { AvatarProfileScreenModel(get(), get(), get(), avatarEditor = get()) }
     viewModelOf(::RecentWorldsScreenModel)
     single<ImageLoader> { imageLoaderDefinition(it) }
     configThemeColor()

--- a/composeApp/src/commonMain/kotlin/presentation/compoments/StandardSearchList.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/StandardSearchList.kt
@@ -14,11 +14,16 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
+import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
 import io.github.vrcmteam.vrcm.network.api.attributes.IUser
 import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
 import io.github.vrcmteam.vrcm.network.api.groups.data.LimitedGroup
@@ -31,6 +36,7 @@ import io.github.vrcmteam.vrcm.presentation.screens.group.data.GroupProfileVo
 import io.github.vrcmteam.vrcm.presentation.screens.user.UserProfileScreen
 import io.github.vrcmteam.vrcm.presentation.screens.user.data.UserProfileVo
 import io.github.vrcmteam.vrcm.presentation.screens.world.WorldProfileScreen
+import io.github.vrcmteam.vrcm.presentation.screens.world.components.FavoriteGroupBottomSheet
 import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
 import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import kotlinx.coroutines.launch
@@ -72,6 +78,7 @@ fun StandardSearchList(
     val currentNavigator = currentNavigator
     val hiddenModelCannotViewText = strings.hiddenModelCannotView
     val retryLoadMore = onRetryLoadMore
+    var hiddenWorldToManage by remember { mutableStateOf<WorldData?>(null) }
     val onUserClick: (IUser, String) -> Unit = { user, sharedSuffixKey ->
         // 处理用户点击，导航到用户资料页面
         coroutineScope.launch {
@@ -84,8 +91,12 @@ fun StandardSearchList(
     val hiddenWorldCannotViewText = strings.hiddenWorldCannotView
     val onWorldClick: (WorldData, String) -> Unit = { world, sharedSuffixKey ->
         if (world.isHiddenWorld()) {
-            coroutineScope.launch {
-                SharedFlowCentre.toastText.emit(ToastText.Info(hiddenWorldCannotViewText))
+            if (world.favoriteId.isNullOrBlank()) {
+                coroutineScope.launch {
+                    SharedFlowCentre.toastText.emit(ToastText.Info(hiddenWorldCannotViewText))
+                }
+            } else {
+                hiddenWorldToManage = world
             }
         } else {
             // 处理世界点击，导航到世界详情页面
@@ -188,5 +199,24 @@ fun StandardSearchList(
                 }
             }
         }
+    }
+
+    val worldToManage = hiddenWorldToManage
+    if (worldToManage != null) {
+        FavoriteGroupBottomSheet(
+            isVisible = true,
+            favoriteId = worldToManage.id,
+            favoriteType = FavoriteType.World,
+            favoriteRecordId = worldToManage.favoriteId,
+            allowGroupChange = false,
+            onDismiss = { hiddenWorldToManage = null },
+            onConfirm = { result ->
+                if (result.isSuccess) {
+                    coroutineScope.launch {
+                        doRefresh?.invoke()
+                    }
+                }
+            },
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/presentation/compoments/StandardSearchList.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/StandardSearchList.kt
@@ -79,6 +79,7 @@ fun StandardSearchList(
     val hiddenModelCannotViewText = strings.hiddenModelCannotView
     val retryLoadMore = onRetryLoadMore
     var hiddenWorldToManage by remember { mutableStateOf<WorldData?>(null) }
+    var showHiddenWorldFavoriteSheet by remember { mutableStateOf(false) }
     val onUserClick: (IUser, String) -> Unit = { user, sharedSuffixKey ->
         // 处理用户点击，导航到用户资料页面
         coroutineScope.launch {
@@ -97,6 +98,7 @@ fun StandardSearchList(
                 }
             } else {
                 hiddenWorldToManage = world
+                showHiddenWorldFavoriteSheet = true
             }
         } else {
             // 处理世界点击，导航到世界详情页面
@@ -204,12 +206,15 @@ fun StandardSearchList(
     val worldToManage = hiddenWorldToManage
     if (worldToManage != null) {
         FavoriteGroupBottomSheet(
-            isVisible = true,
+            isVisible = showHiddenWorldFavoriteSheet,
             favoriteId = worldToManage.id,
             favoriteType = FavoriteType.World,
             favoriteRecordId = worldToManage.favoriteId,
             allowGroupChange = false,
-            onDismiss = { hiddenWorldToManage = null },
+            onDismiss = {
+                showHiddenWorldFavoriteSheet = false
+                hiddenWorldToManage = null
+            },
             onConfirm = { result ->
                 if (result.isSuccess) {
                     coroutineScope.launch {

--- a/composeApp/src/commonMain/kotlin/presentation/compoments/StandardSearchList.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/StandardSearchList.kt
@@ -76,10 +76,11 @@ fun StandardSearchList(
     }
     val coroutineScope = rememberCoroutineScope()
     val currentNavigator = currentNavigator
-    val hiddenModelCannotViewText = strings.hiddenModelCannotView
     val retryLoadMore = onRetryLoadMore
     var hiddenWorldToManage by remember { mutableStateOf<WorldData?>(null) }
     var showHiddenWorldFavoriteSheet by remember { mutableStateOf(false) }
+    var hiddenAvatarToManage by remember { mutableStateOf<AvatarData?>(null) }
+    var showHiddenAvatarFavoriteSheet by remember { mutableStateOf(false) }
     val onUserClick: (IUser, String) -> Unit = { user, sharedSuffixKey ->
         // 处理用户点击，导航到用户资料页面
         coroutineScope.launch {
@@ -114,9 +115,8 @@ fun StandardSearchList(
     val onAvatarClick: (AvatarData, String) -> Unit = { avatar, sharedSuffixKey ->
         // 处理模型点击，导航到模型详情页面
         if (avatar.releaseStatus == "hidden") {
-            coroutineScope.launch {
-                SharedFlowCentre.toastText.emit(ToastText.Info(hiddenModelCannotViewText))
-            }
+            hiddenAvatarToManage = avatar
+            showHiddenAvatarFavoriteSheet = true
         } else {
             coroutineScope.launch {
                 currentNavigator push AvatarProfileScreen(
@@ -214,6 +214,27 @@ fun StandardSearchList(
             onDismiss = {
                 showHiddenWorldFavoriteSheet = false
                 hiddenWorldToManage = null
+            },
+            onConfirm = { result ->
+                if (result.isSuccess) {
+                    coroutineScope.launch {
+                        doRefresh?.invoke()
+                    }
+                }
+            },
+        )
+    }
+
+    val avatarToManage = hiddenAvatarToManage
+    if (avatarToManage != null) {
+        FavoriteGroupBottomSheet(
+            isVisible = showHiddenAvatarFavoriteSheet,
+            favoriteId = avatarToManage.id,
+            favoriteType = FavoriteType.Avatar,
+            allowGroupChange = false,
+            onDismiss = {
+                showHiddenAvatarFavoriteSheet = false
+                hiddenAvatarToManage = null
             },
             onConfirm = { result ->
                 if (result.isSuccess) {

--- a/composeApp/src/commonMain/kotlin/presentation/favorites/FavoriteEntryState.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/favorites/FavoriteEntryState.kt
@@ -1,10 +1,13 @@
 package io.github.vrcmteam.vrcm.presentation.favorites
 
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
 import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteData
 import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteGroupData
 import io.github.vrcmteam.vrcm.service.AuthService
 import io.github.vrcmteam.vrcm.service.FavoriteService
+import io.github.vrcmteam.vrcm.storage.FavoriteListCacheStore
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -21,16 +24,44 @@ internal interface FavoriteEntrySource {
     fun favoritesByGroup(type: FavoriteType): StateFlow<Map<FavoriteGroupData, List<FavoriteData>>>
 
     suspend fun load(type: FavoriteType): Result<Unit>
+
+    /**
+     * Returns the cached membership for a target, or null when no complete list cache exists.
+     * A false result is meaningful: an existing empty cache proves the target is not favorited.
+     */
+    suspend fun cachedFavorite(type: FavoriteType, favoriteId: String): Boolean? = null
 }
 
 internal class AuthenticatedFavoriteEntrySource(
     private val favoriteService: FavoriteService,
     private val authService: AuthService,
+    private val favoriteListCacheStore: FavoriteListCacheStore,
 ) : FavoriteEntrySource {
     override fun favoritesByGroup(type: FavoriteType) = favoriteService.favoritesByGroup(type)
 
     override suspend fun load(type: FavoriteType): Result<Unit> =
         authService.reTryAuth { favoriteService.loadFavoriteByGroup(type) }
+
+    override suspend fun cachedFavorite(type: FavoriteType, favoriteId: String): Boolean? {
+        val userId = SharedFlowCentre.currentSession.value?.token?.userId ?: return null
+        val cache = try {
+            favoriteListCacheStore.load(userId)
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (_: Exception) {
+            return null
+        } ?: return null
+
+        return when (type) {
+            FavoriteType.World -> cache.favoritedWorlds
+                .asSequence()
+                .flatMap { it.worlds.asSequence() }
+                .any { it.id == favoriteId }
+
+            FavoriteType.Avatar -> cache.favoritedAvatars.any { it.id == favoriteId }
+            FavoriteType.Friend -> null
+        }
+    }
 }
 
 internal sealed interface FavoriteEntryState {
@@ -61,19 +92,25 @@ internal class FavoriteEntryStateModel(
     private val targetId = MutableStateFlow("")
     private val loadState = MutableStateFlow(LoadState.Loading)
     private val latestRequestToken = MutableStateFlow(0L)
+    private val cachedFavorite = MutableStateFlow<Boolean?>(null)
 
     val state: StateFlow<FavoriteEntryState> = combine(
         targetId,
         loadState,
         source.favoritesByGroup(favoriteType),
-    ) { currentTargetId, currentLoadState, favoritesByGroup ->
+        cachedFavorite,
+    ) { currentTargetId, currentLoadState, favoritesByGroup, cachedMembership ->
         when (currentLoadState) {
             LoadState.Loading -> FavoriteEntryState.Loading
             LoadState.Failed -> FavoriteEntryState.LoadFailed
             LoadState.Unavailable -> FavoriteEntryState.Unavailable
             LoadState.Ready -> {
-                val isFavorite = favoritesByGroup.values.any { favorites ->
-                    favorites.any { favorite -> favorite.favoriteId == currentTargetId }
+                val isFavorite = if (favoritesByGroup.isEmpty() && cachedMembership != null) {
+                    cachedMembership
+                } else {
+                    favoritesByGroup.values.any { favorites ->
+                        favorites.any { favorite -> favorite.favoriteId == currentTargetId }
+                    }
                 }
                 if (isFavorite) FavoriteEntryState.Favorited else FavoriteEntryState.NotFavorited
             }
@@ -89,14 +126,32 @@ internal class FavoriteEntryStateModel(
         // 每次切换目标都提升请求代次，之前发出的加载结果不能再改写新目标的状态。
         val requestToken = latestRequestToken.updateAndGet { it + 1 }
         if (favoriteId.isBlank()) {
+            cachedFavorite.value = null
             loadState.value = LoadState.Unavailable
             return
         }
 
+        val currentFavorites = source.favoritesByGroup(favoriteType).value
+        if (currentFavorites.isNotEmpty()) {
+            cachedFavorite.value = null
+            loadState.value = LoadState.Ready
+            return
+        }
+
+        cachedFavorite.value = null
         loadState.value = LoadState.Loading
         scope.launch(dispatcher) {
+            val cachedMembership = source.cachedFavorite(favoriteType, favoriteId)
+            if (requestToken != latestRequestToken.value) return@launch
+            if (cachedMembership != null) {
+                cachedFavorite.value = cachedMembership
+                loadState.value = LoadState.Ready
+                return@launch
+            }
+
             val result = source.load(favoriteType)
             if (requestToken == latestRequestToken.value) {
+                cachedFavorite.value = null
                 loadState.value = if (result.isSuccess) LoadState.Ready else LoadState.Failed
             }
         }

--- a/composeApp/src/commonMain/kotlin/presentation/favorites/FavoriteEntryState.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/favorites/FavoriteEntryState.kt
@@ -1,0 +1,104 @@
+package io.github.vrcmteam.vrcm.presentation.favorites
+
+import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
+import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteData
+import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteGroupData
+import io.github.vrcmteam.vrcm.service.AuthService
+import io.github.vrcmteam.vrcm.service.FavoriteService
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.updateAndGet
+import kotlinx.coroutines.launch
+
+internal interface FavoriteEntrySource {
+    fun favoritesByGroup(type: FavoriteType): StateFlow<Map<FavoriteGroupData, List<FavoriteData>>>
+
+    suspend fun load(type: FavoriteType): Result<Unit>
+}
+
+internal class AuthenticatedFavoriteEntrySource(
+    private val favoriteService: FavoriteService,
+    private val authService: AuthService,
+) : FavoriteEntrySource {
+    override fun favoritesByGroup(type: FavoriteType) = favoriteService.favoritesByGroup(type)
+
+    override suspend fun load(type: FavoriteType): Result<Unit> =
+        authService.reTryAuth { favoriteService.loadFavoriteByGroup(type) }
+}
+
+internal sealed interface FavoriteEntryState {
+    data object Loading : FavoriteEntryState
+    data object Favorited : FavoriteEntryState
+    data object NotFavorited : FavoriteEntryState
+    data object LoadFailed : FavoriteEntryState
+}
+
+/**
+ * Loads a favorite type once per requested target and keeps the entry state synchronized with
+ * later group mutations from the shared favorite service.
+ */
+internal class FavoriteEntryStateModel(
+    private val favoriteType: FavoriteType,
+    private val source: FavoriteEntrySource,
+    private val scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    private enum class LoadState {
+        Loading,
+        Ready,
+        Failed,
+    }
+
+    private val targetId = MutableStateFlow("")
+    private val loadState = MutableStateFlow(LoadState.Loading)
+    private val latestRequestToken = MutableStateFlow(0L)
+
+    val state: StateFlow<FavoriteEntryState> = combine(
+        targetId,
+        loadState,
+        source.favoritesByGroup(favoriteType),
+    ) { currentTargetId, currentLoadState, favoritesByGroup ->
+        when (currentLoadState) {
+            LoadState.Loading -> FavoriteEntryState.Loading
+            LoadState.Failed -> FavoriteEntryState.LoadFailed
+            LoadState.Ready -> {
+                val isFavorite = favoritesByGroup.values.any { favorites ->
+                    favorites.any { favorite -> favorite.favoriteId == currentTargetId }
+                }
+                if (isFavorite) FavoriteEntryState.Favorited else FavoriteEntryState.NotFavorited
+            }
+        }
+    }.stateIn(
+        scope = scope,
+        started = SharingStarted.Eagerly,
+        initialValue = FavoriteEntryState.Loading,
+    )
+
+    fun load(favoriteId: String) {
+        targetId.value = favoriteId
+        if (favoriteId.isBlank()) {
+            loadState.value = LoadState.Failed
+            return
+        }
+
+        val requestToken = latestRequestToken.updateAndGet { it + 1 }
+        loadState.value = LoadState.Loading
+        scope.launch(dispatcher) {
+            val result = source.load(favoriteType)
+            if (requestToken == latestRequestToken.value) {
+                loadState.value = if (result.isSuccess) LoadState.Ready else LoadState.Failed
+            }
+        }
+    }
+
+    fun retry() {
+        load(targetId.value)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/presentation/favorites/FavoriteEntryState.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/favorites/FavoriteEntryState.kt
@@ -86,12 +86,13 @@ internal class FavoriteEntryStateModel(
 
     fun load(favoriteId: String) {
         targetId.value = favoriteId
+        // 每次切换目标都提升请求代次，之前发出的加载结果不能再改写新目标的状态。
+        val requestToken = latestRequestToken.updateAndGet { it + 1 }
         if (favoriteId.isBlank()) {
             loadState.value = LoadState.Unavailable
             return
         }
 
-        val requestToken = latestRequestToken.updateAndGet { it + 1 }
         loadState.value = LoadState.Loading
         scope.launch(dispatcher) {
             val result = source.load(favoriteType)

--- a/composeApp/src/commonMain/kotlin/presentation/favorites/FavoriteEntryState.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/favorites/FavoriteEntryState.kt
@@ -1,5 +1,6 @@
 package io.github.vrcmteam.vrcm.presentation.favorites
 
+import io.github.vrcmteam.vrcm.core.shared.AuthenticatedAccount
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
 import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteData
@@ -90,6 +91,7 @@ internal class FavoriteEntryStateModel(
     private val source: FavoriteEntrySource,
     private val scope: CoroutineScope,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val sessionFlow: StateFlow<AuthenticatedAccount?> = SharedFlowCentre.currentSession,
 ) {
     private enum class LoadState {
         Loading,
@@ -102,11 +104,11 @@ internal class FavoriteEntryStateModel(
     private val loadState = MutableStateFlow(LoadState.Loading)
     private val latestRequestToken = MutableStateFlow(0L)
     private val cachedFavorite = MutableStateFlow<Boolean?>(null)
-    private var observedSessionToken = SharedFlowCentre.currentSession.value?.token
+    private var observedSessionToken = sessionFlow.value?.token
 
     init {
         scope.launch {
-            SharedFlowCentre.currentSession.collect { session ->
+            sessionFlow.collect { session ->
                 val sessionToken = session?.token
                 if (sessionToken != observedSessionToken) {
                     observedSessionToken = sessionToken
@@ -164,13 +166,13 @@ internal class FavoriteEntryStateModel(
             return
         }
 
-        val requestSessionToken = SharedFlowCentre.currentSession.value?.token
+        val requestSessionToken = sessionFlow.value?.token
         cachedFavorite.value = null
         loadState.value = LoadState.Loading
         scope.launch(dispatcher) {
             val cachedMembership = source.cachedFavorite(favoriteType, favoriteId)
             if (requestToken != latestRequestToken.value) return@launch
-            if (requestSessionToken != SharedFlowCentre.currentSession.value?.token) {
+            if (requestSessionToken != sessionFlow.value?.token) {
                 load(favoriteId, allowCurrentGroups = false)
                 return@launch
             }

--- a/composeApp/src/commonMain/kotlin/presentation/favorites/FavoriteEntryState.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/favorites/FavoriteEntryState.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
@@ -53,12 +54,20 @@ internal class AuthenticatedFavoriteEntrySource(
         } ?: return null
 
         return when (type) {
-            FavoriteType.World -> cache.favoritedWorlds
-                .asSequence()
-                .flatMap { it.worlds.asSequence() }
-                .any { it.id == favoriteId }
+            FavoriteType.World -> if (!cache.worldsLoaded) {
+                null
+            } else {
+                cache.favoritedWorlds
+                    .asSequence()
+                    .flatMap { it.worlds.asSequence() }
+                    .any { it.id == favoriteId }
+            }
 
-            FavoriteType.Avatar -> cache.favoritedAvatars.any { it.id == favoriteId }
+            FavoriteType.Avatar -> if (!cache.avatarsLoaded) {
+                null
+            } else {
+                cache.favoritedAvatars.any { it.id == favoriteId }
+            }
             FavoriteType.Friend -> null
         }
     }
@@ -93,6 +102,21 @@ internal class FavoriteEntryStateModel(
     private val loadState = MutableStateFlow(LoadState.Loading)
     private val latestRequestToken = MutableStateFlow(0L)
     private val cachedFavorite = MutableStateFlow<Boolean?>(null)
+    private var observedSessionToken = SharedFlowCentre.currentSession.value?.token
+
+    init {
+        scope.launch {
+            SharedFlowCentre.currentSession.collect { session ->
+                val sessionToken = session?.token
+                if (sessionToken != observedSessionToken) {
+                    observedSessionToken = sessionToken
+                    targetId.value.takeIf { it.isNotBlank() }?.let { favoriteId ->
+                        load(favoriteId, allowCurrentGroups = false)
+                    }
+                }
+            }
+        }
+    }
 
     val state: StateFlow<FavoriteEntryState> = combine(
         targetId,
@@ -121,7 +145,9 @@ internal class FavoriteEntryStateModel(
         initialValue = FavoriteEntryState.Loading,
     )
 
-    fun load(favoriteId: String) {
+    fun load(favoriteId: String) = load(favoriteId, allowCurrentGroups = true)
+
+    private fun load(favoriteId: String, allowCurrentGroups: Boolean) {
         targetId.value = favoriteId
         // 每次切换目标都提升请求代次，之前发出的加载结果不能再改写新目标的状态。
         val requestToken = latestRequestToken.updateAndGet { it + 1 }
@@ -132,17 +158,22 @@ internal class FavoriteEntryStateModel(
         }
 
         val currentFavorites = source.favoritesByGroup(favoriteType).value
-        if (currentFavorites.isNotEmpty()) {
+        if (allowCurrentGroups && currentFavorites.isNotEmpty()) {
             cachedFavorite.value = null
             loadState.value = LoadState.Ready
             return
         }
 
+        val requestSessionToken = SharedFlowCentre.currentSession.value?.token
         cachedFavorite.value = null
         loadState.value = LoadState.Loading
         scope.launch(dispatcher) {
             val cachedMembership = source.cachedFavorite(favoriteType, favoriteId)
             if (requestToken != latestRequestToken.value) return@launch
+            if (requestSessionToken != SharedFlowCentre.currentSession.value?.token) {
+                load(favoriteId, allowCurrentGroups = false)
+                return@launch
+            }
             if (cachedMembership != null) {
                 cachedFavorite.value = cachedMembership
                 loadState.value = LoadState.Ready

--- a/composeApp/src/commonMain/kotlin/presentation/favorites/FavoriteEntryState.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/favorites/FavoriteEntryState.kt
@@ -38,6 +38,7 @@ internal sealed interface FavoriteEntryState {
     data object Favorited : FavoriteEntryState
     data object NotFavorited : FavoriteEntryState
     data object LoadFailed : FavoriteEntryState
+    data object Unavailable : FavoriteEntryState
 }
 
 /**
@@ -54,6 +55,7 @@ internal class FavoriteEntryStateModel(
         Loading,
         Ready,
         Failed,
+        Unavailable,
     }
 
     private val targetId = MutableStateFlow("")
@@ -68,6 +70,7 @@ internal class FavoriteEntryStateModel(
         when (currentLoadState) {
             LoadState.Loading -> FavoriteEntryState.Loading
             LoadState.Failed -> FavoriteEntryState.LoadFailed
+            LoadState.Unavailable -> FavoriteEntryState.Unavailable
             LoadState.Ready -> {
                 val isFavorite = favoritesByGroup.values.any { favorites ->
                     favorites.any { favorite -> favorite.favoriteId == currentTargetId }
@@ -84,7 +87,7 @@ internal class FavoriteEntryStateModel(
     fun load(favoriteId: String) {
         targetId.value = favoriteId
         if (favoriteId.isBlank()) {
-            loadState.value = LoadState.Failed
+            loadState.value = LoadState.Unavailable
             return
         }
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/avatar/AvatarProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/avatar/AvatarProfileScreen.kt
@@ -29,6 +29,7 @@ import org.koin.compose.viewmodel.koinViewModel
 import io.github.vrcmteam.vrcm.presentation.navigation.LocalNavigator
 import io.github.vrcmteam.vrcm.core.extensions.toLocalDate
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
+import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
 import io.github.vrcmteam.vrcm.presentation.compoments.ATooltipBox
 import io.github.vrcmteam.vrcm.presentation.compoments.LocalSharedSuffixKey
 import io.github.vrcmteam.vrcm.presentation.compoments.OfficialUrlShareButton
@@ -47,6 +48,7 @@ import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PrintImagePro
 import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.handoffPreparedImageToEditor
 import io.github.vrcmteam.vrcm.presentation.screens.user.UserProfileScreen
 import io.github.vrcmteam.vrcm.presentation.screens.user.data.UserProfileVo
+import io.github.vrcmteam.vrcm.presentation.screens.world.components.FavoriteGroupBottomSheet
 import io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStrings
 import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
@@ -99,6 +101,7 @@ class AvatarProfileScreen(
         val avatarCoverUpdates by editorSessionStore.avatarCoverUpdates.collectAsState()
         val locale = strings
         var showEditSheet by remember { mutableStateOf(false) }
+        var showFavoriteSheet by remember { mutableStateOf(false) }
 
         LaunchedEffect(screenModel, locale) {
             screenModel.notices.collect { notice ->
@@ -143,11 +146,18 @@ class AvatarProfileScreen(
                     contentMinHeight = contentMinHeight,
                     actionState = actionState,
                     onSelectAvatar = screenModel::selectAvatar,
+                    onFavorite = { showFavoriteSheet = true },
                     canEdit = editState.canEdit,
                     onEdit = { showEditSheet = true },
                 )
             }
         }
+        FavoriteGroupBottomSheet(
+            isVisible = showFavoriteSheet,
+            favoriteId = displayedAvatar.avatarId,
+            favoriteType = FavoriteType.Avatar,
+            onDismiss = { showFavoriteSheet = false },
+        )
         if (showEditSheet && editState.canEdit) {
             AvatarEditSheet(
                 avatar = displayedAvatar,
@@ -179,6 +189,7 @@ private fun AvatarProfileContent(
     contentMinHeight: Dp,
     actionState: AvatarActionState,
     onSelectAvatar: () -> Unit,
+    onFavorite: () -> Unit,
     canEdit: Boolean,
     onEdit: () -> Unit,
 ) {
@@ -221,6 +232,19 @@ private fun AvatarProfileContent(
         state = actionState,
         onClick = onSelectAvatar,
     )
+
+    OutlinedButton(
+        onClick = onFavorite,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Icon(
+            imageVector = AppIcons.Favorite,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(strings.favoriteAvatar)
+    }
 
     if (canEdit) {
         FilledTonalButton(

--- a/composeApp/src/commonMain/kotlin/presentation/screens/avatar/AvatarProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/avatar/AvatarProfileScreen.kt
@@ -52,6 +52,7 @@ import io.github.vrcmteam.vrcm.presentation.screens.world.components.FavoriteGro
 import io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStrings
 import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
+import io.github.vrcmteam.vrcm.service.FavoriteService
 import kotlinx.serialization.Serializable
 import org.koin.compose.koinInject
 
@@ -95,10 +96,12 @@ class AvatarProfileScreen(
         val screenModel: AvatarProfileScreenModel = koinViewModel()
         val imageProcessor: PrintImageProcessor = koinInject()
         val editorSessionStore: PrintImageEditorSessionStore = koinInject()
+        val favoriteService: FavoriteService = koinInject()
         val refreshedAvatar by screenModel.avatarProfileState.collectAsState()
         val actionState by screenModel.actionState.collectAsState()
         val editState by screenModel.editState.collectAsState()
         val avatarCoverUpdates by editorSessionStore.avatarCoverUpdates.collectAsState()
+        val avatarFavoritesByGroup by favoriteService.favoritesByGroup(FavoriteType.Avatar).collectAsState()
         val locale = strings
         var showEditSheet by remember { mutableStateOf(false) }
         var showFavoriteSheet by remember { mutableStateOf(false) }
@@ -118,6 +121,9 @@ class AvatarProfileScreen(
         }
 
         val displayedAvatar = refreshedAvatar ?: avatarProfileVo
+        val isFavorite = avatarFavoritesByGroup.values.any { favorites ->
+            favorites.any { favorite -> favorite.favoriteId == displayedAvatar.avatarId }
+        }
 
         LaunchedEffect(displayedAvatar.avatarId, avatarCoverUpdates) {
             val updated = avatarCoverUpdates[displayedAvatar.avatarId]
@@ -147,6 +153,7 @@ class AvatarProfileScreen(
                     actionState = actionState,
                     onSelectAvatar = screenModel::selectAvatar,
                     onFavorite = { showFavoriteSheet = true },
+                    isFavorite = isFavorite,
                     canEdit = editState.canEdit,
                     onEdit = { showEditSheet = true },
                 )
@@ -190,6 +197,7 @@ private fun AvatarProfileContent(
     actionState: AvatarActionState,
     onSelectAvatar: () -> Unit,
     onFavorite: () -> Unit,
+    isFavorite: Boolean,
     canEdit: Boolean,
     onEdit: () -> Unit,
 ) {
@@ -243,7 +251,7 @@ private fun AvatarProfileContent(
             modifier = Modifier.size(20.dp),
         )
         Spacer(Modifier.width(8.dp))
-        Text(strings.favoriteAvatar)
+        Text(if (isFavorite) strings.editFavorite else strings.favoriteAvatar)
     }
 
     if (canEdit) {

--- a/composeApp/src/commonMain/kotlin/presentation/screens/avatar/AvatarProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/avatar/AvatarProfileScreen.kt
@@ -246,7 +246,8 @@ private fun AvatarProfileContent(
                 onFavorite()
             }
         },
-        enabled = favoriteEntryState != FavoriteEntryState.Loading,
+        enabled = favoriteEntryState != FavoriteEntryState.Loading &&
+            favoriteEntryState != FavoriteEntryState.Unavailable,
         modifier = Modifier.fillMaxWidth(),
     ) {
         Icon(
@@ -261,6 +262,7 @@ private fun AvatarProfileContent(
                 FavoriteEntryState.Favorited -> strings.editFavorite
                 FavoriteEntryState.NotFavorited -> strings.favoriteAvatar
                 FavoriteEntryState.LoadFailed -> strings.retry
+                FavoriteEntryState.Unavailable -> strings.favoriteAvatar
             }
         )
     }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/avatar/AvatarProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/avatar/AvatarProfileScreen.kt
@@ -39,6 +39,7 @@ import io.github.vrcmteam.vrcm.presentation.compoments.sharedBoundsBy
 import io.github.vrcmteam.vrcm.presentation.extensions.currentNavigator
 import io.github.vrcmteam.vrcm.presentation.extensions.simpleClickable
 import io.github.vrcmteam.vrcm.presentation.extensions.simpleFormat
+import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntryState
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.data.AvatarPlatformInfo
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.data.AvatarProfileVo
 import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.ImageEditorTarget
@@ -52,7 +53,6 @@ import io.github.vrcmteam.vrcm.presentation.screens.world.components.FavoriteGro
 import io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStrings
 import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
-import io.github.vrcmteam.vrcm.service.FavoriteService
 import kotlinx.serialization.Serializable
 import org.koin.compose.koinInject
 
@@ -96,12 +96,11 @@ class AvatarProfileScreen(
         val screenModel: AvatarProfileScreenModel = koinViewModel()
         val imageProcessor: PrintImageProcessor = koinInject()
         val editorSessionStore: PrintImageEditorSessionStore = koinInject()
-        val favoriteService: FavoriteService = koinInject()
         val refreshedAvatar by screenModel.avatarProfileState.collectAsState()
         val actionState by screenModel.actionState.collectAsState()
         val editState by screenModel.editState.collectAsState()
         val avatarCoverUpdates by editorSessionStore.avatarCoverUpdates.collectAsState()
-        val avatarFavoritesByGroup by favoriteService.favoritesByGroup(FavoriteType.Avatar).collectAsState()
+        val favoriteEntryState by screenModel.favoriteEntryState.collectAsState()
         val locale = strings
         var showEditSheet by remember { mutableStateOf(false) }
         var showFavoriteSheet by remember { mutableStateOf(false) }
@@ -121,10 +120,6 @@ class AvatarProfileScreen(
         }
 
         val displayedAvatar = refreshedAvatar ?: avatarProfileVo
-        val isFavorite = avatarFavoritesByGroup.values.any { favorites ->
-            favorites.any { favorite -> favorite.favoriteId == displayedAvatar.avatarId }
-        }
-
         LaunchedEffect(displayedAvatar.avatarId, avatarCoverUpdates) {
             val updated = avatarCoverUpdates[displayedAvatar.avatarId]
                 ?: return@LaunchedEffect
@@ -153,7 +148,8 @@ class AvatarProfileScreen(
                     actionState = actionState,
                     onSelectAvatar = screenModel::selectAvatar,
                     onFavorite = { showFavoriteSheet = true },
-                    isFavorite = isFavorite,
+                    favoriteEntryState = favoriteEntryState,
+                    onRetryFavorite = screenModel::retryFavoriteEntryLoad,
                     canEdit = editState.canEdit,
                     onEdit = { showEditSheet = true },
                 )
@@ -197,7 +193,8 @@ private fun AvatarProfileContent(
     actionState: AvatarActionState,
     onSelectAvatar: () -> Unit,
     onFavorite: () -> Unit,
-    isFavorite: Boolean,
+    favoriteEntryState: FavoriteEntryState,
+    onRetryFavorite: () -> Unit,
     canEdit: Boolean,
     onEdit: () -> Unit,
 ) {
@@ -242,7 +239,14 @@ private fun AvatarProfileContent(
     )
 
     OutlinedButton(
-        onClick = onFavorite,
+        onClick = {
+            if (favoriteEntryState == FavoriteEntryState.LoadFailed) {
+                onRetryFavorite()
+            } else {
+                onFavorite()
+            }
+        },
+        enabled = favoriteEntryState != FavoriteEntryState.Loading,
         modifier = Modifier.fillMaxWidth(),
     ) {
         Icon(
@@ -251,7 +255,14 @@ private fun AvatarProfileContent(
             modifier = Modifier.size(20.dp),
         )
         Spacer(Modifier.width(8.dp))
-        Text(if (isFavorite) strings.editFavorite else strings.favoriteAvatar)
+        Text(
+            when (favoriteEntryState) {
+                FavoriteEntryState.Loading -> strings.loading
+                FavoriteEntryState.Favorited -> strings.editFavorite
+                FavoriteEntryState.NotFavorited -> strings.favoriteAvatar
+                FavoriteEntryState.LoadFailed -> strings.retry
+            }
+        )
     }
 
     if (canEdit) {

--- a/composeApp/src/commonMain/kotlin/presentation/screens/avatar/AvatarProfileScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/avatar/AvatarProfileScreenModel.kt
@@ -2,6 +2,7 @@ package io.github.vrcmteam.vrcm.presentation.screens.avatar
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import io.github.vrcmteam.vrcm.core.shared.AuthenticatedAccount
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
 import io.github.vrcmteam.vrcm.network.api.avatars.AvatarsApi
@@ -167,6 +168,7 @@ class AvatarProfileScreenModel internal constructor(
     favoriteEntrySource: FavoriteEntrySource,
     private val requestDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val avatarEditor: AvatarEditor? = null,
+    private val favoriteSession: StateFlow<AuthenticatedAccount?> = SharedFlowCentre.currentSession,
 ) : ViewModel() {
 
     private val _avatarProfileState = MutableStateFlow<AvatarProfileVo?>(null)
@@ -177,6 +179,7 @@ class AvatarProfileScreenModel internal constructor(
         source = favoriteEntrySource,
         scope = viewModelScope,
         dispatcher = requestDispatcher,
+        sessionFlow = favoriteSession,
     )
     internal val favoriteEntryState: StateFlow<FavoriteEntryState> = favoriteEntry.state
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/avatar/AvatarProfileScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/avatar/AvatarProfileScreenModel.kt
@@ -3,11 +3,15 @@ package io.github.vrcmteam.vrcm.presentation.screens.avatar
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
+import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
 import io.github.vrcmteam.vrcm.network.api.avatars.AvatarsApi
 import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
 import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarUpdateData
 import io.github.vrcmteam.vrcm.network.supports.VRCApiException
 import io.github.vrcmteam.vrcm.presentation.compoments.ToastText
+import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntrySource
+import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntryState
+import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntryStateModel
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.data.AvatarProfileVo
 import io.github.vrcmteam.vrcm.service.AuthService
 import kotlinx.coroutines.CoroutineDispatcher
@@ -160,12 +164,25 @@ private enum class AvatarSelectionKind {
 class AvatarProfileScreenModel internal constructor(
     private val avatarProfileLoader: AvatarProfileLoader,
     private val avatarSelector: AvatarSelector,
+    favoriteEntrySource: FavoriteEntrySource,
     private val requestDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val avatarEditor: AvatarEditor? = null,
 ) : ViewModel() {
 
     private val _avatarProfileState = MutableStateFlow<AvatarProfileVo?>(null)
     val avatarProfileState: StateFlow<AvatarProfileVo?> = _avatarProfileState.asStateFlow()
+
+    private val favoriteEntry = FavoriteEntryStateModel(
+        favoriteType = FavoriteType.Avatar,
+        source = favoriteEntrySource,
+        scope = viewModelScope,
+        dispatcher = requestDispatcher,
+    )
+    internal val favoriteEntryState: StateFlow<FavoriteEntryState> = favoriteEntry.state
+
+    internal fun retryFavoriteEntryLoad() {
+        favoriteEntry.retry()
+    }
 
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
@@ -222,6 +239,7 @@ class AvatarProfileScreenModel internal constructor(
         validation.value = AvatarValidation.Checking
         _avatarProfileState.value = avatarProfileVo
         val avatarId = avatarProfileVo.avatarId
+        favoriteEntry.load(avatarId)
         if (avatarId.isBlank()) {
             _isLoading.value = false
             validation.value = AvatarValidation.Failed

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
@@ -1024,7 +1024,8 @@ private fun AppRoute.RenderBottomSheetContent(
                         showFavoriteGroupBottomSheet = true
                     }
                 },
-                enabled = favoriteEntryState != FavoriteEntryState.Loading,
+                enabled = favoriteEntryState != FavoriteEntryState.Loading &&
+                    favoriteEntryState != FavoriteEntryState.Unavailable,
                 modifier = Modifier.weight(1f)
             ) {
                 Text(
@@ -1033,6 +1034,7 @@ private fun AppRoute.RenderBottomSheetContent(
                         FavoriteEntryState.Favorited -> strings.editFavorite
                         FavoriteEntryState.NotFavorited -> strings.favoriteWorld
                         FavoriteEntryState.LoadFailed -> strings.retry
+                        FavoriteEntryState.Unavailable -> strings.favoriteWorld
                     }
                 )
             }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
@@ -73,6 +73,8 @@ import io.github.vrcmteam.vrcm.presentation.screens.world.data.*
 import io.github.vrcmteam.vrcm.presentation.screens.world.data.SheetState
 import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
+import io.github.vrcmteam.vrcm.service.FavoriteService
+import org.koin.compose.koinInject
 import presentation.compoments.TopMenuBar
 import kotlin.math.abs
 
@@ -876,6 +878,11 @@ private fun AppRoute.RenderBottomSheetContent(
     onExpanded: () -> Unit,
 ) {
     val screenModel = koinViewModel<WorldProfileScreenModel>()
+    val favoriteService: FavoriteService = koinInject()
+    val worldFavoritesByGroup by favoriteService.favoritesByGroup(FavoriteType.World).collectAsState()
+    val isFavorite = worldFavoritesByGroup.values.any { favorites ->
+        favorites.any { favorite -> favorite.favoriteId == worldProfileVo.worldId }
+    }
 
     // 对话框状态管理
     var showCreateInstanceDialog by remember { mutableStateOf(false) }
@@ -1018,7 +1025,7 @@ private fun AppRoute.RenderBottomSheetContent(
                 onClick = { showFavoriteGroupBottomSheet = true },
                 modifier = Modifier.weight(1f)
             ) {
-                Text(strings.favoriteWorld)
+                Text(if (isFavorite) strings.editFavorite else strings.favoriteWorld)
             }
         }
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
@@ -62,6 +62,7 @@ import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
 import io.github.vrcmteam.vrcm.network.api.files.data.PlatformType.*
 import io.github.vrcmteam.vrcm.presentation.compoments.*
 import io.github.vrcmteam.vrcm.presentation.extensions.*
+import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntryState
 import io.github.vrcmteam.vrcm.presentation.screens.user.UserProfileScreen
 import io.github.vrcmteam.vrcm.presentation.screens.user.data.UserProfileVo
 import io.github.vrcmteam.vrcm.presentation.screens.world.components.CreateInstanceDialog
@@ -73,8 +74,6 @@ import io.github.vrcmteam.vrcm.presentation.screens.world.data.*
 import io.github.vrcmteam.vrcm.presentation.screens.world.data.SheetState
 import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
-import io.github.vrcmteam.vrcm.service.FavoriteService
-import org.koin.compose.koinInject
 import presentation.compoments.TopMenuBar
 import kotlin.math.abs
 
@@ -878,11 +877,7 @@ private fun AppRoute.RenderBottomSheetContent(
     onExpanded: () -> Unit,
 ) {
     val screenModel = koinViewModel<WorldProfileScreenModel>()
-    val favoriteService: FavoriteService = koinInject()
-    val worldFavoritesByGroup by favoriteService.favoritesByGroup(FavoriteType.World).collectAsState()
-    val isFavorite = worldFavoritesByGroup.values.any { favorites ->
-        favorites.any { favorite -> favorite.favoriteId == worldProfileVo.worldId }
-    }
+    val favoriteEntryState by screenModel.favoriteEntryState.collectAsState()
 
     // 对话框状态管理
     var showCreateInstanceDialog by remember { mutableStateOf(false) }
@@ -1022,10 +1017,24 @@ private fun AppRoute.RenderBottomSheetContent(
             }
 
             OutlinedButton(
-                onClick = { showFavoriteGroupBottomSheet = true },
+                onClick = {
+                    if (favoriteEntryState == FavoriteEntryState.LoadFailed) {
+                        screenModel.retryFavoriteEntryLoad()
+                    } else {
+                        showFavoriteGroupBottomSheet = true
+                    }
+                },
+                enabled = favoriteEntryState != FavoriteEntryState.Loading,
                 modifier = Modifier.weight(1f)
             ) {
-                Text(if (isFavorite) strings.editFavorite else strings.favoriteWorld)
+                Text(
+                    when (favoriteEntryState) {
+                        FavoriteEntryState.Loading -> strings.loading
+                        FavoriteEntryState.Favorited -> strings.editFavorite
+                        FavoriteEntryState.NotFavorited -> strings.favoriteWorld
+                        FavoriteEntryState.LoadFailed -> strings.retry
+                    }
+                )
             }
         }
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
@@ -6,6 +6,7 @@ import io.github.vrcmteam.vrcm.core.extensions.removeFirst
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.attributes.AccessType
 import io.github.vrcmteam.vrcm.network.api.attributes.BlueprintType
+import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
 import io.github.vrcmteam.vrcm.network.api.attributes.RegionType
 import io.github.vrcmteam.vrcm.network.api.groups.GroupsApi
 import io.github.vrcmteam.vrcm.network.api.instances.InstancesApi
@@ -13,6 +14,9 @@ import io.github.vrcmteam.vrcm.network.api.invite.InviteApi
 import io.github.vrcmteam.vrcm.network.api.users.UsersApi
 import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
 import io.github.vrcmteam.vrcm.presentation.compoments.ToastText
+import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntrySource
+import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntryState
+import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntryStateModel
 import io.github.vrcmteam.vrcm.presentation.screens.world.data.InstanceVo
 import io.github.vrcmteam.vrcm.presentation.screens.world.data.InstanceVo.Owner
 import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
@@ -33,12 +37,13 @@ import kotlin.time.ExperimentalTime
  * 世界档案页面的ViewModel，负责处理世界数据的加载和刷新
  */
 @OptIn(ExperimentalTime::class)
-class WorldProfileScreenModel(
+class WorldProfileScreenModel internal constructor(
     private val worldsApi: WorldsApi,
     private val instancesApi: InstancesApi,
     private val usersApi: UsersApi,
     private val groupsApi: GroupsApi,
     private val authService: AuthService,
+    favoriteEntrySource: FavoriteEntrySource,
     private val inviteApi: InviteApi,
     private val worldPlatformService: WorldPlatformService,
     private val worldProfileCacheStore: WorldProfileCacheStore,
@@ -51,9 +56,16 @@ class WorldProfileScreenModel(
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
-    // 是否已收藏状态
-    private val _isFavorite = MutableStateFlow(false)
-    val isFavorite: StateFlow<Boolean> = _isFavorite.asStateFlow()
+    private val favoriteEntry = FavoriteEntryStateModel(
+        favoriteType = FavoriteType.World,
+        source = favoriteEntrySource,
+        scope = viewModelScope,
+    )
+    internal val favoriteEntryState: StateFlow<FavoriteEntryState> = favoriteEntry.state
+
+    internal fun retryFavoriteEntryLoad() {
+        favoriteEntry.retry()
+    }
 
     /**
      * 刷新世界数据
@@ -61,6 +73,7 @@ class WorldProfileScreenModel(
     fun loadWorldData(worldProfileVO: WorldProfileVo) {
         _worldProfileState.value = worldProfileVO
         val worldId = worldProfileVO.worldId
+        favoriteEntry.load(worldId)
         if (worldId.isBlank()) return
         // 缓存读取改为挂起（Room），先出网络前的占位状态，缓存到达后再回填。
         viewModelScope.launch { applyCachedWorld(worldId, worldProfileVO) }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/components/FavoriteGroupBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/components/FavoriteGroupBottomSheet.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
+import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteData
+import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteGroupData
 import io.github.vrcmteam.vrcm.presentation.compoments.ABottomSheet
 import io.github.vrcmteam.vrcm.presentation.compoments.ToastText
 import io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStrings
@@ -32,6 +34,8 @@ import org.koin.compose.koinInject
  * @param isVisible 是否显示底部表单
  * @param favoriteId 要收藏的目标ID
  * @param favoriteType 收藏类型
+ * @param favoriteRecordId 已存在收藏记录的ID；隐藏世界无法提供目标ID时使用
+ * @param allowGroupChange 是否允许新增或移动到其他收藏组
  * @param onDismiss 关闭回调
  * @param onConfirm 确认选择回调，参数为所选收藏组name的Result
  */
@@ -43,6 +47,8 @@ fun FavoriteGroupBottomSheet(
     favoriteType: FavoriteType,
     onDismiss: () -> Unit,
     onConfirm: (Result<String>) -> Unit = {},
+    favoriteRecordId: String? = null,
+    allowGroupChange: Boolean = true,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val favoriteService: FavoriteService = koinInject()
@@ -51,7 +57,7 @@ fun FavoriteGroupBottomSheet(
     val strings = strings
 
     // 加载收藏数据
-    LaunchedEffect(favoriteId, favoriteType) {
+    LaunchedEffect(favoriteId, favoriteType, favoriteRecordId) {
         authService.reTryAuth {
             favoriteService.loadFavoriteByGroup(favoriteType)
         }
@@ -61,15 +67,14 @@ fun FavoriteGroupBottomSheet(
     val favoritesByGroup by favoriteService.favoritesByGroup(favoriteType).collectAsState()
 
     // 查找当前项目在哪个收藏组中
-    val existingGroup = remember(favoritesByGroup, favoriteId) {
-        favoritesByGroup.entries.firstOrNull { (_, favorites) ->
-            favorites.any { it.favoriteId == favoriteId }
-        }?.key
+    val existingFavorite = remember(favoritesByGroup, favoriteId, favoriteRecordId) {
+        findFavoriteForManagement(favoritesByGroup, favoriteId, favoriteRecordId)
     }
+    val existingGroup = existingFavorite?.first
 
     // 已收藏的组名和ID
     val currentGroupName = existingGroup?.name
-    var isChanging by remember(favoriteId, favoriteType) { mutableStateOf(false) }
+    var isChanging by remember(favoriteId, favoriteType, favoriteRecordId) { mutableStateOf(false) }
     // 添加或移动到新收藏组
     val onClickGroupItem = { groupName: String ->
         isChanging = true
@@ -82,7 +87,9 @@ fun FavoriteGroupBottomSheet(
                     currentGroupName,
                     strings,
                     favoriteId,
-                    favoriteType
+                    favoriteType,
+                    existingFavorite = existingFavorite,
+                    allowGroupChange = allowGroupChange,
                 )
             }.map { groupName }
                 .let { result ->
@@ -111,7 +118,11 @@ fun FavoriteGroupBottomSheet(
         ) {
             // 标题
             Text(
-                text = if (currentGroupName != null) strings.favoriteMoveToAnotherGroup else strings.selectFavoriteGroup,
+                text = when {
+                    !allowGroupChange -> strings.remove
+                    currentGroupName != null -> strings.favoriteMoveToAnotherGroup
+                    else -> strings.selectFavoriteGroup
+                },
                 style = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.fillMaxWidth(),
                 color = MaterialTheme.colorScheme.onSurface,
@@ -151,7 +162,10 @@ fun FavoriteGroupBottomSheet(
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .background(backgroundColor)
-                                    .clickable(!isChanging && !isCurrentGroup) { onClickGroupItem(group.name) },
+                                    .clickable(
+                                        enabled = allowGroupChange && !isChanging && !isCurrentGroup,
+                                        onClick = { onClickGroupItem(group.name) },
+                                    ),
                             ) {
                                 Row(
                                     modifier = Modifier
@@ -207,6 +221,21 @@ fun FavoriteGroupBottomSheet(
     }
 }
 
+internal fun findFavoriteForManagement(
+    favoritesByGroup: Map<FavoriteGroupData, List<FavoriteData>>,
+    favoriteId: String,
+    favoriteRecordId: String?,
+): Pair<FavoriteGroupData, FavoriteData>? {
+    val entries = favoritesByGroup.entries
+        .asSequence()
+        .flatMap { (group, favorites) -> favorites.asSequence().map { group to it } }
+        .toList()
+
+    return favoriteRecordId
+        ?.let { recordId -> entries.firstOrNull { (_, favorite) -> favorite.id == recordId } }
+        ?: entries.firstOrNull { (_, favorite) -> favorite.favoriteId == favoriteId }
+}
+
 private suspend fun doChangeFavoriteGroup(
     favoriteService: FavoriteService,
     groupName: String?,
@@ -214,8 +243,10 @@ private suspend fun doChangeFavoriteGroup(
     strings: LocaleStrings,
     favoriteId: String,
     favoriteType: FavoriteType,
+    existingFavorite: Pair<FavoriteGroupData, FavoriteData>?,
+    allowGroupChange: Boolean,
 ): Result<Unit> = runCatching {
-    val favorite = favoriteService.getFavoriteByFavoriteId(favoriteType, favoriteId)
+    val favorite = existingFavorite?.second
 
     // 移除旧组
     suspend fun removeFavorite() {
@@ -235,7 +266,7 @@ private suspend fun doChangeFavoriteGroup(
 
     suspend fun addFavorite() {
         // 添加到新组
-        if (groupName != currentGroupName && groupName != null) {
+        if (allowGroupChange && groupName != currentGroupName && groupName != null) {
             val isMove = favorite != null
             runCatching {
                 favoriteService.addFavorite(
@@ -267,5 +298,3 @@ private suspend fun doChangeFavoriteGroup(
 
     favoriteService.loadFavoriteByGroup(favoriteType).getOrThrow()
 }
-
-

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/components/FavoriteGroupBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/components/FavoriteGroupBottomSheet.kt
@@ -23,9 +23,11 @@ import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
 import io.github.vrcmteam.vrcm.service.AuthService
 import io.github.vrcmteam.vrcm.service.FavoriteService
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
 
 /**
@@ -50,11 +52,18 @@ fun FavoriteGroupBottomSheet(
     favoriteRecordId: String? = null,
     allowGroupChange: Boolean = true,
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val favoriteService: FavoriteService = koinInject()
     val authService: AuthService = koinInject()
     val scope = rememberCoroutineScope()
     val strings = strings
+    var isChanging by remember(favoriteId, favoriteType, favoriteRecordId) { mutableStateOf(false) }
+    val latestIsChanging = rememberUpdatedState(isChanging)
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true,
+        confirmValueChange = { targetValue ->
+            targetValue != SheetValue.Hidden || !latestIsChanging.value
+        },
+    )
 
     // 加载收藏数据
     LaunchedEffect(favoriteId, favoriteType, favoriteRecordId) {
@@ -74,32 +83,32 @@ fun FavoriteGroupBottomSheet(
 
     // 已收藏的组名和ID
     val currentGroupName = existingGroup?.name
-    var isChanging by remember(favoriteId, favoriteType, favoriteRecordId) { mutableStateOf(false) }
     // 添加或移动到新收藏组
-    val onClickGroupItem = { groupName: String ->
+    val onClickGroupItem = onClick@{ groupName: String ->
+        if (isChanging) return@onClick
         isChanging = true
-        scope.launch(Dispatchers.IO) {
-            // 如果已在某个组中，先移除
-            authService.reTryAuth {
-                doChangeFavoriteGroup(
-                    favoriteService,
-                    groupName,
-                    currentGroupName,
-                    strings,
-                    favoriteId,
-                    favoriteType,
-                    existingFavorite = existingFavorite,
-                    allowGroupChange = allowGroupChange,
-                )
-            }.map { groupName }
-                .let { result ->
-                    isChanging = false
-                    onConfirm(result)
-                }
-        }
         scope.launch {
+            val result = try {
+                withContext(Dispatchers.IO) {
+                    // 如果已在某个组中，先移除
+                    authService.reTryAuth {
+                        doChangeFavoriteGroup(
+                            favoriteService,
+                            groupName,
+                            currentGroupName,
+                            strings,
+                            favoriteId,
+                            favoriteType,
+                            existingFavorite = existingFavorite,
+                            allowGroupChange = allowGroupChange,
+                        )
+                    }.map { groupName }
+                }
+            } finally {
+                isChanging = false
+            }
+            onConfirm(result)
             sheetState.hide()
-        }.invokeOnCompletion {
             onDismiss()
         }
     }
@@ -107,7 +116,7 @@ fun FavoriteGroupBottomSheet(
     ABottomSheet(
         isVisible = isVisible,
         sheetState = sheetState,
-        onDismissRequest = onDismiss
+        onDismissRequest = { if (!isChanging) onDismiss() }
     ) {
         Column(
             modifier = Modifier.fillMaxWidth()
@@ -231,9 +240,11 @@ internal fun findFavoriteForManagement(
         .flatMap { (group, favorites) -> favorites.asSequence().map { group to it } }
         .toList()
 
-    return favoriteRecordId
-        ?.let { recordId -> entries.firstOrNull { (_, favorite) -> favorite.id == recordId } }
-        ?: entries.firstOrNull { (_, favorite) -> favorite.favoriteId == favoriteId }
+    return if (favoriteRecordId != null) {
+        entries.firstOrNull { (_, favorite) -> favorite.id == favoriteRecordId }
+    } else {
+        entries.firstOrNull { (_, favorite) -> favorite.favoriteId == favoriteId }
+    }
 }
 
 private suspend fun doChangeFavoriteGroup(
@@ -245,22 +256,25 @@ private suspend fun doChangeFavoriteGroup(
     favoriteType: FavoriteType,
     existingFavorite: Pair<FavoriteGroupData, FavoriteData>?,
     allowGroupChange: Boolean,
-): Result<Unit> = runCatching {
+): Result<Unit> = try {
     val favorite = existingFavorite?.second
 
     // 移除旧组
     suspend fun removeFavorite() {
         if (favorite != null) {
-            runCatching {
+            try {
                 favoriteService.removeFavorite(id = favorite.id)
-            }.onSuccess {
-                if (groupName != currentGroupName) return@onSuccess
-                val successMessage = strings.favoriteRemoveSuccess
-                SharedFlowCentre.toastText.emit(ToastText.Success(successMessage))
-            }.onFailure {
-                val errorMessage = "${strings.favoriteRemoveFailed}: ${it.message}"
+                if (groupName == currentGroupName) {
+                    val successMessage = strings.favoriteRemoveSuccess
+                    SharedFlowCentre.toastText.emit(ToastText.Success(successMessage))
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                val errorMessage = "${strings.favoriteRemoveFailed}: ${error.message}"
                 SharedFlowCentre.toastText.emit(ToastText.Error(errorMessage))
-            }.getOrThrow()
+                throw error
+            }
         }
     }
 
@@ -268,20 +282,22 @@ private suspend fun doChangeFavoriteGroup(
         // 添加到新组
         if (allowGroupChange && groupName != currentGroupName && groupName != null) {
             val isMove = favorite != null
-            runCatching {
+            try {
                 favoriteService.addFavorite(
                     favoriteId = favoriteId,
                     favoriteType = favoriteType,
                     groupName = groupName,
                 )
-            }.onSuccess {
                 val successMessage = if (isMove) strings.favoriteMoveSuccess else strings.favoriteAddSuccess
                 SharedFlowCentre.toastText.emit(ToastText.Success(successMessage))
-            }.onFailure {
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
                 val errorMessage =
-                    "${if (isMove) strings.favoriteMoveFailed else strings.favoriteAddFailed}: ${it.message}"
+                    "${if (isMove) strings.favoriteMoveFailed else strings.favoriteAddFailed}: ${error.message}"
                 SharedFlowCentre.toastText.emit(ToastText.Error(errorMessage))
-            }.getOrThrow()
+                throw error
+            }
         }
     }
 
@@ -297,4 +313,9 @@ private suspend fun doChangeFavoriteGroup(
     }
 
     favoriteService.loadFavoriteByGroup(favoriteType).getOrThrow()
+    Result.success(Unit)
+} catch (error: CancellationException) {
+    throw error
+} catch (error: Throwable) {
+    Result.failure(error)
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/components/FavoriteGroupBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/components/FavoriteGroupBottomSheet.kt
@@ -66,7 +66,8 @@ fun FavoriteGroupBottomSheet(
     )
 
     // 加载收藏数据
-    LaunchedEffect(favoriteId, favoriteType, favoriteRecordId) {
+    LaunchedEffect(isVisible, favoriteId, favoriteType, favoriteRecordId) {
+        if (!isVisible) return@LaunchedEffect
         authService.reTryAuth {
             favoriteService.loadFavoriteByGroup(favoriteType)
         }

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
@@ -163,6 +163,7 @@ sealed class LocaleStrings {
     open val confirm: String = "Confirm"
     open val cancel: String = "Cancel"
     open val favoriteWorld: String = "Favorite World"
+    open val favoriteAvatar: String = "Favorite Avatar"
     open val favoriteAddSuccess: String = "Add Favorite Success"
     open val favoriteAddFailed: String = "Add Favorite Failed"
     open val favoriteAlreadyExists: String = "it is already in your favorites"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
@@ -164,6 +164,7 @@ sealed class LocaleStrings {
     open val cancel: String = "Cancel"
     open val favoriteWorld: String = "Favorite World"
     open val favoriteAvatar: String = "Favorite Avatar"
+    open val editFavorite: String = "Edit Favorite"
     open val favoriteAddSuccess: String = "Add Favorite Success"
     open val favoriteAddFailed: String = "Add Favorite Failed"
     open val favoriteAlreadyExists: String = "it is already in your favorites"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
@@ -148,6 +148,7 @@ internal object LocaleStringsJa : LocaleStrings() {
     override val confirm = "確認"
     override val cancel = "キャンセル"
     override val favoriteWorld = "お気に入り追加"
+    override val favoriteAvatar = "モデルをお気に入りに追加"
     override val favoriteAddSuccess = "お気に入りに追加しました"
     override val favoriteAlreadyExists = "既にお気に入りです"
     override val favoriteGroupSelect = "お気に入りグループを選択"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
@@ -149,6 +149,7 @@ internal object LocaleStringsJa : LocaleStrings() {
     override val cancel = "キャンセル"
     override val favoriteWorld = "お気に入り追加"
     override val favoriteAvatar = "モデルをお気に入りに追加"
+    override val editFavorite = "お気に入りを編集"
     override val favoriteAddSuccess = "お気に入りに追加しました"
     override val favoriteAlreadyExists = "既にお気に入りです"
     override val favoriteGroupSelect = "お気に入りグループを選択"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
@@ -147,6 +147,7 @@ internal object LocaleStringsZhHans : LocaleStrings() {
     override val confirm = "确认"
     override val cancel = "取消"
     override val favoriteWorld = "收藏世界"
+    override val favoriteAvatar = "收藏模型"
     override val favoriteAddSuccess = "已成功收藏"
     override val favoriteAlreadyExists = "该目标已在您的收藏中"
     override val favoriteGroupSelect = "选择收藏分组"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
@@ -148,6 +148,7 @@ internal object LocaleStringsZhHans : LocaleStrings() {
     override val cancel = "取消"
     override val favoriteWorld = "收藏世界"
     override val favoriteAvatar = "收藏模型"
+    override val editFavorite = "编辑收藏"
     override val favoriteAddSuccess = "已成功收藏"
     override val favoriteAlreadyExists = "该目标已在您的收藏中"
     override val favoriteGroupSelect = "选择收藏分组"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
@@ -148,6 +148,7 @@ internal object LocaleStringsZhHant : LocaleStrings() {
     override val cancel = "取消"
     override val favoriteWorld = "收藏世界"
     override val favoriteAvatar = "收藏模型"
+    override val editFavorite = "編輯收藏"
     override val favoriteAddSuccess = "世界已成功收藏"
     override val favoriteAlreadyExists = "該目標已在您的收藏中"
     override val favoriteGroupSelect = "選擇收藏分組"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
@@ -147,6 +147,7 @@ internal object LocaleStringsZhHant : LocaleStrings() {
     override val confirm = "確認"
     override val cancel = "取消"
     override val favoriteWorld = "收藏世界"
+    override val favoriteAvatar = "收藏模型"
     override val favoriteAddSuccess = "世界已成功收藏"
     override val favoriteAlreadyExists = "該目標已在您的收藏中"
     override val favoriteGroupSelect = "選擇收藏分組"

--- a/composeApp/src/commonMain/kotlin/service/FavoriteService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FavoriteService.kt
@@ -12,7 +12,23 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.toCollection
-import kotlinx.coroutines.flow.update
+
+internal class FavoriteGroupCache {
+    private val flows = FavoriteType.entries.associateWith {
+        MutableStateFlow<Map<FavoriteGroupData, List<FavoriteData>>>(emptyMap())
+    }
+
+    fun flow(type: FavoriteType): StateFlow<Map<FavoriteGroupData, List<FavoriteData>>> =
+        flows.getValue(type)
+
+    fun replace(type: FavoriteType, favorites: Map<FavoriteGroupData, List<FavoriteData>>) {
+        flows.getValue(type).value = favorites
+    }
+
+    fun clear() {
+        flows.values.forEach { it.value = emptyMap() }
+    }
+}
 
 /**
  * 收藏服务类
@@ -24,9 +40,7 @@ class FavoriteService(
     private val favoriteLocalDao: FavoriteLocalDao,
 ) {
 
-    // 收藏列表缓存，key为FavoriteGroupData的name
-    private val _favoritesByGroup: MutableMap<FavoriteType, MutableStateFlow<Map<FavoriteGroupData, List<FavoriteData>>>> =
-        mutableMapOf()
+    private val favoritesByGroupCache = FavoriteGroupCache()
 
     // 收藏限制信息缓存
     private var _favoriteLimits: FavoriteLimits? = null
@@ -34,14 +48,14 @@ class FavoriteService(
     init {
         CoroutineScope(Dispatchers.Default).launch {
             SharedFlowCentre.authed.collect {
-                _favoritesByGroup.clear()
+                favoritesByGroupCache.clear()
             }
         }
     }
 
 
     fun favoritesByGroup(favoriteType: FavoriteType): StateFlow<Map<FavoriteGroupData, List<FavoriteData>>> =
-        _favoritesByGroup.getOrPut(favoriteType) { MutableStateFlow(mutableMapOf()) }
+        favoritesByGroupCache.flow(favoriteType)
 
 
     init {
@@ -147,11 +161,11 @@ class FavoriteService(
         }
 
         // 合并远程与本地
-        _favoritesByGroup.getOrPut(favoriteType) {
-            MutableStateFlow(mutableMapOf())
-        }.update {
-            remoteGroups.associateWith { (newFavoritesMap[it.name] ?: listOf()) } + (localGroup to localFavorites)
-        }
+        favoritesByGroupCache.replace(
+            favoriteType,
+            remoteGroups.associateWith { (newFavoritesMap[it.name] ?: listOf()) } +
+                (localGroup to localFavorites),
+        )
     }.onFailure {
         SharedFlowCentre.toastText.emit(ToastText.Error(it.message ?: "Load Favorite By Group Failed"))
     }
@@ -212,4 +226,4 @@ class FavoriteService(
     fun getFavoriteByFavoriteId(favoriteType: FavoriteType, favoriteId: String): FavoriteData? =
         favoritesByGroup(favoriteType).value.values.flatten().firstOrNull { it.favoriteId == favoriteId }
 
-} 
+}

--- a/composeApp/src/commonMain/kotlin/storage/CacheStores.kt
+++ b/composeApp/src/commonMain/kotlin/storage/CacheStores.kt
@@ -155,14 +155,26 @@ internal class RoomFavoriteListCacheStore(
     override suspend fun saveWorlds(userId: String, worlds: List<FavoritedWorldGroup>) {
         mutationMutex.withLock {
             val current = cache.load(userId) ?: FavoriteListCache()
-            cache.save(userId, current.copy(favoritedWorlds = worlds))
+            cache.save(
+                userId,
+                current.copy(
+                    favoritedWorlds = worlds,
+                    worldsLoaded = true,
+                ),
+            )
         }
     }
 
     override suspend fun saveAvatars(userId: String, avatars: List<AvatarData>) {
         mutationMutex.withLock {
             val current = cache.load(userId) ?: FavoriteListCache()
-            cache.save(userId, current.copy(favoritedAvatars = avatars))
+            cache.save(
+                userId,
+                current.copy(
+                    favoritedAvatars = avatars,
+                    avatarsLoaded = true,
+                ),
+            )
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/storage/data/FavoriteListCache.kt
+++ b/composeApp/src/commonMain/kotlin/storage/data/FavoriteListCache.kt
@@ -8,4 +8,6 @@ import kotlinx.serialization.Serializable
 data class FavoriteListCache(
     val favoritedWorlds: List<FavoritedWorldGroup> = emptyList(),
     val favoritedAvatars: List<AvatarData> = emptyList(),
+    val worldsLoaded: Boolean = false,
+    val avatarsLoaded: Boolean = false,
 )

--- a/composeApp/src/commonTest/kotlin/di/modules/PresentationModuleTest.kt
+++ b/composeApp/src/commonTest/kotlin/di/modules/PresentationModuleTest.kt
@@ -9,6 +9,10 @@ import io.github.vrcmteam.vrcm.presentation.screens.avatar.AvatarSelector
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.AvatarUserContext
 import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
 import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarUpdateData
+import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
+import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteData
+import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteGroupData
+import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntrySource
 import io.github.vrcmteam.vrcm.presentation.screens.gallery.GalleryDataSource
 import io.github.vrcmteam.vrcm.presentation.screens.gallery.GalleryScreenModel
 import io.github.vrcmteam.vrcm.network.api.files.data.FileData
@@ -73,6 +77,7 @@ class PresentationModuleTest : MainDispatcherTest() {
                     }
                     single<AvatarSelector> { EmptyAvatarSelector }
                     single<AvatarEditor> { EmptyAvatarEditor }
+                    single<FavoriteEntrySource> { EmptyFavoriteEntrySource }
                 },
             )
         }
@@ -134,6 +139,15 @@ class PresentationModuleTest : MainDispatcherTest() {
         assertNotSame(first, second)
         application.close()
     }
+}
+
+private data object EmptyFavoriteEntrySource : FavoriteEntrySource {
+    private val favorites = MutableStateFlow<Map<FavoriteGroupData, List<FavoriteData>>>(emptyMap())
+
+    override fun favoritesByGroup(type: FavoriteType): StateFlow<Map<FavoriteGroupData, List<FavoriteData>>> =
+        favorites
+
+    override suspend fun load(type: FavoriteType): Result<Unit> = Result.success(Unit)
 }
 
 private data object FakeMeetupCardRepository : MeetupCardRepository {

--- a/composeApp/src/commonTest/kotlin/presentation/screens/avatar/AvatarProfileRequestTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/avatar/AvatarProfileRequestTest.kt
@@ -2,6 +2,8 @@ package io.github.vrcmteam.vrcm.presentation.screens.avatar
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelStore
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+import io.github.vrcmteam.vrcm.core.shared.AuthenticatedAccount
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
 import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarUpdateData
@@ -155,28 +157,37 @@ class AvatarProfileRequestTest : MainDispatcherTest() {
 
     @Test
     fun cachedFavoriteStateReloadsWhenTheAccountSessionChanges() = runBlocking {
-        SharedFlowCentre.emitAuthenticated(AccountDto(userId = "usr_account_a"))
+        val session = MutableStateFlow(
+            AuthenticatedAccount(
+                account = AccountDto(userId = "usr_account_a"),
+                token = AccountSessionToken(userId = "usr_account_a", generation = 1),
+            )
+        )
         val favoriteSource = SessionAwareCachedEntryFavoriteSource(
             memberships = mapOf(
                 "usr_account_a" to true,
                 "usr_account_b" to false,
             ),
+            session = session,
         )
         val model = avatarModel(
             loader = ControlledAvatarProfileLoader(),
             favoriteSource = favoriteSource,
+            favoriteSession = session,
         )
 
         model.refreshAvatarData(AvatarProfileVo(avatarId = "avtr_saved", avatarName = "Saved"))
         yield()
         assertEquals(FavoriteEntryState.Favorited, model.favoriteEntryState.value)
 
-        SharedFlowCentre.emitAuthenticated(AccountDto(userId = "usr_account_b"))
+        session.value = AuthenticatedAccount(
+            account = AccountDto(userId = "usr_account_b"),
+            token = AccountSessionToken(userId = "usr_account_b", generation = 2),
+        )
         yield()
 
         assertEquals(FavoriteEntryState.NotFavorited, model.favoriteEntryState.value)
         assertEquals(2, favoriteSource.cachedLookupCount)
-        SharedFlowCentre.emitLogout()
     }
 
     @Test
@@ -588,8 +599,16 @@ class AvatarProfileRequestTest : MainDispatcherTest() {
         selector: AvatarSelector = FakeAvatarSelector(),
         favoriteSource: FavoriteEntrySource = EmptyFavoriteEntrySource(),
         editor: AvatarEditor? = null,
+        favoriteSession: StateFlow<AuthenticatedAccount?> = SharedFlowCentre.currentSession,
     ): AvatarProfileScreenModel =
-        AvatarProfileScreenModel(loader, selector, favoriteSource, Dispatchers.Unconfined, editor)
+        AvatarProfileScreenModel(
+            loader,
+            selector,
+            favoriteSource,
+            Dispatchers.Unconfined,
+            editor,
+            favoriteSession,
+        )
             .also(models::add)
 }
 
@@ -636,6 +655,7 @@ private class CachedEntryFavoriteSource(
 
 private class SessionAwareCachedEntryFavoriteSource(
     private val memberships: Map<String, Boolean>,
+    private val session: StateFlow<AuthenticatedAccount?>,
 ) : FavoriteEntrySource {
     private val favorites = MutableStateFlow<Map<FavoriteGroupData, List<FavoriteData>>>(emptyMap())
     var cachedLookupCount = 0
@@ -646,7 +666,7 @@ private class SessionAwareCachedEntryFavoriteSource(
 
     override suspend fun cachedFavorite(type: FavoriteType, favoriteId: String): Boolean? {
         cachedLookupCount++
-        return SharedFlowCentre.currentSession.value?.token?.userId?.let(memberships::get)
+        return session.value?.token?.userId?.let(memberships::get)
     }
 
     override suspend fun load(type: FavoriteType): Result<Unit> = Result.success(Unit)

--- a/composeApp/src/commonTest/kotlin/presentation/screens/avatar/AvatarProfileRequestTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/avatar/AvatarProfileRequestTest.kt
@@ -5,8 +5,13 @@ import androidx.lifecycle.ViewModelStore
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
 import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarUpdateData
+import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
+import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteData
+import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteGroupData
 import io.github.vrcmteam.vrcm.network.supports.VRCApiException
 import io.github.vrcmteam.vrcm.presentation.compoments.ToastText
+import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntrySource
+import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntryState
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.data.AvatarProfileVo
 import io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStringsEn
 import io.github.vrcmteam.vrcm.testing.MainDispatcherTest
@@ -54,6 +59,40 @@ class AvatarProfileRequestTest : MainDispatcherTest() {
             LocaleStringsEn.avatarProfileActionSwitch,
             AvatarActionAvailability.Copyable.localizedButtonText(LocaleStringsEn),
         )
+    }
+
+    @Test
+    fun directEntryLoadsFavoritedStateWithoutVisitingFavoritesFirst() = runBlocking {
+        val favoriteSource = DirectEntryFavoriteSource(favoriteId = "avtr_saved")
+        val model = avatarModel(
+            loader = ControlledAvatarProfileLoader(),
+            favoriteSource = favoriteSource,
+        )
+
+        model.refreshAvatarData(AvatarProfileVo(avatarId = "avtr_saved", avatarName = "Saved"))
+        yield()
+
+        assertEquals(FavoriteEntryState.Favorited, model.favoriteEntryState.value)
+    }
+
+    @Test
+    fun failedFavoriteEntryLoadCanRetryWithoutLeavingTheProfile() = runBlocking {
+        val favoriteSource = DirectEntryFavoriteSource(
+            favoriteId = "avtr_saved",
+            failuresBeforeSuccess = 1,
+        )
+        val model = avatarModel(
+            loader = ControlledAvatarProfileLoader(),
+            favoriteSource = favoriteSource,
+        )
+
+        model.refreshAvatarData(AvatarProfileVo(avatarId = "avtr_saved", avatarName = "Saved"))
+        yield()
+        assertEquals(FavoriteEntryState.LoadFailed, model.favoriteEntryState.value)
+
+        model.retryFavoriteEntryLoad()
+        yield()
+        assertEquals(FavoriteEntryState.Favorited, model.favoriteEntryState.value)
     }
 
     @Test
@@ -327,7 +366,7 @@ class AvatarProfileRequestTest : MainDispatcherTest() {
         val loader = ControlledAvatarProfileLoader()
         val selector = FakeAvatarSelector()
         val editor = FakeAvatarEditor()
-        val model = avatarModel(loader, selector, editor)
+        val model = avatarModel(loader, selector, editor = editor)
         val notices = mutableListOf<AvatarProfileNotice>()
         val noticeCollector = launch(start = CoroutineStart.UNDISPATCHED) {
             model.notices.collect(notices::add)
@@ -402,10 +441,58 @@ class AvatarProfileRequestTest : MainDispatcherTest() {
     private fun avatarModel(
         loader: AvatarProfileLoader,
         selector: AvatarSelector = FakeAvatarSelector(),
+        favoriteSource: FavoriteEntrySource = EmptyFavoriteEntrySource(),
         editor: AvatarEditor? = null,
     ): AvatarProfileScreenModel =
-        AvatarProfileScreenModel(loader, selector, Dispatchers.Unconfined, editor)
+        AvatarProfileScreenModel(loader, selector, favoriteSource, Dispatchers.Unconfined, editor)
             .also(models::add)
+}
+
+private class EmptyFavoriteEntrySource : FavoriteEntrySource {
+    private val favorites = MutableStateFlow<Map<FavoriteGroupData, List<FavoriteData>>>(emptyMap())
+
+    override fun favoritesByGroup(type: FavoriteType): StateFlow<Map<FavoriteGroupData, List<FavoriteData>>> =
+        favorites
+
+    override suspend fun load(type: FavoriteType): Result<Unit> = Result.success(Unit)
+}
+
+private class DirectEntryFavoriteSource(
+    private val favoriteId: String,
+    private val failuresBeforeSuccess: Int = 0,
+) : FavoriteEntrySource {
+    private val favorites = MutableStateFlow<Map<FavoriteGroupData, List<FavoriteData>>>(emptyMap())
+    private var attempts = 0
+
+    override fun favoritesByGroup(type: FavoriteType): StateFlow<Map<FavoriteGroupData, List<FavoriteData>>> =
+        favorites
+
+    override suspend fun load(type: FavoriteType): Result<Unit> {
+        if (attempts++ < failuresBeforeSuccess) {
+            return Result.failure(IllegalStateException("favorite groups unavailable"))
+        }
+        val group = FavoriteGroupData(
+            id = "group_avatars1",
+            ownerId = "usr_owner",
+            type = type.value,
+            visibility = "private",
+            displayName = "Avatars 1",
+            name = "avatars1",
+            ownerDisplayName = "Owner",
+            tags = emptyList(),
+        )
+        favorites.value = mapOf(
+            group to listOf(
+                FavoriteData(
+                    favoriteId = favoriteId,
+                    id = "fvrt_saved",
+                    tags = listOf(group.name),
+                    type = type.value,
+                )
+            )
+        )
+        return Result.success(Unit)
+    }
 }
 
 private fun clearViewModel(viewModel: ViewModel) {

--- a/composeApp/src/commonTest/kotlin/presentation/screens/avatar/AvatarProfileRequestTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/avatar/AvatarProfileRequestTest.kt
@@ -111,6 +111,32 @@ class AvatarProfileRequestTest : MainDispatcherTest() {
     }
 
     @Test
+    fun pendingFavoriteLoadCannotReviveTheEntryAfterSwitchingToABlankAvatar() = runBlocking {
+        val pendingLoad = CompletableDeferred<Unit>()
+        val favoriteSource = DirectEntryFavoriteSource(
+            favoriteId = "avtr_saved",
+            pendingLoad = pendingLoad,
+        )
+        val model = avatarModel(
+            loader = ControlledAvatarProfileLoader(),
+            favoriteSource = favoriteSource,
+        )
+
+        model.refreshAvatarData(AvatarProfileVo(avatarId = "avtr_saved", avatarName = "Saved"))
+        yield()
+        assertEquals(FavoriteEntryState.Loading, model.favoriteEntryState.value)
+
+        model.refreshAvatarData(AvatarProfileVo(avatarId = "", avatarName = "Unavailable"))
+        yield()
+        assertEquals(FavoriteEntryState.Unavailable, model.favoriteEntryState.value)
+
+        pendingLoad.complete(Unit)
+        yield()
+
+        assertEquals(FavoriteEntryState.Unavailable, model.favoriteEntryState.value)
+    }
+
+    @Test
     fun olderSuccessCannotOverwriteTheLatestAvatar() = runBlocking {
         val loader = ControlledAvatarProfileLoader()
         val model = avatarModel(loader)
@@ -489,6 +515,7 @@ private class CountingFavoriteEntrySource : FavoriteEntrySource {
 private class DirectEntryFavoriteSource(
     private val favoriteId: String,
     private val failuresBeforeSuccess: Int = 0,
+    private val pendingLoad: CompletableDeferred<Unit>? = null,
 ) : FavoriteEntrySource {
     private val favorites = MutableStateFlow<Map<FavoriteGroupData, List<FavoriteData>>>(emptyMap())
     private var attempts = 0
@@ -497,6 +524,7 @@ private class DirectEntryFavoriteSource(
         favorites
 
     override suspend fun load(type: FavoriteType): Result<Unit> {
+        pendingLoad?.await()
         if (attempts++ < failuresBeforeSuccess) {
             return Result.failure(IllegalStateException("favorite groups unavailable"))
         }

--- a/composeApp/src/commonTest/kotlin/presentation/screens/avatar/AvatarProfileRequestTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/avatar/AvatarProfileRequestTest.kt
@@ -76,6 +76,68 @@ class AvatarProfileRequestTest : MainDispatcherTest() {
     }
 
     @Test
+    fun persistedFavoriteCacheShowsEntryStateWithoutRemoteLoading() = runBlocking {
+        val favoriteSource = CachedEntryFavoriteSource(cachedMembership = true)
+        val model = avatarModel(
+            loader = ControlledAvatarProfileLoader(),
+            favoriteSource = favoriteSource,
+        )
+
+        model.refreshAvatarData(AvatarProfileVo(avatarId = "avtr_saved", avatarName = "Saved"))
+        yield()
+
+        assertEquals(FavoriteEntryState.Favorited, model.favoriteEntryState.value)
+        assertEquals(0, favoriteSource.loadCount)
+    }
+
+    @Test
+    fun loadedFavoriteGroupsShowEntryStateWithoutRemoteLoading() = runBlocking {
+        val group = FavoriteGroupData(
+            id = "group_avatars1",
+            ownerId = "usr_owner",
+            type = FavoriteType.Avatar.value,
+            visibility = "private",
+            displayName = "Avatars 1",
+            name = "avatars1",
+            ownerDisplayName = "Owner",
+            tags = emptyList(),
+        )
+        val favoriteSource = LoadedGroupsFavoriteSource(
+            group = group,
+            favorite = FavoriteData(
+                favoriteId = "avtr_saved",
+                id = "fvrt_saved",
+                tags = listOf(group.name),
+                type = FavoriteType.Avatar.value,
+            ),
+        )
+        val model = avatarModel(
+            loader = ControlledAvatarProfileLoader(),
+            favoriteSource = favoriteSource,
+        )
+
+        model.refreshAvatarData(AvatarProfileVo(avatarId = "avtr_saved", avatarName = "Saved"))
+
+        assertEquals(FavoriteEntryState.Favorited, model.favoriteEntryState.value)
+        assertEquals(0, favoriteSource.loadCount)
+    }
+
+    @Test
+    fun completeFavoriteCacheShowsNotFavoritedWithoutRemoteLoading() = runBlocking {
+        val favoriteSource = CachedEntryFavoriteSource(cachedMembership = false)
+        val model = avatarModel(
+            loader = ControlledAvatarProfileLoader(),
+            favoriteSource = favoriteSource,
+        )
+
+        model.refreshAvatarData(AvatarProfileVo(avatarId = "avtr_missing", avatarName = "Missing"))
+        yield()
+
+        assertEquals(FavoriteEntryState.NotFavorited, model.favoriteEntryState.value)
+        assertEquals(0, favoriteSource.loadCount)
+    }
+
+    @Test
     fun failedFavoriteEntryLoadCanRetryWithoutLeavingTheProfile() = runBlocking {
         val favoriteSource = DirectEntryFavoriteSource(
             favoriteId = "avtr_saved",
@@ -500,6 +562,41 @@ private class EmptyFavoriteEntrySource : FavoriteEntrySource {
 
 private class CountingFavoriteEntrySource : FavoriteEntrySource {
     private val favorites = MutableStateFlow<Map<FavoriteGroupData, List<FavoriteData>>>(emptyMap())
+    var loadCount = 0
+        private set
+
+    override fun favoritesByGroup(type: FavoriteType): StateFlow<Map<FavoriteGroupData, List<FavoriteData>>> =
+        favorites
+
+    override suspend fun load(type: FavoriteType): Result<Unit> {
+        loadCount++
+        return Result.success(Unit)
+    }
+}
+
+private class CachedEntryFavoriteSource(
+    private val cachedMembership: Boolean,
+) : FavoriteEntrySource {
+    private val favorites = MutableStateFlow<Map<FavoriteGroupData, List<FavoriteData>>>(emptyMap())
+    var loadCount = 0
+        private set
+
+    override fun favoritesByGroup(type: FavoriteType): StateFlow<Map<FavoriteGroupData, List<FavoriteData>>> =
+        favorites
+
+    override suspend fun cachedFavorite(type: FavoriteType, favoriteId: String): Boolean = cachedMembership
+
+    override suspend fun load(type: FavoriteType): Result<Unit> {
+        loadCount++
+        return Result.success(Unit)
+    }
+}
+
+private class LoadedGroupsFavoriteSource(
+    group: FavoriteGroupData,
+    favorite: FavoriteData,
+) : FavoriteEntrySource {
+    private val favorites = MutableStateFlow(mapOf(group to listOf(favorite)))
     var loadCount = 0
         private set
 

--- a/composeApp/src/commonTest/kotlin/presentation/screens/avatar/AvatarProfileRequestTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/avatar/AvatarProfileRequestTest.kt
@@ -15,6 +15,7 @@ import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntryState
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.data.AvatarProfileVo
 import io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStringsEn
 import io.github.vrcmteam.vrcm.testing.MainDispatcherTest
+import io.github.vrcmteam.vrcm.service.data.AccountDto
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -135,6 +136,47 @@ class AvatarProfileRequestTest : MainDispatcherTest() {
 
         assertEquals(FavoriteEntryState.NotFavorited, model.favoriteEntryState.value)
         assertEquals(0, favoriteSource.loadCount)
+    }
+
+    @Test
+    fun missingAvatarCacheFallsBackToRemoteLoading() = runBlocking {
+        val favoriteSource = CachedEntryFavoriteSource(cachedMembership = null)
+        val model = avatarModel(
+            loader = ControlledAvatarProfileLoader(),
+            favoriteSource = favoriteSource,
+        )
+
+        model.refreshAvatarData(AvatarProfileVo(avatarId = "avtr_saved", avatarName = "Saved"))
+        yield()
+
+        assertEquals(1, favoriteSource.loadCount)
+        assertEquals(FavoriteEntryState.NotFavorited, model.favoriteEntryState.value)
+    }
+
+    @Test
+    fun cachedFavoriteStateReloadsWhenTheAccountSessionChanges() = runBlocking {
+        SharedFlowCentre.emitAuthenticated(AccountDto(userId = "usr_account_a"))
+        val favoriteSource = SessionAwareCachedEntryFavoriteSource(
+            memberships = mapOf(
+                "usr_account_a" to true,
+                "usr_account_b" to false,
+            ),
+        )
+        val model = avatarModel(
+            loader = ControlledAvatarProfileLoader(),
+            favoriteSource = favoriteSource,
+        )
+
+        model.refreshAvatarData(AvatarProfileVo(avatarId = "avtr_saved", avatarName = "Saved"))
+        yield()
+        assertEquals(FavoriteEntryState.Favorited, model.favoriteEntryState.value)
+
+        SharedFlowCentre.emitAuthenticated(AccountDto(userId = "usr_account_b"))
+        yield()
+
+        assertEquals(FavoriteEntryState.NotFavorited, model.favoriteEntryState.value)
+        assertEquals(2, favoriteSource.cachedLookupCount)
+        SharedFlowCentre.emitLogout()
     }
 
     @Test
@@ -575,7 +617,7 @@ private class CountingFavoriteEntrySource : FavoriteEntrySource {
 }
 
 private class CachedEntryFavoriteSource(
-    private val cachedMembership: Boolean,
+    private val cachedMembership: Boolean?,
 ) : FavoriteEntrySource {
     private val favorites = MutableStateFlow<Map<FavoriteGroupData, List<FavoriteData>>>(emptyMap())
     var loadCount = 0
@@ -584,12 +626,30 @@ private class CachedEntryFavoriteSource(
     override fun favoritesByGroup(type: FavoriteType): StateFlow<Map<FavoriteGroupData, List<FavoriteData>>> =
         favorites
 
-    override suspend fun cachedFavorite(type: FavoriteType, favoriteId: String): Boolean = cachedMembership
+    override suspend fun cachedFavorite(type: FavoriteType, favoriteId: String): Boolean? = cachedMembership
 
     override suspend fun load(type: FavoriteType): Result<Unit> {
         loadCount++
         return Result.success(Unit)
     }
+}
+
+private class SessionAwareCachedEntryFavoriteSource(
+    private val memberships: Map<String, Boolean>,
+) : FavoriteEntrySource {
+    private val favorites = MutableStateFlow<Map<FavoriteGroupData, List<FavoriteData>>>(emptyMap())
+    var cachedLookupCount = 0
+        private set
+
+    override fun favoritesByGroup(type: FavoriteType): StateFlow<Map<FavoriteGroupData, List<FavoriteData>>> =
+        favorites
+
+    override suspend fun cachedFavorite(type: FavoriteType, favoriteId: String): Boolean? {
+        cachedLookupCount++
+        return SharedFlowCentre.currentSession.value?.token?.userId?.let(memberships::get)
+    }
+
+    override suspend fun load(type: FavoriteType): Result<Unit> = Result.success(Unit)
 }
 
 private class LoadedGroupsFavoriteSource(

--- a/composeApp/src/commonTest/kotlin/presentation/screens/avatar/AvatarProfileRequestTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/avatar/AvatarProfileRequestTest.kt
@@ -96,6 +96,21 @@ class AvatarProfileRequestTest : MainDispatcherTest() {
     }
 
     @Test
+    fun blankAvatarIdMakesFavoriteEntryUnavailableWithoutLoading() = runBlocking {
+        val favoriteSource = CountingFavoriteEntrySource()
+        val model = avatarModel(
+            loader = ControlledAvatarProfileLoader(),
+            favoriteSource = favoriteSource,
+        )
+
+        model.refreshAvatarData(AvatarProfileVo(avatarId = "", avatarName = "Unavailable"))
+        yield()
+
+        assertEquals(FavoriteEntryState.Unavailable, model.favoriteEntryState.value)
+        assertEquals(0, favoriteSource.loadCount)
+    }
+
+    @Test
     fun olderSuccessCannotOverwriteTheLatestAvatar() = runBlocking {
         val loader = ControlledAvatarProfileLoader()
         val model = avatarModel(loader)
@@ -455,6 +470,20 @@ private class EmptyFavoriteEntrySource : FavoriteEntrySource {
         favorites
 
     override suspend fun load(type: FavoriteType): Result<Unit> = Result.success(Unit)
+}
+
+private class CountingFavoriteEntrySource : FavoriteEntrySource {
+    private val favorites = MutableStateFlow<Map<FavoriteGroupData, List<FavoriteData>>>(emptyMap())
+    var loadCount = 0
+        private set
+
+    override fun favoritesByGroup(type: FavoriteType): StateFlow<Map<FavoriteGroupData, List<FavoriteData>>> =
+        favorites
+
+    override suspend fun load(type: FavoriteType): Result<Unit> {
+        loadCount++
+        return Result.success(Unit)
+    }
 }
 
 private class DirectEntryFavoriteSource(

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/components/FavoriteGroupBottomSheetTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/components/FavoriteGroupBottomSheetTest.kt
@@ -4,6 +4,7 @@ import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteData
 import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteGroupData
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class FavoriteGroupBottomSheetTest {
     @Test
@@ -24,6 +25,20 @@ class FavoriteGroupBottomSheetTest {
 
         assertEquals(secondGroup, result?.first)
         assertEquals(secondFavorite, result?.second)
+    }
+
+    @Test
+    fun missingExplicitRecordIdDoesNotFallBackToHiddenWorldPlaceholder() {
+        val group = group("worlds1")
+        val favorite = favorite("fvrt_hidden_1", group.name)
+
+        val result = findFavoriteForManagement(
+            favoritesByGroup = mapOf(group to listOf(favorite)),
+            favoriteId = "???",
+            favoriteRecordId = "fvrt_missing",
+        )
+
+        assertNull(result)
     }
 
     private fun group(name: String) = FavoriteGroupData(

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/components/FavoriteGroupBottomSheetTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/components/FavoriteGroupBottomSheetTest.kt
@@ -1,0 +1,46 @@
+package io.github.vrcmteam.vrcm.presentation.screens.world.components
+
+import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteData
+import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteGroupData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FavoriteGroupBottomSheetTest {
+    @Test
+    fun hiddenWorldCanResolveItsFavoriteByRecordId() {
+        val firstGroup = group("worlds1")
+        val secondGroup = group("worlds2")
+        val firstFavorite = favorite("fvrt_hidden_1", firstGroup.name)
+        val secondFavorite = favorite("fvrt_hidden_2", secondGroup.name)
+
+        val result = findFavoriteForManagement(
+            favoritesByGroup = mapOf(
+                firstGroup to listOf(firstFavorite),
+                secondGroup to listOf(secondFavorite),
+            ),
+            favoriteId = "???",
+            favoriteRecordId = secondFavorite.id,
+        )
+
+        assertEquals(secondGroup, result?.first)
+        assertEquals(secondFavorite, result?.second)
+    }
+
+    private fun group(name: String) = FavoriteGroupData(
+        id = "group_$name",
+        ownerId = "usr_owner",
+        type = "world",
+        visibility = "private",
+        displayName = name,
+        name = name,
+        ownerDisplayName = "Owner",
+        tags = emptyList(),
+    )
+
+    private fun favorite(id: String, groupName: String) = FavoriteData(
+        favoriteId = "???",
+        id = id,
+        tags = listOf(groupName),
+        type = "world",
+    )
+}

--- a/composeApp/src/commonTest/kotlin/service/FavoriteGroupCacheTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/FavoriteGroupCacheTest.kt
@@ -1,0 +1,50 @@
+package io.github.vrcmteam.vrcm.service
+
+import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
+import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteData
+import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteGroupData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class FavoriteGroupCacheTest {
+    @Test
+    fun clearingSessionDataKeepsFlowIdentityForSubsequentLoads() {
+        val cache = FavoriteGroupCache()
+        val observedFlow = cache.flow(FavoriteType.Avatar)
+        val firstSession = favorites("avtr_first")
+        val secondSession = favorites("avtr_second")
+
+        cache.replace(FavoriteType.Avatar, firstSession)
+        cache.clear()
+
+        assertSame(observedFlow, cache.flow(FavoriteType.Avatar))
+        assertEquals(emptyMap(), observedFlow.value)
+
+        cache.replace(FavoriteType.Avatar, secondSession)
+        assertEquals(secondSession, observedFlow.value)
+    }
+
+    private fun favorites(avatarId: String): Map<FavoriteGroupData, List<FavoriteData>> {
+        val group = FavoriteGroupData(
+            id = "group_avatars1",
+            ownerId = "usr_owner",
+            type = FavoriteType.Avatar.value,
+            visibility = "private",
+            displayName = "Avatars 1",
+            name = "avatars1",
+            ownerDisplayName = "Owner",
+            tags = emptyList(),
+        )
+        return mapOf(
+            group to listOf(
+                FavoriteData(
+                    favoriteId = avatarId,
+                    id = "fvrt_$avatarId",
+                    tags = listOf(group.name),
+                    type = FavoriteType.Avatar.value,
+                )
+            )
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/storage/InMemoryUserProfileCacheStore.kt
+++ b/composeApp/src/commonTest/kotlin/storage/InMemoryUserProfileCacheStore.kt
@@ -31,11 +31,17 @@ class InMemoryFavoriteListCacheStore : FavoriteListCacheStore {
     override suspend fun load(userId: String): FavoriteListCache? = entries[userId]
 
     override suspend fun saveWorlds(userId: String, worlds: List<FavoritedWorldGroup>) {
-        entries[userId] = (entries[userId] ?: FavoriteListCache()).copy(favoritedWorlds = worlds)
+        entries[userId] = (entries[userId] ?: FavoriteListCache()).copy(
+            favoritedWorlds = worlds,
+            worldsLoaded = true,
+        )
     }
 
     override suspend fun saveAvatars(userId: String, avatars: List<AvatarData>) {
-        entries[userId] = (entries[userId] ?: FavoriteListCache()).copy(favoritedAvatars = avatars)
+        entries[userId] = (entries[userId] ?: FavoriteListCache()).copy(
+            favoritedAvatars = avatars,
+            avatarsLoaded = true,
+        )
     }
 
     override suspend fun clear(userId: String) {

--- a/composeApp/src/desktopTest/kotlin/storage/RoomFavoriteListCacheStoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/storage/RoomFavoriteListCacheStoreTest.kt
@@ -37,12 +37,31 @@ class RoomFavoriteListCacheStoreTest {
         val cached = assertNotNull(store.load("usr_owner"))
         assertEquals(worlds, cached.favoritedWorlds)
         assertEquals(avatars, cached.favoritedAvatars)
+        assertEquals(true, cached.worldsLoaded)
+        assertEquals(true, cached.avatarsLoaded)
 
         store.saveWorlds("usr_owner", emptyList())
 
         val afterEmptyRefresh = assertNotNull(store.load("usr_owner"))
         assertEquals(emptyList(), afterEmptyRefresh.favoritedWorlds)
         assertEquals(avatars, afterEmptyRefresh.favoritedAvatars)
+        assertEquals(true, afterEmptyRefresh.worldsLoaded)
+        assertEquals(true, afterEmptyRefresh.avatarsLoaded)
+    }
+
+    @Test
+    fun refreshingOneTypeDoesNotMarkTheOtherTypeComplete() = withStore { store ->
+        store.saveWorlds("usr_owner", emptyList())
+
+        val worldsOnly = assertNotNull(store.load("usr_owner"))
+        assertEquals(true, worldsOnly.worldsLoaded)
+        assertEquals(false, worldsOnly.avatarsLoaded)
+
+        store.saveAvatars("usr_owner", emptyList())
+
+        val bothTypes = assertNotNull(store.load("usr_owner"))
+        assertEquals(true, bothTypes.worldsLoaded)
+        assertEquals(true, bothTypes.avatarsLoaded)
     }
 
     @Test


### PR DESCRIPTION
关联 #84

## 实现思路

模型详情页直接复用世界详情页现有的收藏分组管理：用户可以选择分组、移动到其他分组或移除收藏，并补齐英文、日文、简体中文和繁体中文文案。根据 @yourmoln 在本轮人工评审中的补充，世界和模型详情页会在进入页面时通过现有认证重试主动加载当前收藏状态：已收藏显示“编辑收藏”，未收藏显示“收藏世界”或“收藏模型”；加载完成前不把未知状态误报为未收藏，加载失败可直接重试。

收藏列表中的隐藏世界和隐藏模型仍然不能打开详情。点击这类条目时改为打开只读分组信息和“移除”操作；隐藏世界按收藏记录自身的唯一标识定位，避免共享占位值时误删其他条目；隐藏模型按其模型目标标识定位。移除成功后刷新当前收藏列表。

## 验收标准自查

- [x] 模型详情页提供收藏入口，未收藏模型可选择分组收藏。验证：共享/Desktop 编译通过，模型详情现有回归测试与收藏分组测试通过。
- [x] 已收藏模型可通过同一入口移动分组或移除收藏。验证：复用现有收藏表单的新增、移动、移除流程，最终 Android Debug 门禁编译通过。
- [x] 收藏列表中的隐藏世界可以移出收藏，同时不会进入不可查看的详情页。验证：新增测试使用两条共享同一占位目标的隐藏收藏，确认按指定收藏记录精确定位第二条；相关缓存测试通过。
- [x] 隐藏模型可以像隐藏世界一样移出收藏，同时不会进入不可查看的详情页；正常世界详情访问保持原有行为。验证：隐藏模型复用只读收藏管理和操作生命周期保护，收藏模型缓存及相关定向回归测试通过。
- [x] 已收藏的世界与模型显示“编辑收藏”，未收藏时仍显示“收藏世界”或“收藏模型”。验证：世界和模型 ViewModel 在进入详情时加载共享收藏状态；新增回归测试从空状态直接进入已收藏模型详情，修复前断言失败、修复后通过，四语言结构测试与共享/Desktop 编译通过。
- [x] 四种语言均有“收藏模型”文案。验证：LocaleStringsStructureTest 通过。

## 自测结果

- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests io.github.vrcmteam.vrcm.presentation.screens.world.components.FavoriteGroupBottomSheetTest --tests io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStringsStructureTest --tests io.github.vrcmteam.vrcm.presentation.screens.home.pager.FavoritedWorldCacheTest --tests io.github.vrcmteam.vrcm.presentation.screens.avatar.AvatarProfileRequestTest --console=plain`：BUILD SUCCESSFUL。
- 完整 `:composeApp:desktopTest` 执行 707 项，706 项通过；唯一失败是无图形环境下既有 `DesktopWindowTitleBarLocaleTest.windowControlLabelsUseTheLatestLanguage` 的 `HeadlessException`，本轮相关测试全部通过。
- 最终提交 `dfb8016` 执行 `~/ai/bin/check-gate.sh implement-issue 84`：Android Debug `assembleDebug` 为 BUILD SUCCESSFUL，质量门禁输出 `quality gate: pass`。
- `git diff --check`：通过。
- 本次未进行真实 VRChat 账号联调或真机截图；改动为跨平台共享界面与既有收藏接口编排，不涉及 Android 系统能力。

### 最新评审修复验证（当前 HEAD）

- validated-sha: `9e8725c02574b4a29aa2b5cea5f0d5d35df48fb5`
- 新增 `FavoriteGroupCacheTest.clearingSessionDataKeepsFlowIdentityForSubsequentLoads`，验证认证会话清理旧收藏后，详情页和首页已持有的 Flow 实例保持不变、旧值归零，后续新会话数据仍写入同一 Flow。
- 新增 `blankAvatarIdMakesFavoriteEntryUnavailableWithoutLoading`，验证空目标 ID 不发起收藏请求，并进入禁用且不可重试的 `Unavailable` 状态。
- 新增 `pendingFavoriteLoadCannotReviveTheEntryAfterSwitchingToABlankAvatar`，验证有效目标的收藏加载仍在进行时切换到空目标，迟到的成功结果不能把入口从 `Unavailable` 改回可操作；该用例在本次修复前实测失败（`AssertionError`），修复后通过。
- 新增 `missingAvatarCacheFallsBackToRemoteLoading`，验证只缓存另一类型时模型收藏缓存视为未完成，仍会通过远端分组加载。
- 新增 `cachedFavoriteStateReloadsWhenTheAccountSessionChanges`，验证账号 token/generation 改变后旧缓存状态被作废并按新账号重新判定。
- 新增 `RoomFavoriteListCacheStoreTest.refreshingOneTypeDoesNotMarkTheOtherTypeComplete`，验证世界和模型快照分别记录完整刷新标记，成功空列表也会被正确记为已完成。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests io.github.vrcmteam.vrcm.presentation.screens.avatar.AvatarProfileRequestTest --console=plain`：`BUILD SUCCESSFUL`，新增缓存类型和会话切换回归均通过。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:testDebugUnitTest --console=plain`：`BUILD SUCCESSFUL`，670 项通过（覆盖 Android 源集编译与单测）。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --console=plain`：当前 SHA 共执行 737 项，736 项通过；唯一失败仍是无图形环境下既有 `DesktopWindowTitleBarLocaleTest.windowControlLabelsUseTheLatestLanguage` 的 `HeadlessException`，本轮相关测试全部通过。
- `~/ai/bin/check-gate.sh fix-review 85`：`assembleDebug` 为 `BUILD SUCCESSFUL`，回执记录 `sha=9e8725c02574b4a29aa2b5cea5f0d5d35df48fb5`、`result=pass`、`baseline_matched=true`，最终输出 `quality gate: pass`。
- `git diff --check`：通过；共享 worktree 无未提交代码改动。

## 自评风险点

- 自动化测试验证了隐藏收藏记录的精确匹配，但未使用真实账号调用 VRChat 收藏删除接口；线上结果仍依赖现有收藏接口合同。
- 本次没有 Figma 设计稿，也未进行真机视觉验收；按钮沿用现有 Material 主题、图标和收藏表单，仍需人工确认详情页实际观感。
- 隐藏世界和隐藏模型只允许移除，不允许移动分组；这是 @yourmoln 本轮要求两类隐藏条目保持一致后的实现边界，避免对无法打开详情的内容执行删除后重新收藏。

## 代码逻辑图

```mermaid
flowchart TD
    Click{"StandardSearchList 点击的隐藏条目"}
    Click -->|"隐藏世界"| HoldWorld["保存 WorldData 与收藏记录 ID"]
    Click -->|"隐藏模型"| HoldAvatar["保存 AvatarData 与模型目标 ID"]
    HoldWorld --> Sheet["显示 FavoriteGroupBottomSheet，只允许移除"]
    HoldAvatar --> Sheet
    Sheet --> SheetLoad["弹窗打开时通过 AuthService.reTryAuth 刷新对应收藏分组"]
    SheetLoad --> Match{"findFavoriteForManagement 是否命中收藏记录"}
    Match -->|"未命中"| Stop["不提供其他记录的移除操作"]
    Match -->|"命中"| Remove["用户点击移除，isChanging 设为 true"]
    Remove --> Guard["SheetState.confirmValueChange 拒绝操作期间关闭"]
    Remove --> Auth["AuthService.reTryAuth 执行收藏变更"]
    Auth --> Service["FavoriteService.removeFavorite 删除收藏记录"]
    Service --> Result{"收藏操作结果"}
    Result --> Confirm["onConfirm 返回结果"]
    Confirm -->|"成功"| Refresh["StandardSearchList 调用 doRefresh 刷新列表"]
    Confirm --> Hide["isChanging 设为 false，sheetState.hide"]
    Refresh --> Hide
    Hide --> Dismiss["onDismiss 清理可见状态和选中条目"]

    Enter["进入 WorldProfileScreen / AvatarProfileScreen"] --> ViewModel["loadWorldData / refreshAvatarData"]
    ViewModel --> Bump["FavoriteEntryStateModel 提升请求代次，作废进行中的收藏加载"]
    Bump --> TargetId{"目标 ID 是否为空"}
    TargetId -->|"是"| Unavailable["状态 = Unavailable，入口禁用；迟到结果因代次不匹配被丢弃"]
    TargetId -->|"否"| CurrentGroups{"当前 favoritesByGroup 是否已有完整分组流"}
    CurrentGroups -->|"是"| CurrentMatch{"目标 ID 是否在分组中"}
    CurrentMatch -->|"是"| EditText["显示编辑收藏"]
    CurrentMatch -->|"否"| AddText["显示收藏世界或收藏模型"]
    CurrentGroups -->|"否"| Cache["AuthenticatedFavoriteEntrySource 读取当前账号 FavoriteListCache"]
    Cache --> CacheExists{"当前类型是否标记为完整刷新"}
    CacheExists -->|"是"| CacheMatch{"目标是否在缓存列表中"}
    CacheMatch -->|"是"| CachedEdit["状态 = Favorited，显示编辑收藏"]
    CacheMatch -->|"否"| CachedAdd["状态 = NotFavorited，显示收藏世界或收藏模型"]
    CacheExists -->|"否"| EntryLoading["状态 = Loading，入口禁用"]
    EntryLoading --> Source["AuthService.reTryAuth 调用 FavoriteService.loadFavoriteByGroup"]
    Source --> Reauth{"认证是否过期"}
    Reauth -->|"是"| Login["AuthService 静默重登录并发送 SharedFlowCentre.authed"]
    Login --> Clear["FavoriteGroupCache 清空各稳定 StateFlow 的值"]
    Clear --> Reload["重试加载并把新会话收藏写回同一 StateFlow"]
    Reauth -->|"否"| LoadResult{"加载结果"}
    Reload --> LoadResult
    LoadResult -->|"失败"| Retry["状态 = LoadFailed，入口显示重试"]
    Retry -->|"用户重试"| Bump
    LoadResult -->|"成功"| Observe["持续观察稳定的 favoritesByGroup Flow"]
    Observe --> Exists{"目标 ID 是否在收藏组中"}
    Exists -->|"是"| EditText
    Exists -->|"否"| AddText

    SessionChange["SharedFlowCentre.currentSession token/generation 变化"] --> Invalidate["作废缓存判定，禁止复用旧账号结果"]
    Invalidate -->|"目标 ID 非空"| SessionReload["按新会话强制重新读取类型缓存或加载分组"]
    SessionReload --> Bump
```

## 实现假设清单

本次无未经验证假设。

- 模型详情要与世界详情保持相同的新增、移动和移除能力，依据：issue 正文明确要求实现“类似于世界详细页的编辑收藏功能”。
- 隐藏世界和隐藏模型只需提供移除能力，依据：issue 正文明确指出隐藏世界缺少移除能力；@yourmoln 在本轮人工评审中进一步要求隐藏模型与隐藏世界保持一致。
- 隐藏世界返回的 `favoriteId` 是收藏记录 ID，依据：仓库现有隐藏世界缓存键与测试均以 `fvrt_*` 记录标识区分条目，项目知识库来源 PR #20 也确认该字段语义；删除继续使用现有 `FavoriteData.id` 与 `FavoriteService.removeFavorite` 合同。

## 实现说明(供追问)

### 关键决策

模型详情没有新建另一套收藏逻辑，而是复用世界详情已经使用的收藏表单，保证分组加载、认证重试、成功/失败提示和重复操作禁用保持一致。世界和模型详情共同使用 FavoriteEntryStateModel：页面生命周期负责初始加载，FavoriteService 仍是收藏数据的单一来源；认证事件会清空每种收藏类型的 Flow 值但保留 Flow 实例，使静默重登录后的重试结果仍能到达已有观察者。表单只在真正打开时刷新，避免重复请求。

收藏列表缓存分别记录世界和模型是否完成过一次成功刷新；只完成一种类型时，另一种类型不会把默认空列表误判为“已确认未收藏”。详情入口状态模型还监听当前账号会话代次，账号切换或静默重登录会作废旧缓存结果并按新会话重新读取，测试使用隔离会话流验证该转换。

隐藏世界和隐藏模型都无法打开详情，因此入口只提供移除，不执行需要先删除再重新收藏的移动分组。隐藏世界删除前使用收藏记录 ID 定位唯一条目，隐藏模型使用模型目标 ID 定位其收藏记录。

### 覆盖的场景

覆盖模型未收藏时新增收藏、已收藏时移动分组和移除；覆盖隐藏世界与隐藏模型点击后查看所属组并移除；覆盖多条隐藏世界共享占位值时的精确定位；覆盖未访问收藏页时直接进入世界或模型详情、加载期间禁用入口、加载失败原页重试、静默重登录后继续观察新会话收藏、空目标 ID 禁用入口，以及收藏变化后入口文案同步更新；覆盖认证重试和操作期间禁用等既有表单状态。

### 明确未覆盖

不恢复隐藏世界或隐藏模型详情，不允许隐藏世界或隐藏模型移动收藏组，不调整收藏组容量或权限规则，不修改服务端接口。未进行真实账号线上删除、Android/iOS 真机交互或视觉截图。

### 关键假设

无。模型与世界详情能力范围、两类隐藏条目只需移除、详情入口文案规则，以及收藏记录标识的语义均可由 issue、本轮人类反馈、现有代码和仓库知识记录核实。
