### PR TITLE
fix(links): 忽略应用内分享的剪贴板链接

### DIFF
--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -130,15 +130,16 @@ fun App(
                                 .padding(vertical = 76.dp, horizontal = 12.dp)
                         ) {
                             VersionDialog()
-                            OfficialLinkPrompt(navigator, activeOfficialLinkInbox)
-                            NotificationLaunchHandler(navigator, activeNotificationLaunchInbox)
-                            SharedTransitionScreen(
-                                navigator = navigator,
-                                transitionSpec = { selectTransition(isPop = false) },
-                                popTransitionSpec = { selectTransition(isPop = true) },
-                            ) { screen ->
-                                SharedTransitionDialog(key = screen.key) {
-                                    screen.Content()
+                            OfficialLinkPrompt(navigator, activeOfficialLinkInbox) {
+                                NotificationLaunchHandler(navigator, activeNotificationLaunchInbox)
+                                SharedTransitionScreen(
+                                    navigator = navigator,
+                                    transitionSpec = { selectTransition(isPop = false) },
+                                    popTransitionSpec = { selectTransition(isPop = true) },
+                                ) { screen ->
+                                    SharedTransitionDialog(key = screen.key) {
+                                        screen.Content()
+                                    }
                                 }
                             }
                         }

--- a/composeApp/src/commonMain/kotlin/presentation/compoments/OfficialLinkPrompt.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/OfficialLinkPrompt.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
@@ -22,6 +23,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
@@ -49,10 +51,13 @@ import io.github.vrcmteam.vrcm.service.OfficialLinkTarget
 import io.github.vrcmteam.vrcm.service.OfficialLinkType
 import org.koin.compose.koinInject
 
+internal val LocalOfficialLinkInspectionMarker = staticCompositionLocalOf<(String) -> Unit> { {} }
+
 @Composable
 internal fun OfficialLinkPrompt(
     navigator: AppNavigator,
     inbox: OfficialLinkInbox,
+    content: @Composable () -> Unit,
 ) {
     val clipboard = LocalClipboardManager.current
     val service: OfficialLinkService = koinInject()
@@ -62,6 +67,7 @@ internal fun OfficialLinkPrompt(
     val clipboardInspectionGate = remember { OfficialLinkClipboardInspectionGate() }
     val isAuthenticated = navigator.items.any { it is HomeScreen }
     val controller = rememberOfficialLinkPromptController(service, navigator, inbox)
+    val markClipboardInspected = remember(controller) { controller::markClipboardInspected }
     val promptState by controller.state.collectAsState()
 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
@@ -96,6 +102,11 @@ internal fun OfficialLinkPrompt(
         if (!isAuthenticated) return@LaunchedEffect
         controller.openExternal(request)
     }
+
+    CompositionLocalProvider(
+        LocalOfficialLinkInspectionMarker provides markClipboardInspected,
+        content = content,
+    )
 
     when (val state = promptState) {
         OfficialLinkPromptState.Idle -> Unit

--- a/composeApp/src/commonMain/kotlin/presentation/compoments/OfficialLinkPromptController.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/OfficialLinkPromptController.kt
@@ -68,6 +68,11 @@ internal class OfficialLinkPromptController<T>(
         }
     }
 
+    fun markClipboardInspected(value: String) {
+        val target = parseOfficialId(value) ?: parseOfficialLink(value) ?: return
+        markInspected(target.key())
+    }
+
     fun inspectClipboard(value: String) {
         if (!isAuthenticated) return
         val target = parseOfficialId(value) ?: parseOfficialLink(value) ?: return

--- a/composeApp/src/commonMain/kotlin/presentation/compoments/OfficialUrlRow.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/OfficialUrlRow.kt
@@ -32,6 +32,7 @@ fun OfficialUrlShareButton(
     val platform = getAppPlatform()
     val clipboard = LocalClipboardManager.current
     val scope = rememberCoroutineScope()
+    val markClipboardInspected = LocalOfficialLinkInspectionMarker.current
     val usesSystemShare = platform.supportsSystemShare
     val actionDescription = if (usesSystemShare) strings.shareOfficialUrl else strings.copyOfficialUrl
     val copiedMessage = strings.officialUrlCopied
@@ -47,7 +48,9 @@ fun OfficialUrlShareButton(
             colors = colors,
             onClick = {
                 if (usesSystemShare) {
-                    if (!runCatching { platform.shareUrl(url) }.getOrDefault(false)) {
+                    if (runCatching { platform.shareUrl(url) }.getOrDefault(false)) {
+                        markClipboardInspected(url)
+                    } else {
                         scope.launch {
                             SharedFlowCentre.toastText.emit(ToastText.Error(failedMessage))
                         }
@@ -56,6 +59,9 @@ fun OfficialUrlShareButton(
                     val copied = runCatching {
                         clipboard.setText(AnnotatedString(url))
                     }.isSuccess
+                    if (copied) {
+                        markClipboardInspected(url)
+                    }
                     scope.launch {
                         SharedFlowCentre.toastText.emit(
                             if (copied) {

--- a/composeApp/src/commonTest/kotlin/presentation/compoments/OfficialLinkPromptControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/compoments/OfficialLinkPromptControllerTest.kt
@@ -96,6 +96,28 @@ class OfficialLinkPromptControllerTest {
     }
 
     @Test
+    fun appSharedLinkIsAlreadyInspectedButAnotherClipboardLinkStillPrompts() = runTest {
+        val controller = OfficialLinkPromptController<String>(
+            scope = this,
+            resolve = { Result.success("resolved") },
+            onResolved = {},
+            onExternalConsumed = {},
+        )
+        controller.updateAuthentication(true)
+        controller.markClipboardInspected("https://vrchat.com/home/user/usr_shared")
+
+        controller.inspectClipboard("https://www.vrchat.com/home/user/usr_shared?ref=share")
+        assertEquals(OfficialLinkPromptState.Idle, controller.state.value)
+
+        controller.inspectClipboard("https://vrchat.com/home/world/wrld_external")
+        val confirmation = assertIs<OfficialLinkPromptState.ClipboardConfirmation>(
+            controller.state.value,
+        )
+        assertEquals(OfficialLinkType.World, confirmation.operation.target.type)
+        assertEquals("wrld_external", confirmation.operation.target.id)
+    }
+
+    @Test
     fun recreatedControllerKeepsTheClipboardConfirmation() = runTest {
         val firstController = OfficialLinkPromptController<String>(
             scope = this,


### PR DESCRIPTION
关联 #86

## 实现思路

应用成功打开系统分享面板或完成桌面端复制后，将这次官方链接交给现有链接检测控制器登记。应用恢复前台读取剪贴板时，同一个资料、世界、群组或模型目标会被视为已经检测，不再弹出重复确认；不同目标仍按原流程提示。分享面板、分享文本和外部应用选择均未改变。

## 验收自查

- [x] 从 VRCM 分享功能复制官方链接后，返回应用不再弹出检测到链接的确认框。新增控制器回归测试验证应用内分享的同一目标保持空闲状态。
- [x] 直接把链接分享给其他应用的流程保持不变。Android 单元测试验证仍使用系统分享面板，并以 text/plain 原样传递链接。
- [x] 从其他来源复制不同的官方链接时仍会提示。回归测试在忽略应用内分享链接后继续放入另一世界链接，并验证出现确认状态。
- [x] 资料、世界、群组和模型页面共用的分享入口均生效。四类页面继续使用同一个官方链接分享按钮，登记逻辑按解析后的官方目标类型和编号统一处理。

## 自测结果

- `~/ai/bin/check-gate.sh implement-issue 86`：`quality gate: pass`，并成功完成 Android Debug APK 打包。
- `:composeApp:testDebugUnitTest`：`BUILD SUCCESSFUL`，包含 Android 系统分享 Intent 合同测试及共享回归测试。
- `:composeApp:desktopTest --tests io.github.vrcmteam.vrcm.presentation.compoments.OfficialLinkPromptControllerTest`：`BUILD SUCCESSFUL`。
- 完整 `:composeApp:desktopTest`：707 项中 706 项通过；唯一失败为仓库已记录的无图形环境基线 `DesktopWindowTitleBarLocaleTest.windowControlLabelsUseTheLatestLanguage`，原因是 AWT 抛出 `HeadlessException`，与本次链接改动无关。
- `git diff --check`：通过。
- 未进行真机操作；剩余风险主要是不同系统分享面板的前后台切换时序，核心状态与 Android 分享参数已由自动化测试覆盖。

## 自评风险点

系统分享接口只返回面板是否成功打开，不返回用户最终选择了复制、发送还是取消。因此面板成功打开后，该官方链接都会登记为已检测；这不会改变发送内容或目标应用，但如果用户取消面板后又从其他来源复制完全相同的官方目标，现有的重复目标规则仍会把它视为已检测。不同目标不受影响。

## 代码逻辑图

```mermaid
sequenceDiagram
    participant Button as OfficialUrlShareButton
    participant Platform as AppPlatform.shareUrl
    participant Controller as OfficialLinkPromptController
    participant Lifecycle as OfficialLinkPrompt ON_RESUME
    Button->>Platform: 打开系统分享面板并传入官方链接
    Platform-->>Button: 返回是否成功打开
    alt 成功打开
        Button->>Controller: markClipboardInspected(url)
        Lifecycle->>Controller: inspectClipboard(clipboardText)
        alt 剪贴板是同一官方目标
            Controller-->>Lifecycle: 保持 Idle，不显示确认框
        else 剪贴板是不同官方目标
            Controller-->>Lifecycle: 进入 ClipboardConfirmation
        end
    else 打开失败
        Button-->>Button: 保留现有失败提示
    end
```

## 实现假设清单

- 系统分享面板成功打开即可把本次官方链接登记为已检测。依据：issue #86 明确要求应用内分享复制的链接直接标记为检测过；现有 Android 与 iOS `shareUrl` 契约只能返回面板是否打开，无法跨平台获知复制、发送或取消的最终动作。
- 所有需要处理的官方链接分享入口都复用同一个分享按钮。依据：已核对现有资料、世界、群组和模型页面的四个调用方，没有其他官方链接分享实现。
- 同一官方目标应忽略主机是否带 `www` 及查询参数差异。依据：现有官方链接解析与重复检测本来就按目标类型和编号识别，新增测试沿用并保护这一合同。

## 实现说明(供追问)

### 关键决策

复用现有链接检测控制器保存已检测目标，不另建一套分享历史。页面通过组合范围内的登记入口把成功分享的链接交给同一个控制器，因此分享和前台剪贴板检测不会出现两份可能失同步的状态。没有改系统分享实现，因为直接分享给其他应用的内容和选择流程需要保持原样。

### 覆盖的场景

覆盖资料、世界、群组、模型官方链接；覆盖 Android 和 iOS 的系统分享入口，以及不支持系统分享时的复制回退；覆盖同一目标带 `www` 或查询参数的等价链接；覆盖分享后剪贴板出现另一个官方目标时仍正常提示；覆盖分享面板打开失败时继续显示原有错误。

### 明确未覆盖

未改变非官方链接、外部深链打开、链接解析规则、分享面板样式和各系统提供的分享目标。未通过真机自动操作系统分享面板，系统界面的具体文案和布局不在本次验收范围内。

### 关键假设

跨平台系统分享接口无法可靠报告用户最终选择的是复制、发送还是取消，因此以面板成功打开作为登记时点；该取舍及其对取消后再次复制同一目标的影响已在风险点和假设清单中说明。