### PR TITLE
fix(profile): 缓存创建世界描述并按版本增量刷新

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreenModel.kt
@@ -43,9 +43,11 @@ import io.github.vrcmteam.vrcm.service.BoopService
 import io.github.vrcmteam.vrcm.storage.UserProfileCacheStore
 import io.github.vrcmteam.vrcm.storage.data.FavoritedWorldGroup
 import io.github.vrcmteam.vrcm.storage.data.UserProfileCache
+import io.github.vrcmteam.vrcm.storage.data.WorldDetailRevision
 import io.ktor.client.call.*
 import io.ktor.client.statement.*
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.NonCancellable
@@ -218,6 +220,72 @@ internal fun mergeFavoritedWorldGroups(
     }
 }
 
+internal data class CreatedWorldRefreshPlan(
+    val worlds: List<WorldData>,
+    val worldIdsToRefresh: List<String>,
+    val detailRevisions: Map<String, WorldDetailRevision>,
+)
+
+internal data class CreatedWorldRefreshResult(
+    val worlds: List<WorldData>,
+    val detailRevisions: Map<String, WorldDetailRevision>,
+)
+
+/** Keeps cached descriptions visible while identifying only stale world details for refresh. */
+internal fun planCreatedWorldRefresh(
+    summaries: List<WorldData>,
+    cachedWorlds: List<WorldData>,
+    cachedDetailRevisions: Map<String, WorldDetailRevision>,
+): CreatedWorldRefreshPlan {
+    val cachedById = cachedWorlds.associateBy(WorldData::id)
+    val currentIds = summaries.mapTo(mutableSetOf(), WorldData::id)
+    val retainedRevisions = cachedDetailRevisions.filterKeys { it in currentIds }
+    val worlds = summaries.map { summary ->
+        val cachedDescription = cachedById[summary.id]?.description
+        if (cachedDescription != null && summary.description == null) {
+            summary.copy(description = cachedDescription)
+        } else {
+            summary
+        }
+    }
+    val worldIdsToRefresh = summaries.mapNotNull { summary ->
+        val cachedRevision = retainedRevisions[summary.id]
+        summary.id.takeUnless { cachedRevision?.matches(summary) == true }
+    }
+    return CreatedWorldRefreshPlan(
+        worlds = worlds,
+        worldIdsToRefresh = worldIdsToRefresh,
+        detailRevisions = retainedRevisions,
+    )
+}
+
+/** Applies successful detail responses without marking failed requests as current. */
+internal fun mergeCreatedWorldDetails(
+    plan: CreatedWorldRefreshPlan,
+    refreshedWorlds: List<WorldData>,
+): CreatedWorldRefreshResult {
+    val visibleIds = plan.worlds.mapTo(mutableSetOf(), WorldData::id)
+    val refreshedById = refreshedWorlds
+        .filter { it.id in visibleIds }
+        .associateBy(WorldData::id)
+    val revisions = plan.detailRevisions.toMutableMap()
+    refreshedById.forEach { (id, world) ->
+        revisions[id] = world.detailRevision()
+    }
+    return CreatedWorldRefreshResult(
+        worlds = plan.worlds.map { refreshedById[it.id] ?: it },
+        detailRevisions = revisions,
+    )
+}
+
+internal fun WorldData.detailRevision() = WorldDetailRevision(
+    updatedAt = updatedAt,
+    version = version,
+)
+
+private fun WorldDetailRevision.matches(world: WorldData): Boolean =
+    (updatedAt != null || version != null) && updatedAt == world.updatedAt && version == world.version
+
 class UserProfileScreenModel(
     userProfileVO: UserProfileVo,
     private val authService: AuthService,
@@ -287,6 +355,8 @@ class UserProfileScreenModel(
     private val loadCoordinator = UserProfileLoadCoordinator()
     private val cacheMutex = Mutex()
     private var cachedUserData: UserData? = null
+    private var createdWorldDetailRevisions = emptyMap<String, WorldDetailRevision>()
+    private val profileCacheRestored = CompletableDeferred<Unit>()
     private val bioLinksUpdateStateMachine = BioLinksUpdateStateMachine()
     internal val bioLinksUpdateState: StateFlow<BioLinksUpdateState> =
         bioLinksUpdateStateMachine.state
@@ -318,8 +388,12 @@ class UserProfileScreenModel(
         viewModelScope.launch {
             // Room 读取是挂起的，缓存会比首帧稍晚一点到；只回填静态资料，
             // 在线状态一律沿用内存里的实时来源，不被上次运行的历史值压回离线。
-            userProfileCacheStore.load(cacheOwnerUserId, userProfileVO.id)
-                ?.let(::restoreCachedProfile)
+            try {
+                userProfileCacheStore.load(cacheOwnerUserId, userProfileVO.id)
+                    ?.let(::restoreCachedProfile)
+            } finally {
+                profileCacheRestored.complete(Unit)
+            }
         }
         if (userProfileVO.id == cacheOwnerUserId) {
             viewModelScope.launch {
@@ -362,6 +436,11 @@ class UserProfileScreenModel(
         _userGroups.value = visibleUserGroups(cache.groups, profile.isSelf)
         _mutualGroups.value = cache.mutualGroups
         _createdWorlds.value = cache.createdWorlds
+        createdWorldDetailRevisions = cache.createdWorldDetailRevisions.ifEmpty {
+            cache.createdWorlds
+                .filter { it.description != null }
+                .associate { it.id to it.detailRevision() }
+        }
         _createdAvatars.value = cache.createdAvatars
         setFavoritedWorldGroups(cache.favoritedWorlds)
     }
@@ -378,6 +457,7 @@ class UserProfileScreenModel(
                     groups = _userGroups.value,
                     mutualGroups = _mutualGroups.value,
                     createdWorlds = _createdWorlds.value,
+                    createdWorldDetailRevisions = createdWorldDetailRevisions,
                     createdAvatars = _createdAvatars.value,
                     favoritedWorlds = favoritedWorldGroups,
                 ),
@@ -581,6 +661,7 @@ class UserProfileScreenModel(
         _isLoadingWorlds.value = true
         viewModelScope.launch(Dispatchers.IO) {
             try {
+                profileCacheRestored.await()
                 val isSelf = userState.isSelf
                 val allWorlds = mutableListOf<WorldData>()
                 worldsApi.userWorldsFlow(
@@ -593,20 +674,29 @@ class UserProfileScreenModel(
                 ).collect { worldList ->
                     allWorlds.addAll(worldList)
                 }
-                // 展示列表
-                if (_createdWorlds.value != allWorlds) _createdWorlds.value = allWorlds
+                val refreshPlan = planCreatedWorldRefresh(
+                    summaries = allWorlds,
+                    cachedWorlds = _createdWorlds.value,
+                    cachedDetailRevisions = createdWorldDetailRevisions,
+                )
+                if (_createdWorlds.value != refreshPlan.worlds) {
+                    _createdWorlds.value = refreshPlan.worlds
+                }
                 _isLoadingWorlds.value = false
 
-                // 逐批获取完整详情以填充description
-                val worldIds = allWorlds.map { it.id }
-                if (worldIds.isNotEmpty()) {
-                    val fullWorlds = worldsApi.fetchWorldsByIds(worldIds)
-                    val fullMap = fullWorlds.associateBy { it.id }
-                    val completeWorlds = allWorlds.map { world ->
-                        fullMap[world.id] ?: world
-                    }
-                    if (_createdWorlds.value != completeWorlds) _createdWorlds.value = completeWorlds
+                val result = if (refreshPlan.worldIdsToRefresh.isNotEmpty()) {
+                    mergeCreatedWorldDetails(
+                        plan = refreshPlan,
+                        refreshedWorlds = worldsApi.fetchWorldsByIds(refreshPlan.worldIdsToRefresh),
+                    )
+                } else {
+                    CreatedWorldRefreshResult(
+                        worlds = refreshPlan.worlds,
+                        detailRevisions = refreshPlan.detailRevisions,
+                    )
                 }
+                if (_createdWorlds.value != result.worlds) _createdWorlds.value = result.worlds
+                createdWorldDetailRevisions = result.detailRevisions
                 saveCache()
             } catch (e: Exception) {
                 handleError(e)

--- a/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreenModel.kt
@@ -224,6 +224,7 @@ internal data class CreatedWorldRefreshPlan(
     val worlds: List<WorldData>,
     val worldIdsToRefresh: List<String>,
     val detailRevisions: Map<String, WorldDetailRevision>,
+    val summaryRevisions: Map<String, WorldDetailRevision>,
 )
 
 internal data class CreatedWorldRefreshResult(
@@ -240,6 +241,7 @@ internal fun planCreatedWorldRefresh(
     val cachedById = cachedWorlds.associateBy(WorldData::id)
     val currentIds = summaries.mapTo(mutableSetOf(), WorldData::id)
     val retainedRevisions = cachedDetailRevisions.filterKeys { it in currentIds }
+    val summaryRevisions = summaries.associate { it.id to it.detailRevision() }
     val worlds = summaries.map { summary ->
         val cachedDescription = cachedById[summary.id]?.description
         if (cachedDescription != null && summary.description == null) {
@@ -256,6 +258,7 @@ internal fun planCreatedWorldRefresh(
         worlds = worlds,
         worldIdsToRefresh = worldIdsToRefresh,
         detailRevisions = retainedRevisions,
+        summaryRevisions = summaryRevisions,
     )
 }
 
@@ -269,8 +272,8 @@ internal fun mergeCreatedWorldDetails(
         .filter { it.id in visibleIds }
         .associateBy(WorldData::id)
     val revisions = plan.detailRevisions.toMutableMap()
-    refreshedById.forEach { (id, world) ->
-        revisions[id] = world.detailRevision()
+    refreshedById.forEach { (id, _) ->
+        revisions[id] = plan.summaryRevisions.getValue(id)
     }
     return CreatedWorldRefreshResult(
         worlds = plan.worlds.map { refreshedById[it.id] ?: it },
@@ -436,11 +439,7 @@ class UserProfileScreenModel(
         _userGroups.value = visibleUserGroups(cache.groups, profile.isSelf)
         _mutualGroups.value = cache.mutualGroups
         _createdWorlds.value = cache.createdWorlds
-        createdWorldDetailRevisions = cache.createdWorldDetailRevisions.ifEmpty {
-            cache.createdWorlds
-                .filter { it.description != null }
-                .associate { it.id to it.detailRevision() }
-        }
+        createdWorldDetailRevisions = cache.createdWorldDetailRevisions
         _createdAvatars.value = cache.createdAvatars
         setFavoritedWorldGroups(cache.favoritedWorlds)
     }

--- a/composeApp/src/commonMain/kotlin/storage/data/UserProfileCache.kt
+++ b/composeApp/src/commonMain/kotlin/storage/data/UserProfileCache.kt
@@ -18,6 +18,7 @@ data class UserProfileCache(
     val favoritedWorlds: List<FavoritedWorldGroup> = emptyList(),
 )
 
+/** List-summary revision captured after the corresponding cached details were refreshed. */
 @Serializable
 data class WorldDetailRevision(
     val updatedAt: String?,

--- a/composeApp/src/commonMain/kotlin/storage/data/UserProfileCache.kt
+++ b/composeApp/src/commonMain/kotlin/storage/data/UserProfileCache.kt
@@ -13,8 +13,15 @@ data class UserProfileCache(
     val groups: List<LimitedUserGroup> = emptyList(),
     val mutualGroups: List<LimitedUserGroup> = emptyList(),
     val createdWorlds: List<WorldData> = emptyList(),
+    val createdWorldDetailRevisions: Map<String, WorldDetailRevision> = emptyMap(),
     val createdAvatars: List<AvatarData> = emptyList(),
     val favoritedWorlds: List<FavoritedWorldGroup> = emptyList(),
+)
+
+@Serializable
+data class WorldDetailRevision(
+    val updatedAt: String?,
+    val version: Int?,
 )
 
 @Serializable

--- a/composeApp/src/commonTest/kotlin/presentation/screens/user/UserProfileCreatedWorldCacheTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/user/UserProfileCreatedWorldCacheTest.kt
@@ -1,0 +1,104 @@
+package io.github.vrcmteam.vrcm.presentation.screens.user
+
+import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
+import io.github.vrcmteam.vrcm.storage.data.WorldDetailRevision
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UserProfileCreatedWorldCacheTest {
+    @Test
+    fun unchangedWorldKeepsCachedDescriptionWithoutDetailRefresh() {
+        val cached = world(id = "wrld_same", description = "Cached description", updatedAt = "2026-08-01", version = 2)
+        val summary = cached.copy(description = null, visits = 200)
+
+        val plan = planCreatedWorldRefresh(
+            summaries = listOf(summary),
+            cachedWorlds = listOf(cached),
+            cachedDetailRevisions = mapOf(cached.id to cached.detailRevision()),
+        )
+
+        assertEquals("Cached description", plan.worlds.single().description)
+        assertEquals(200, plan.worlds.single().visits)
+        assertEquals(emptyList(), plan.worldIdsToRefresh)
+    }
+
+    @Test
+    fun changedAndNewWorldsRefreshIncrementallyWithoutBlankingCachedDescription() {
+        val unchanged = world(id = "wrld_same", description = "Same", updatedAt = "2026-08-01", version = 1)
+        val changed = world(id = "wrld_changed", description = "Stale", updatedAt = "2026-08-01", version = 1)
+        val removed = world(id = "wrld_removed", description = "Removed", updatedAt = "2026-08-01", version = 1)
+        val summaries = listOf(
+            unchanged.copy(description = null),
+            changed.copy(description = null, updatedAt = "2026-08-02", version = 2),
+            world(id = "wrld_new", description = null, updatedAt = "2026-08-02", version = 1),
+        )
+
+        val plan = planCreatedWorldRefresh(
+            summaries = summaries,
+            cachedWorlds = listOf(unchanged, changed, removed),
+            cachedDetailRevisions = listOf(unchanged, changed, removed)
+                .associate { it.id to it.detailRevision() },
+        )
+
+        assertEquals(listOf("wrld_same", "wrld_changed", "wrld_new"), plan.worlds.map(WorldData::id))
+        assertEquals("Stale", plan.worlds[1].description)
+        assertEquals(listOf("wrld_changed", "wrld_new"), plan.worldIdsToRefresh)
+        assertEquals(setOf("wrld_same", "wrld_changed"), plan.detailRevisions.keys)
+    }
+
+    @Test
+    fun failedDetailRequestKeepsOldRevisionSoNextRefreshRetriesIt() {
+        val cached = world(id = "wrld_changed", description = "Stale", updatedAt = "2026-08-01", version = 1)
+        val summary = cached.copy(description = null, updatedAt = "2026-08-02", version = 2)
+        val oldRevision = cached.detailRevision()
+        val plan = planCreatedWorldRefresh(
+            summaries = listOf(summary),
+            cachedWorlds = listOf(cached),
+            cachedDetailRevisions = mapOf(cached.id to oldRevision),
+        )
+
+        val failedResult = mergeCreatedWorldDetails(plan, refreshedWorlds = emptyList())
+        val successfulResult = mergeCreatedWorldDetails(
+            plan,
+            refreshedWorlds = listOf(summary.copy(description = "Fresh")),
+        )
+
+        assertEquals("Stale", failedResult.worlds.single().description)
+        assertEquals(oldRevision, failedResult.detailRevisions.getValue(cached.id))
+        assertEquals("Fresh", successfulResult.worlds.single().description)
+        assertEquals(WorldDetailRevision("2026-08-02", 2), successfulResult.detailRevisions.getValue(cached.id))
+    }
+
+    private fun world(
+        id: String,
+        description: String?,
+        updatedAt: String?,
+        version: Int?,
+    ) = WorldData(
+        authorId = "usr_author",
+        authorName = "Author",
+        capacity = 16,
+        createdAt = "2026-01-01",
+        description = description,
+        favorites = 10,
+        featured = false,
+        heat = 0,
+        id = id,
+        imageUrl = "https://example.com/$id.png",
+        labsPublicationDate = "none",
+        name = id,
+        namespace = null,
+        organization = "vrchat",
+        popularity = 1,
+        publicationDate = "2026-01-01",
+        recommendedCapacity = 8,
+        releaseStatus = "public",
+        tags = emptyList(),
+        thumbnailImageUrl = null,
+        udonProducts = emptyList(),
+        unityPackages = emptyList(),
+        updatedAt = updatedAt,
+        version = version,
+        visits = 100,
+    )
+}

--- a/composeApp/src/commonTest/kotlin/presentation/screens/user/UserProfileCreatedWorldCacheTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/user/UserProfileCreatedWorldCacheTest.kt
@@ -69,6 +69,31 @@ class UserProfileCreatedWorldCacheTest {
         assertEquals(WorldDetailRevision("2026-08-02", 2), successfulResult.detailRevisions.getValue(cached.id))
     }
 
+    @Test
+    fun successfulRefreshUsesSummaryRevisionForTheNextComparison() {
+        val cached = world(id = "wrld_changed", description = "Stale", updatedAt = "2026-08-01", version = 4)
+        val summary = cached.copy(description = null, updatedAt = "2026-08-02", version = null)
+        val initialPlan = planCreatedWorldRefresh(
+            summaries = listOf(summary),
+            cachedWorlds = listOf(cached),
+            cachedDetailRevisions = mapOf(cached.id to cached.detailRevision()),
+        )
+
+        val refreshed = mergeCreatedWorldDetails(
+            plan = initialPlan,
+            refreshedWorlds = listOf(summary.copy(description = "Fresh", version = 5)),
+        )
+        val nextPlan = planCreatedWorldRefresh(
+            summaries = listOf(summary.copy(visits = 200)),
+            cachedWorlds = refreshed.worlds,
+            cachedDetailRevisions = refreshed.detailRevisions,
+        )
+
+        assertEquals(WorldDetailRevision("2026-08-02", null), refreshed.detailRevisions.getValue(cached.id))
+        assertEquals("Fresh", nextPlan.worlds.single().description)
+        assertEquals(emptyList(), nextPlan.worldIdsToRefresh)
+    }
+
     private fun world(
         id: String,
         description: String?,


### PR DESCRIPTION
关联 #91

## 实现思路

资料页缓存现在同时保存创建世界的描述和对应的列表摘要版本标记。进入资料页时先恢复缓存，所以已有世界卡片和描述可以立即显示；随后获取当前世界列表，只为新增或列表摘要发生变化的世界请求完整详情，并把成功结果合并回缓存。详情请求成功后写入同一轮列表摘要的版本标记，保证后续比较始终来自同一个接口；单个详情请求失败时保留旧描述和旧标记，让下次进入继续重试。

## 验收标准自查

- [x] 再次打开个人资料时，已缓存的创建世界描述会随世界卡片立即显示，不再先空白后补出。验证：缓存恢复先于创建世界网络刷新，定向缓存分支测试通过。
- [x] 后台核对最新创建世界列表，未变化的世界不重复请求详情，新增或版本变化的世界才补取详情。验证：定向测试覆盖不变、变更、新增，以及列表不含 `version` 而详情包含 `version` 的真实字段差异。
- [x] 刷新成功后，最新描述和同轮列表摘要的版本标记会写回资料缓存。验证：定向测试断言详情合并结果及下一轮增量判断。
- [x] 已删除或不再可见的世界会从当前列表和后续缓存中移除。验证：刷新计划只保留当前列表中的世界 ID。
- [x] 单个世界详情获取失败时保留仍可用的信息，其余世界继续更新，并在下一次刷新时重试。验证：详情合并不会覆盖失败条目或推进其旧版本标记，定向测试覆盖失败后重试。

## 自测结果

- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests io.github.vrcmteam.vrcm.presentation.screens.user.UserProfileCreatedWorldCacheTest`：4 项全部通过，BUILD SUCCESSFUL。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:compileKotlinDesktop`：BUILD SUCCESSFUL。
- 完整 `:composeApp:desktopTest`：713 项中 712 项通过；唯一失败是无图形环境下既有 `DesktopWindowTitleBarLocaleTest.windowControlLabelsUseTheLatestLanguage` 的 `HeadlessException`，本次相关测试均通过。
- `~/ai/bin/check-gate.sh fix-review 92`：`quality gate: pass`，Android Debug 构建 BUILD SUCCESSFUL。
- `git diff --check`：通过。
- VRChat 公开 OpenAPI 的 `GET /worlds` 响应类型为 `LimitedWorld`：定义必填 `updated_at`，不定义 `version`；详情 `World` 才定义 `version`。本轮尝试实时探测时被 VRChat WAF 以 403 拒绝，因此未将该探测当作真实账号联调证据。
- 未进行真实 VRChat 账号联调或真机测试；本次改动是共享资料缓存逻辑，不涉及 Android 专属能力。

## 自评风险点

- 增量判断使用同一路世界列表响应中的 `updated_at` 和 `version`。两者的值（包括缺失状态）均与上次摘要相等且至少一项非空时才跳过详情；若上游两项都不返回，会保守地再次请求，不会让描述长期过期。
- 完整 Desktop 测试在无图形环境仍有一个仓库既有失败，需在具备图形会话的环境补跑该测试。

## 代码逻辑图

```mermaid
sequenceDiagram
    participant Screen as ProfileContent
    participant Model as UserProfileScreenModel
    participant Cache as UserProfileCacheStore
    participant Worlds as WorldsApi

    par init 缓存恢复协程
        Model->>Cache: load(ownerUserId, userId)
        Cache-->>Model: cached worlds and summary revisions
        Model->>Model: restore cache and complete profileCacheRestored
    and 页面触发世界加载
        Screen->>Model: loadCreatedWorlds(userId)
        Model->>Model: await profileCacheRestored
    end
    Model->>Worlds: userWorldsFlow(...)
    Worlds-->>Model: current world summaries
    Model->>Model: plan refresh and capture summary revisions
    alt new or changed worlds exist
        Model->>Worlds: fetchWorldsByIds(stale IDs)
        Worlds-->>Model: successful detail responses
        Model->>Model: merge details and commit matching summary revisions
    else all summary revisions unchanged
        Model->>Model: keep cached descriptions
    end
    Model->>Cache: save(updated worlds and summary revisions)
```

## 实现假设清单

- 增量机制不再假设列表接口与详情接口的 `version` 一致。依据：公开规范中的 [LimitedWorld](https://github.com/vrchatapi/specification/blob/main/openapi/components/schemas/LimitedWorld.yaml) 定义 `updated_at` 而不定义 `version`，完整 [World](https://github.com/vrchatapi/specification/blob/main/openapi/components/schemas/World.yaml) 才定义 `version`；实现保存并比较同一路列表摘要。若列表同时提供两个字段，则两个字段（含缺失状态）都要与缓存基线一致；若仅提供 `updated_at`，仍可正常增量刷新。
- `WorldsApi.fetchWorldsByIds` 对单个详情失败时跳过该项并返回其他成功项。依据：现有 API 实现对每个 ID 使用独立的失败捕获；合并逻辑因此保留失败条目的旧描述并不推进版本。

## 实现说明(供追问)

### 关键决策

缓存恢复和世界列表刷新之间增加明确的先后关系，避免网络摘要先返回并把已有描述清空。刷新计划从当前列表摘要采集版本标记；详情请求成功后写入对应的摘要标记，而不是详情响应自己的标记，因此下一轮始终是列表对列表比较。详情接口返回的结果按世界 ID 合并，避免失败条目影响其他世界；旧缓存没有摘要标记时会保守刷新一次并建立新基线。

### 覆盖的场景

覆盖已有缓存的立即展示、未变化世界跳过请求、变更或新增世界增量请求、列表缺少 `version` 但详情带有 `version`、世界被移除、详情部分失败、旧缓存没有版本映射时的兼容回退，以及刷新成功后的缓存写回。

### 明确未覆盖

没有调整世界卡片样式、排序或点击行为，没有改变创建模型、收藏世界或世界详情页的缓存策略，也没有修改服务端接口和详情请求的并发策略。未做真实账号联调和真机视觉验证。

### 关键假设

列表摘要的 `updated_at` 可作为详情变化信号；公开规范将其列为 `LimitedWorld` 必填字段。实现不依赖列表提供 `version`，也不依赖列表与详情的版本字段一致；如果上游连可用的摘要标记都暂时不返回，系统会重复刷新以保证描述不会长期过期。