### PR TITLE
fix(gallery): 保留无地点拍立得的拍摄信息

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/GalleryTabPager.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/GalleryTabPager.kt
@@ -309,6 +309,7 @@ sealed class GalleryTabPager(private val tagType: FileTagType) {
         galleryScreenModel: GalleryScreenModel,
     ) {
         val imageUrl = print.files?.image ?: ""
+        val fallbackMetadata = print.fallbackMetadata()
         val (dialogContent, setDialogContent) = LocationDialogContent.current
         val selected = galleryScreenModel.isSelected(FileTagType.Print, print.id)
         val photoPainter = rememberPrintPhotoPainter(imageUrl)
@@ -336,7 +337,16 @@ sealed class GalleryTabPager(private val tagType: FileTagType) {
                                 if (galleryScreenModel.hasSelection(FileTagType.Print)) {
                                     galleryScreenModel.toggleSelection(FileTagType.Print, print.id)
                                 } else {
-                                    setDialogContent(ImagePreviewDialog(print.id, print.id, ".png", imageUrl))
+                                    setDialogContent(
+                                        ImagePreviewDialog(
+                                            fileId = print.id,
+                                            fileName = print.id,
+                                            fileExtension = ".png",
+                                            directImageUrl = imageUrl,
+                                            printAuthorName = fallbackMetadata?.authorName,
+                                            printTimestamp = fallbackMetadata?.timestamp,
+                                        )
+                                    )
                                 }
                             },
                             onLongClick = {

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/ImagePreviewDialog.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/ImagePreviewDialog.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -32,6 +33,7 @@ import coil3.compose.rememberAsyncImagePainter
 import coil3.request.ImageRequest
 import io.github.vrcmteam.vrcm.core.extensions.saveImageToGallery
 import io.github.vrcmteam.vrcm.core.extensions.shareImage
+import io.github.vrcmteam.vrcm.core.extensions.toLocalDateTime
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.getAppPlatform
 import io.github.vrcmteam.vrcm.network.api.files.FileApi
@@ -39,6 +41,7 @@ import io.github.vrcmteam.vrcm.presentation.animations.DefaultBoundsTransform
 import io.github.vrcmteam.vrcm.presentation.compoments.*
 import io.github.vrcmteam.vrcm.presentation.extensions.enableIf
 import io.github.vrcmteam.vrcm.presentation.extensions.getInsetPadding
+import io.github.vrcmteam.vrcm.presentation.extensions.ignoredFormat
 import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
 import io.github.vrcmteam.vrcm.service.AuthService
@@ -57,6 +60,8 @@ class ImagePreviewDialog(
     private val fileName: String,
     private val fileExtension: String,
     private val directImageUrl: String? = null,
+    private val printAuthorName: String? = null,
+    private val printTimestamp: String? = null,
 ) : SharedDialog {
 
     override val transitionDurationMillis: Int =
@@ -101,6 +106,8 @@ class ImagePreviewDialog(
                         setDialogContent(null)
                     },
                     printLayoutEnabled = directImageUrl != null,
+                    printAuthorName = printAuthorName,
+                    printTimestamp = printTimestamp,
                 )
             }
 
@@ -219,6 +226,8 @@ fun BoxScope.ZoomableImage(
     animatedVisibilityScope: AnimatedVisibilityScope,
     onDismiss: () -> Unit,
     printLayoutEnabled: Boolean = false,
+    printAuthorName: String? = null,
+    printTimestamp: String? = null,
 ) {
     var targetScale by remember { mutableStateOf(1f) }
     var targetOffset by remember { mutableStateOf(Offset.Zero) }
@@ -375,6 +384,13 @@ fun BoxScope.ZoomableImage(
                         imageUrl = imageUrl,
                         modifier = Modifier.fillMaxSize(),
                     )
+                    if (printAuthorName != null || printTimestamp != null) {
+                        PrintFallbackMetadataOverlay(
+                            authorName = printAuthorName,
+                            timestamp = printTimestamp,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
                 }
                 PrintTargetPhotoLayout(modifier = Modifier.fillMaxSize()) {
                     Box(
@@ -414,6 +430,38 @@ fun BoxScope.ZoomableImage(
                     renderInOverlayDuringTransition = true,
                     clipInOverlayDuringTransition = NoOverlayClip,
                 ),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PrintFallbackMetadataOverlay(
+    authorName: String?,
+    timestamp: String?,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.Bottom,
+    ) {
+        authorName?.let {
+            Text(
+                text = it,
+                modifier = Modifier.weight(1f),
+                color = Color.Black,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.labelMedium,
+            )
+        } ?: Spacer(modifier = Modifier.weight(1f))
+        timestamp?.let {
+            Text(
+                text = it.toLocalDateTime()?.ignoredFormat ?: it,
+                color = Color.Black,
+                maxLines = 1,
+                style = MaterialTheme.typography.labelMedium,
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/ImagePreviewDialog.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/ImagePreviewDialog.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -15,15 +17,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.compose.AsyncImage
@@ -49,6 +56,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import kotlin.math.ceil
+import kotlin.math.floor
 import kotlin.math.min
 import kotlin.math.roundToInt
 
@@ -441,27 +450,93 @@ private fun PrintFallbackMetadataOverlay(
     timestamp: String?,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = modifier.padding(horizontal = 16.dp, vertical = 12.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalAlignment = Alignment.Bottom,
+    Layout(
+        content = {
+            PrintFallbackMetadataCell(
+                text = authorName,
+                alignment = Alignment.CenterStart,
+                textAlign = TextAlign.Start,
+            )
+            PrintFallbackMetadataCell(
+                text = timestamp?.let { it.toLocalDateTime()?.ignoredFormat ?: it },
+                alignment = Alignment.CenterEnd,
+                textAlign = TextAlign.End,
+            )
+        },
+        modifier = modifier,
+    ) { measurables, constraints ->
+        require(constraints.hasBoundedWidth && constraints.hasBoundedHeight) {
+            "PrintFallbackMetadataOverlay requires bounded width and height"
+        }
+        val width = constraints.maxWidth
+        val height = constraints.maxHeight
+        val bounds = Rect(0f, 0f, width.toFloat(), height.toFloat())
+        // Measure both cells inside the real lower frame so one field cannot starve the other.
+        val canvas = PrintDisplayGeometry.canvasRect(bounds)
+        val photo = PrintDisplayGeometry.targetPhotoRect(bounds)
+        val bandLeft = ceil(photo.left).toInt().coerceIn(0, width)
+        val bandRight = floor(photo.right).toInt().coerceIn(bandLeft, width)
+        val bandTop = ceil(photo.bottom).toInt().coerceIn(0, height)
+        val bandBottom = floor(canvas.bottom).toInt().coerceIn(bandTop, height)
+        val bandWidth = bandRight - bandLeft
+        val bandHeight = bandBottom - bandTop
+        val hasBothFields = authorName != null && timestamp != null
+        val sourceGap = PrintDisplayGeometry.spec.contentInsets.let { it.left + it.right }
+        val canvasScale = canvas.width / PrintDisplayGeometry.spec.canvas.canvasWidth
+        val gapWidth = if (hasBothFields) {
+            (sourceGap * canvasScale).roundToInt().coerceIn(0, bandWidth)
+        } else {
+            0
+        }
+        val availableWidth = bandWidth - gapWidth
+        val authorWidth = when {
+            authorName == null -> 0
+            timestamp == null -> availableWidth
+            else -> availableWidth / 2
+        }
+        val timestampWidth = when {
+            timestamp == null -> 0
+            authorName == null -> availableWidth
+            else -> availableWidth - authorWidth
+        }
+        val authorPlaceable = measurables[0].measure(
+            Constraints.fixed(authorWidth, bandHeight)
+        )
+        val timestampPlaceable = measurables[1].measure(
+            Constraints.fixed(timestampWidth, bandHeight)
+        )
+
+        layout(width, height) {
+            authorPlaceable.place(bandLeft, bandTop)
+            timestampPlaceable.place(
+                x = bandLeft + authorWidth + gapWidth,
+                y = bandTop,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PrintFallbackMetadataCell(
+    text: String?,
+    alignment: Alignment,
+    textAlign: TextAlign,
+) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = alignment,
     ) {
-        authorName?.let {
-            Text(
-                text = it,
-                modifier = Modifier.weight(1f),
+        text?.let {
+            val textStyle = MaterialTheme.typography.labelMedium.copy(
                 color = Color.Black,
+                textAlign = textAlign,
+            )
+            BasicText(
+                text = it,
+                style = textStyle,
+                autoSize = TextAutoSize.StepBased(8.sp, textStyle.fontSize),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
-                style = MaterialTheme.typography.labelMedium,
-            )
-        } ?: Spacer(modifier = Modifier.weight(1f))
-        timestamp?.let {
-            Text(
-                text = it.toLocalDateTime()?.ignoredFormat ?: it,
-                color = Color.Black,
-                maxLines = 1,
-                style = MaterialTheme.typography.labelMedium,
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/PrintFallbackMetadata.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/PrintFallbackMetadata.kt
@@ -1,0 +1,20 @@
+package io.github.vrcmteam.vrcm.presentation.screens.gallery
+
+import io.github.vrcmteam.vrcm.network.api.prints.data.PrintData
+
+internal data class PrintFallbackMetadata(
+    val authorName: String?,
+    val timestamp: String?,
+)
+
+internal fun PrintData.fallbackMetadata(): PrintFallbackMetadata? {
+    if (!worldName.isNullOrBlank()) return null
+
+    val metadata = PrintFallbackMetadata(
+        authorName = authorName.nonBlankOrNull(),
+        timestamp = timestamp.nonBlankOrNull() ?: createdAt.nonBlankOrNull(),
+    )
+    return metadata.takeIf { it.authorName != null || it.timestamp != null }
+}
+
+private fun String?.nonBlankOrNull(): String? = this?.trim()?.takeIf(String::isNotEmpty)

--- a/composeApp/src/commonTest/kotlin/presentation/screens/gallery/PrintFallbackMetadataTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/gallery/PrintFallbackMetadataTest.kt
@@ -1,0 +1,70 @@
+package io.github.vrcmteam.vrcm.presentation.screens.gallery
+
+import io.github.vrcmteam.vrcm.network.api.prints.data.PrintData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class PrintFallbackMetadataTest {
+    @Test
+    fun printWithoutLocationRetainsAuthorAndCaptureTime() {
+        val print = PrintData(
+            id = "prnt_uploaded",
+            authorName = "Photographer",
+            timestamp = "2026-08-18T12:00:00Z",
+        )
+
+        assertEquals(
+            PrintFallbackMetadata(
+                authorName = "Photographer",
+                timestamp = "2026-08-18T12:00:00Z",
+            ),
+            print.fallbackMetadata(),
+        )
+    }
+
+    @Test
+    fun missingMetadataFieldsAreHandledIndependently() {
+        val print = PrintData(
+            id = "prnt_saved",
+            authorName = "  ",
+            createdAt = "2026-08-18T12:00:00Z",
+        )
+
+        assertEquals(
+            PrintFallbackMetadata(
+                authorName = null,
+                timestamp = "2026-08-18T12:00:00Z",
+            ),
+            print.fallbackMetadata(),
+        )
+    }
+
+    @Test
+    fun authorIsRetainedWhenCaptureTimeIsMissing() {
+        val print = PrintData(
+            id = "prnt_legacy",
+            authorName = "Photographer",
+        )
+
+        assertEquals(
+            PrintFallbackMetadata(
+                authorName = "Photographer",
+                timestamp = null,
+            ),
+            print.fallbackMetadata(),
+        )
+    }
+
+    @Test
+    fun printWithLocationKeepsMetadataFromItsExistingCanvas() {
+        val print = PrintData(
+            id = "prnt_camera",
+            worldName = "Test World",
+            authorName = "Photographer",
+            timestamp = "2026-08-18T12:00:00Z",
+        )
+
+        assertNull(print.fallbackMetadata())
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/presentation/screens/gallery/PrintFallbackMetadataLayoutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/presentation/screens/gallery/PrintFallbackMetadataLayoutTest.kt
@@ -1,0 +1,136 @@
+package io.github.vrcmteam.vrcm.presentation.screens.gallery
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.getBoundsInRoot
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.intercept.Interceptor
+import coil3.request.ErrorResult
+import io.github.vrcmteam.vrcm.presentation.compoments.LocalSharedTransitionDialogScope
+import org.koin.compose.KoinApplication
+import org.koin.dsl.module
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class, ExperimentalSharedTransitionApi::class)
+class PrintFallbackMetadataLayoutTest {
+    @Test
+    fun narrowCanvasWithLargeFontKeepsBothFieldsInsideBottomBand() = runComposeUiTest {
+        setContent {
+            MetadataTestHost(fontScale = 2f) {
+                Box(
+                    modifier = Modifier
+                        .size(CanvasWidth, CanvasHeight)
+                        .testTag(CanvasTag),
+                ) {
+                    AnimatedVisibility(visible = true) {
+                        Box(modifier = Modifier.fillMaxSize()) {
+                            ZoomableImage(
+                                id = "prnt_layout",
+                                imageUrl = "",
+                                animatedVisibilityScope = this@AnimatedVisibility,
+                                onDismiss = {},
+                                printLayoutEnabled = true,
+                                printAuthorName = Author,
+                                printTimestamp = LongRawTimestamp,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        waitForIdle()
+        val canvas = onNodeWithTag(CanvasTag).getBoundsInRoot()
+        val author = onNodeWithText(Author).getBoundsInRoot()
+        val timestamp = onNodeWithText(LongRawTimestamp).getBoundsInRoot()
+        val photo = PrintDisplayGeometry.targetPhotoRect(
+            Rect(
+                0f,
+                0f,
+                (canvas.right - canvas.left).value,
+                (canvas.bottom - canvas.top).value,
+            )
+        )
+        val bottomBandTop = canvas.top + photo.bottom.dp
+
+        assertTrue(author.right - author.left > 0.dp, "拍摄者不能被时间压成零宽")
+        assertTrue(timestamp.right - timestamp.left > 0.dp, "时间必须保留独立的可见区域")
+        assertTrue(author.right <= timestamp.left, "拍摄者与时间不能重叠")
+        assertTrue(author.top >= bottomBandTop, "拍摄者必须位于照片下方白边内")
+        assertTrue(timestamp.top >= bottomBandTop, "时间必须位于照片下方白边内")
+        assertTrue(author.bottom <= canvas.bottom, "拍摄者不能越出画布")
+        assertTrue(timestamp.bottom <= canvas.bottom, "时间不能越出画布")
+    }
+
+    @Composable
+    private fun MetadataTestHost(
+        fontScale: Float,
+        content: @Composable () -> Unit,
+    ) {
+        val imageLoader = ImageLoader.Builder(PlatformContext.INSTANCE)
+            .components {
+                add(
+                    Interceptor { chain ->
+                        ErrorResult(
+                            image = null,
+                            request = chain.request,
+                            throwable = IllegalStateException("No network in layout tests"),
+                        )
+                    }
+                )
+            }
+            .build()
+        KoinApplication(
+            application = {
+                modules(
+                    module {
+                        single<PlatformContext> { PlatformContext.INSTANCE }
+                        single<ImageLoader> { imageLoader }
+                    }
+                )
+            },
+        ) {
+            val base = LocalDensity.current
+            CompositionLocalProvider(
+                LocalDensity provides Density(base.density, fontScale),
+            ) {
+                MaterialTheme {
+                    SharedTransitionLayout {
+                        CompositionLocalProvider(
+                            LocalSharedTransitionDialogScope provides this@SharedTransitionLayout,
+                            content = content,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private companion object {
+        val CanvasWidth = 240.dp
+        val CanvasHeight = 168.75.dp
+        const val CanvasTag = "print_metadata_canvas"
+        const val Author = "Photographer With A Very Long Display Name"
+        const val LongRawTimestamp =
+            "not-an-instant-with-a-very-long-value-that-must-not-starve-the-author"
+    }
+}


### PR DESCRIPTION
关联 #88

## 实现思路

拍立得列表接口已经返回拍摄者和拍摄时间，但打开预览时原先只传递图片地址。现在会在地点名称缺失时保留这两项信息，并把它们绘制到现有拍立得白边的信息层中；文字会跟随原有的打开、关闭和缩放效果。拍摄时间优先使用照片时间，缺失时使用记录创建时间，并按设备本地时间展示。

有地点名称的照片继续使用图片白边里原有的完整信息，不额外叠加文字，避免重复显示。

拍摄者与时间会依据现有 Print 几何定位到照片下方的真实白边，两项同时存在时各自拥有独立的有界区域，并在区域内自动缩放和单行省略，避免长原始时间、窄画布或系统大字体让其中一项消失或越出白边。

## 验收自查

- [x] 用户上传或保存的无地点拍立得仍显示拍摄者和拍摄时间。验证：`PrintFallbackMetadataTest.printWithoutLocationRetainsAuthorAndCaptureTime` 通过，并完成共享 Desktop 编译。
- [x] 地点缺失时不补造地点，有地点的拍立得保持原有展示。验证：`PrintFallbackMetadataTest.printWithLocationKeepsMetadataFromItsExistingCanvas` 通过。
- [x] 拍摄者或时间单独缺失时只省略缺失项。验证：两个单字段分支测试均通过。
- [x] 窄画布、2 倍系统字体和超长原始时间下，拍摄者与时间仍各有可见区域、互不重叠且完全位于底部白边。验证：`PrintFallbackMetadataLayoutTest.narrowCanvasWithLargeFontKeepsBothFieldsInsideBottomBand` 在修复前因拍摄者零宽失败，修复后通过。
- [x] Android 应用可以正常构建。验证：`check-gate.sh fix-review 89` 执行 `:composeApp:assembleDebug`，输出 `BUILD SUCCESSFUL` 与 `quality gate: pass`。

## 自测结果

- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests io.github.vrcmteam.vrcm.presentation.screens.gallery.PrintFallbackMetadataTest --tests io.github.vrcmteam.vrcm.presentation.screens.gallery.PrintFallbackMetadataLayoutTest --tests io.github.vrcmteam.vrcm.presentation.screens.gallery.PrintSharedBoundsRenderingTest`：通过。
- `ANDROID_HOME=/home/ubuntu/Android/Sdk ~/ai/bin/check-gate.sh fix-review 89`：通过，Android Debug APK 构建成功。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest`：共执行 711 项，710 项通过；唯一失败是仓库已知的无图形环境问题，`DesktopWindowTitleBarLocaleTest` 在创建桌面窗口时抛出 `HeadlessException`，与本次拍立得改动无关。

## 自评风险点

本次没有使用已登录的真实 VRChat 账号打开对应照片，因此没有自动取得真实数据下的视觉截图。窄画布、大字体和长文本的布局边界已有自动化测量覆盖；仍需评审或验证阶段用一张无地点照片确认真实接口字段和值的最终视觉效果。

## 代码逻辑图

本次无复杂代码逻辑，无需图示。

## 实现假设清单

- 假设 `worldName` 为空可以作为“没有可展示地点”的判断。依据：Issue 描述指出这类照片缺少地点；当前拍立得模型中 `worldName` 是唯一可直接展示的地点名称，没有单独的地点可用标记。
- 假设 `authorName` 表示应展示的拍摄者，`timestamp` 表示拍摄时间，`created_at` 可作为旧数据的时间后备。依据：当前接口模型的字段命名，以及上传请求会明确提交 `timestamp`；本次未使用真实账号数据重新核验服务端返回样本。
- 假设有地点名称的照片已经从原始图片白边提供完整信息，不应再次叠加。依据：现有预览专门保留照片区域外的信息层，且 `PrintSharedBoundsRenderingTest` 保护该行为；这样可以避免正常照片出现重复文字。

## 实现说明(供追问)

### 关键决策

只在地点名称缺失时使用接口返回的拍摄者和时间补齐白边，不修改图片文件，也不尝试从像素内容识别文字。这样可以直接修复信息被丢弃的问题，并保持已有拍立得动画与正常照片展示不变。

文字布局使用与照片裁剪相同的 Print 几何边界确定底部信息带，不再使用固定垂直内边距。两项同时存在时分别约束在左右区域，单项存在时使用完整信息带；字号在既有 8sp 到主题标签字号之间自适应。

### 覆盖的场景

覆盖无地点但两项信息齐全、只有拍摄者、只有时间、有地点无需回退，以及时间字段缺失时使用创建时间的情况。无法解析为标准时间的值会原样展示，避免再次静默丢失信息。布局额外覆盖窄画布、2 倍系统字体、超长作者和超长原始时间。

### 明确未覆盖

不补造地点，不修改网格缩略图，不改变照片上传、编辑、保存、分享或删除流程，也不调整普通图库、头像、表情和贴纸。保存和分享仍使用原始图片文件，不会把本次界面回退文字写入图片。

### 关键假设

依赖上述 `worldName`、`authorName` 和时间字段语义；真实接口样本尚未在本轮自动化环境中核验。