### PR TITLE
feat(favorites): 缓存收藏世界和模型列表

### DIFF
--- a/composeApp/src/commonMain/kotlin/di/modules/StorageModule.kt
+++ b/composeApp/src/commonMain/kotlin/di/modules/StorageModule.kt
@@ -6,8 +6,10 @@ import io.github.vrcmteam.vrcm.storage.AccountDao
 import io.github.vrcmteam.vrcm.storage.AccountCacheManager
 import io.github.vrcmteam.vrcm.storage.DaoKeys
 import io.github.vrcmteam.vrcm.storage.FavoriteLocalDao
+import io.github.vrcmteam.vrcm.storage.FavoriteListCacheStore
 import io.github.vrcmteam.vrcm.storage.FriendActivityCacheStore
 import io.github.vrcmteam.vrcm.storage.RoomFriendActivityStore
+import io.github.vrcmteam.vrcm.storage.RoomFavoriteListCacheStore
 import io.github.vrcmteam.vrcm.storage.SettingsDao
 import io.github.vrcmteam.vrcm.storage.SecureStorage
 import io.github.vrcmteam.vrcm.storage.FriendListCacheStore
@@ -67,11 +69,12 @@ internal val storageModule: Module = module {
     single { get<io.github.vrcmteam.vrcm.storage.VrcmDatabase>().friendActivityDao() }
     single { get<io.github.vrcmteam.vrcm.storage.VrcmDatabase>().cachedBlobDao() }
     single<UserProfileCacheStore> { RoomUserProfileCacheStore(get(), appClock) }
+    single<FavoriteListCacheStore> { RoomFavoriteListCacheStore(get(), appClock) }
     single<FriendListCacheStore> { RoomFriendListCacheStore(get(), appClock) }
     single<FriendNetworkCacheStore> { RoomFriendNetworkCacheStore(get(), appClock) }
     single<WorldProfileCacheStore> { RoomWorldProfileCacheStore(get(), appClock) }
     single<GroupProfileCacheStore> { RoomGroupProfileCacheStore(get(), appClock) }
     singleOf(::RoomFriendActivityStore) bind FriendActivityCacheStore::class
-    single { AccountCacheManager(get(), get(), get(), get(), get()).also { purgeLegacySettingsCaches() } }
+    single { AccountCacheManager(get(), get(), get(), get(), get(), get()).also { purgeLegacySettingsCaches() } }
     singleOf(::PersistentCookiesStorage) bind CookiesStorage::class
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
@@ -3,6 +3,7 @@ package io.github.vrcmteam.vrcm.presentation.screens.home.pager
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
 import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType.*
@@ -26,6 +27,10 @@ import io.github.vrcmteam.vrcm.presentation.screens.user.data.UserProfileVo
 import io.github.vrcmteam.vrcm.service.AuthService
 import io.github.vrcmteam.vrcm.service.FavoriteService
 import io.github.vrcmteam.vrcm.service.FriendService
+import io.github.vrcmteam.vrcm.storage.AccountCacheManager
+import io.github.vrcmteam.vrcm.storage.AccountCacheWriteToken
+import io.github.vrcmteam.vrcm.storage.FavoriteListCacheStore
+import io.github.vrcmteam.vrcm.storage.data.FavoritedWorldGroup
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -65,6 +70,8 @@ class FriendListPagerModel(
     private val favoriteService: FavoriteService,
     private val worldsApi: WorldsApi,
     private val avatarsApi: AvatarsApi,
+    private val favoriteListCacheStore: FavoriteListCacheStore,
+    private val accountCacheManager: AccountCacheManager,
 ) : ViewModel() {
 
     // 当前选中的标签页索引
@@ -177,23 +184,68 @@ class FriendListPagerModel(
                     }
 
                     World -> {
+                        val sessionToken = SharedFlowCentre.currentSession.value?.token ?: return@launch
+                        restoreFavoriteListCache(World, sessionToken)
+                        if (!SharedFlowCentre.isCurrentSession(sessionToken)) return@launch
                         // 加载收藏组信息，用于分组过滤
                         favoriteService.loadFavoriteByGroup(World)
+                        if (!SharedFlowCentre.isCurrentSession(sessionToken)) return@launch
                         // 直接从API获取收藏世界列表
-                        doRefreshWorldList()
+                        doRefreshWorldList(sessionToken)
                     }
 
                     Avatar -> {
+                        val sessionToken = SharedFlowCentre.currentSession.value?.token ?: return@launch
+                        restoreFavoriteListCache(Avatar, sessionToken)
+                        if (!SharedFlowCentre.isCurrentSession(sessionToken)) return@launch
                         favoriteService.loadFavoriteByGroup(Avatar)
-                        doRefreshAvatarList()
+                        if (!SharedFlowCentre.isCurrentSession(sessionToken)) return@launch
+                        doRefreshAvatarList(sessionToken)
                     }
                 }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
             } catch (e: Exception) {
                 SharedFlowCentre.toastText.emit(ToastText.Error("加载收藏组信息失败: ${e.message}"))
             } finally {
                 _isRefreshing.value = false
             }
         }
+
+    private suspend fun restoreFavoriteListCache(
+        favoriteType: FavoriteType,
+        sessionToken: AccountSessionToken,
+    ) {
+        val cached = try {
+            favoriteListCacheStore.load(sessionToken.userId)
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            SharedFlowCentre.toastText.emit(ToastText.Error("读取收藏缓存失败: ${error.message}"))
+            null
+        } ?: return
+        if (!SharedFlowCentre.isCurrentSession(sessionToken)) return
+
+        when (favoriteType) {
+            World -> {
+                replaceFavoritedWorldCache(
+                    cache = favoritedWorldMap,
+                    worlds = cached.favoritedWorlds.flatMap { it.worlds },
+                )
+                _worldTotal.value = favoritedWorldMap.size
+                findWorldList(_searchText.value)
+            }
+
+            Avatar -> {
+                favoritedAvatarMap.clear()
+                favoritedAvatarMap.putAll(cached.favoritedAvatars.associateBy { it.id })
+                _avatarTotal.value = favoritedAvatarMap.size
+                findAvatarList(_searchText.value)
+            }
+
+            Friend -> Unit
+        }
+    }
 
     private suspend fun doRefreshFriendList() {
         friendService.refreshFriendList()
@@ -455,7 +507,8 @@ class FriendListPagerModel(
     /**
      * 刷新收藏的模型列表
      */
-    private suspend fun doRefreshAvatarList() {
+    private suspend fun doRefreshAvatarList(sessionToken: AccountSessionToken) {
+        val cacheWriteToken = accountCacheManager.captureWriteToken(sessionToken.userId)
         authService.reTryAuthCatching {
             // /avatars/favorites 默认只返回默认收藏组，必须按组 tag 分别请求。
             val remoteTags = remoteAvatarFavoriteTags(avatarFavoriteGroupsFlow.value).let { tags ->
@@ -471,11 +524,14 @@ class FriendListPagerModel(
             }
             mergeFavoritedAvatars(remoteAvatars, localAvatars)
         }.onSuccess { avatars ->
+            if (!SharedFlowCentre.isCurrentSession(sessionToken)) return@onSuccess
             favoritedAvatarMap.clear()
             favoritedAvatarMap.putAll(avatars.associateBy { it.id })
             _avatarTotal.value = favoritedAvatarMap.size
             findAvatarList(_searchText.value)
+            persistFavoritedAvatars(cacheWriteToken, avatars)
         }.onFailure {
+            if (it is CancellationException) throw it
             SharedFlowCentre.toastText.emit(ToastText.Error("获取收藏模型失败: ${it.message}"))
         }
     }
@@ -500,7 +556,8 @@ class FriendListPagerModel(
      * 刷新收藏的世界列表
      * 使用流式分页API获取全部收藏世界列表
      */
-    private suspend fun doRefreshWorldList() {
+    private suspend fun doRefreshWorldList(sessionToken: AccountSessionToken) {
+        val cacheWriteToken = accountCacheManager.captureWriteToken(sessionToken.userId)
         try {
             val localEntry = worldFavoriteGroupsFlow.value.entries.firstOrNull { (group, _) ->
                 group.ownerId == "local" && group.type == World.value
@@ -518,16 +575,45 @@ class FriendListPagerModel(
                 .toList()
                 .flatten()
 
-            replaceFavoritedWorldCache(
-                cache = favoritedWorldMap,
-                worlds = mergeFavoritedWorlds(remoteFavoritedWorlds, localFavoritedWorlds),
-            )
+            if (!SharedFlowCentre.isCurrentSession(sessionToken)) return
+            val worlds = mergeFavoritedWorlds(remoteFavoritedWorlds, localFavoritedWorlds)
+            replaceFavoritedWorldCache(cache = favoritedWorldMap, worlds = worlds)
             _worldTotal.value = favoritedWorldMap.size
             findWorldList(_searchText.value)
+            persistFavoritedWorlds(
+                cacheWriteToken,
+                groupFavoritedWorlds(worlds, worldFavoriteGroupsFlow.value),
+            )
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             SharedFlowCentre.toastText.emit(ToastText.Error("获取收藏世界失败: ${e.message}"))
+        }
+    }
+
+    private suspend fun persistFavoritedWorlds(
+        token: AccountCacheWriteToken,
+        worlds: List<FavoritedWorldGroup>,
+    ) {
+        try {
+            accountCacheManager.saveFavoriteWorldsIfCurrent(token, worlds)
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            SharedFlowCentre.toastText.emit(ToastText.Error("保存收藏世界缓存失败: ${error.message}"))
+        }
+    }
+
+    private suspend fun persistFavoritedAvatars(
+        token: AccountCacheWriteToken,
+        avatars: List<AvatarData>,
+    ) {
+        try {
+            accountCacheManager.saveFavoriteAvatarsIfCurrent(token, avatars)
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            SharedFlowCentre.toastText.emit(ToastText.Error("保存收藏模型缓存失败: ${error.message}"))
         }
     }
 }
@@ -644,6 +730,32 @@ internal fun mergeFavoritedWorlds(
     remoteWorlds: List<FavoritedWorld>,
     localWorlds: List<FavoritedWorld>,
 ): List<FavoritedWorld> = (remoteWorlds + localWorlds).distinctBy(::favoritedWorldCacheKey)
+
+internal fun groupFavoritedWorlds(
+    worlds: List<FavoritedWorld>,
+    favoriteGroups: Map<FavoriteGroupData, List<FavoriteData>>,
+): List<FavoritedWorldGroup> {
+    val worldsByGroup = worlds.groupBy { it.favoriteGroup }
+    val groups = favoriteGroups.keys
+        .filter { it.type == World.value }
+        .distinctBy { it.name }
+    val knownGroupKeys = groups.mapTo(mutableSetOf()) { it.name }
+    return groups.map { group ->
+        FavoritedWorldGroup(
+            name = group.displayName,
+            worlds = worldsByGroup[group.name].orEmpty(),
+            groupKey = group.name,
+        )
+    } + worldsByGroup
+        .filterKeys { it !in knownGroupKeys }
+        .map { (groupKey, groupedWorlds) ->
+            FavoritedWorldGroup(
+                name = groupKey,
+                worlds = groupedWorlds,
+                groupKey = groupKey,
+            )
+        }
+}
 
 internal fun replaceFavoritedWorldCache(
     cache: MutableMap<String, FavoritedWorld>,

--- a/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreenModel.kt
@@ -232,6 +232,19 @@ internal fun mergeFavoritedWorldGroups(
 private fun FavoritedWorldGroup.isLocalWorldGroup(): Boolean =
     groupKey == "__local_world__" || worlds.any { it.favoriteId.startsWith("local|world|") }
 
+/** 迁移未成功时保留旧资料字段，避免异步迁移期间用空快照覆盖旧收藏。 */
+internal fun profileFavoritedWorldsForCache(
+    userId: String,
+    cacheOwnerUserId: String,
+    migrationSucceeded: Boolean,
+    favoritedWorldGroups: List<FavoritedWorldGroup>,
+): List<FavoritedWorldGroup> =
+    if (userId == cacheOwnerUserId && migrationSucceeded) {
+        emptyList()
+    } else {
+        favoritedWorldGroups
+    }
+
 class UserProfileScreenModel(
     userProfileVO: UserProfileVo,
     private val authService: AuthService,
@@ -305,6 +318,8 @@ class UserProfileScreenModel(
     private val loadCoordinator = UserProfileLoadCoordinator()
     private val cacheMutex = Mutex()
     private val cacheRestoreCompleted = CompletableDeferred<Unit>()
+    /** 本人资料的旧收藏世界只有迁移成功后才能从旧缓存字段移除。 */
+    private val selfFavoriteWorldMigration = CompletableDeferred<Boolean>()
     private var cachedUserData: UserData? = null
     private val bioLinksUpdateStateMachine = BioLinksUpdateStateMachine()
     internal val bioLinksUpdateState: StateFlow<BioLinksUpdateState> =
@@ -337,13 +352,19 @@ class UserProfileScreenModel(
         viewModelScope.launch {
             // Room 读取是挂起的，缓存会比首帧稍晚一点到；只回填静态资料，
             // 在线状态一律沿用内存里的实时来源，不被上次运行的历史值压回离线。
+            var migrationSucceeded = userProfileVO.id != cacheOwnerUserId
             try {
                 val profileCache = userProfileCacheStore.load(cacheOwnerUserId, userProfileVO.id)
                 profileCache?.let(::restoreCachedProfile)
                 if (userProfileVO.id == cacheOwnerUserId) {
-                    restoreSelfFavoriteWorldCache(profileCache)
+                    migrationSucceeded = restoreSelfFavoriteWorldCache(profileCache)
                 }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Exception) {
+                handleError(error)
             } finally {
+                selfFavoriteWorldMigration.complete(migrationSucceeded)
                 cacheRestoreCompleted.complete(Unit)
             }
         }
@@ -392,28 +413,28 @@ class UserProfileScreenModel(
         setFavoritedWorldGroups(cache.favoritedWorlds)
     }
 
-    private suspend fun restoreSelfFavoriteWorldCache(profileCache: UserProfileCache?) {
-        if (!isProfileSessionCurrent()) return
+    private suspend fun restoreSelfFavoriteWorldCache(profileCache: UserProfileCache?): Boolean {
+        if (!isProfileSessionCurrent()) return false
         val sharedCache = try {
             favoriteListCacheStore.load(cacheOwnerUserId)
         } catch (cancelled: CancellationException) {
             throw cancelled
         } catch (error: Exception) {
             handleError(error)
-            return
+            return false
         }
-        if (!isProfileSessionCurrent()) return
+        if (!isProfileSessionCurrent()) return false
 
         if (sharedCache != null) {
             setFavoritedWorldGroups(sharedCache.favoritedWorlds)
+            return true
         } else {
             val legacyWorlds = profileCache?.favoritedWorlds.orEmpty()
-            if (legacyWorlds.isNotEmpty()) {
-                accountCacheManager.saveFavoriteWorldsIfCurrent(
-                    favoriteCacheWriteToken,
-                    legacyWorlds,
-                )
-            }
+            if (legacyWorlds.isEmpty()) return true
+            return accountCacheManager.saveFavoriteWorldsIfCurrent(
+                favoriteCacheWriteToken,
+                legacyWorlds,
+            )
         }
     }
 
@@ -421,6 +442,7 @@ class UserProfileScreenModel(
         profileSessionToken?.let(SharedFlowCentre::isCurrentSession) == true
 
     private suspend fun saveCache(user: UserData? = null) {
+        val migrationSucceeded = selfFavoriteWorldMigration.await()
         cacheMutex.withLock {
             user?.let { cachedUserData = it }
             val cachedUser = cachedUserData ?: return
@@ -433,11 +455,12 @@ class UserProfileScreenModel(
                     mutualGroups = _mutualGroups.value,
                     createdWorlds = _createdWorlds.value,
                     createdAvatars = _createdAvatars.value,
-                    favoritedWorlds = if (cachedUser.id == cacheOwnerUserId) {
-                        emptyList()
-                    } else {
-                        favoritedWorldGroups
-                    },
+                    favoritedWorlds = profileFavoritedWorldsForCache(
+                        userId = cachedUser.id,
+                        cacheOwnerUserId = cacheOwnerUserId,
+                        migrationSucceeded = migrationSucceeded,
+                        favoritedWorldGroups = favoritedWorldGroups,
+                    ),
                 ),
             )
         }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreenModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.github.vrcmteam.vrcm.core.extensions.pretty
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.attributes.BlueprintType
 import io.github.vrcmteam.vrcm.network.api.attributes.LocationType
@@ -40,12 +41,15 @@ import io.github.vrcmteam.vrcm.service.FriendActivityService
 import io.github.vrcmteam.vrcm.service.FriendActivitySummary
 import io.github.vrcmteam.vrcm.service.BoopResult
 import io.github.vrcmteam.vrcm.service.BoopService
+import io.github.vrcmteam.vrcm.storage.AccountCacheManager
+import io.github.vrcmteam.vrcm.storage.FavoriteListCacheStore
 import io.github.vrcmteam.vrcm.storage.UserProfileCacheStore
 import io.github.vrcmteam.vrcm.storage.data.FavoritedWorldGroup
 import io.github.vrcmteam.vrcm.storage.data.UserProfileCache
 import io.ktor.client.call.*
 import io.ktor.client.statement.*
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.NonCancellable
@@ -204,19 +208,29 @@ internal data class FavoritedWorldGroupLoad(
 internal fun mergeFavoritedWorldGroups(
     cachedGroups: List<FavoritedWorldGroup>,
     loads: List<FavoritedWorldGroupLoad>,
-): List<FavoritedWorldGroup> = loads.mapNotNull { load ->
-    if (load.result.isSuccess) {
-        FavoritedWorldGroup(
-            name = load.displayName,
-            worlds = load.result.getOrThrow(),
-            groupKey = load.groupKey,
-        )
-    } else {
-        cachedGroups.firstOrNull { cached ->
-            cached.groupKey == load.groupKey || cached.name == load.displayName
-        }?.copy(name = load.displayName, groupKey = load.groupKey)
+): List<FavoritedWorldGroup> {
+    val remoteGroups = loads.mapNotNull { load ->
+        if (load.result.isSuccess) {
+            FavoritedWorldGroup(
+                name = load.displayName,
+                worlds = load.result.getOrThrow(),
+                groupKey = load.groupKey,
+            )
+        } else {
+            cachedGroups.firstOrNull { cached ->
+                cached.groupKey == load.groupKey || cached.name == load.displayName
+            }?.copy(name = load.displayName, groupKey = load.groupKey)
+        }
     }
+    val loadedKeys = loads.mapTo(mutableSetOf()) { it.groupKey }
+    val localGroups = cachedGroups.filter { cached ->
+        cached.groupKey !in loadedKeys && cached.isLocalWorldGroup()
+    }
+    return remoteGroups + localGroups
 }
+
+private fun FavoritedWorldGroup.isLocalWorldGroup(): Boolean =
+    groupKey == "__local_world__" || worlds.any { it.favoriteId.startsWith("local|world|") }
 
 class UserProfileScreenModel(
     userProfileVO: UserProfileVo,
@@ -232,12 +246,16 @@ class UserProfileScreenModel(
     private val favoriteApi: FavoriteApi,
     private val inviteApi: InviteApi,
     private val userProfileCacheStore: UserProfileCacheStore,
+    private val favoriteListCacheStore: FavoriteListCacheStore,
+    private val accountCacheManager: AccountCacheManager,
     private val friendLocationPagerModel: FriendLocationPagerModel,
     friendActivityService: FriendActivityService,
     private val boopService: BoopService,
 ) : ViewModel() {
 
     private val cacheOwnerUserId = authService.accountDto().userId
+    private val profileSessionToken: AccountSessionToken? = SharedFlowCentre.currentSession.value?.token
+    private val favoriteCacheWriteToken = accountCacheManager.captureWriteToken(cacheOwnerUserId)
     private val _userState = mutableStateOf(userProfileVO.withSelfIdentity())
     val userState by _userState
 
@@ -286,6 +304,7 @@ class UserProfileScreenModel(
 
     private val loadCoordinator = UserProfileLoadCoordinator()
     private val cacheMutex = Mutex()
+    private val cacheRestoreCompleted = CompletableDeferred<Unit>()
     private var cachedUserData: UserData? = null
     private val bioLinksUpdateStateMachine = BioLinksUpdateStateMachine()
     internal val bioLinksUpdateState: StateFlow<BioLinksUpdateState> =
@@ -318,8 +337,15 @@ class UserProfileScreenModel(
         viewModelScope.launch {
             // Room 读取是挂起的，缓存会比首帧稍晚一点到；只回填静态资料，
             // 在线状态一律沿用内存里的实时来源，不被上次运行的历史值压回离线。
-            userProfileCacheStore.load(cacheOwnerUserId, userProfileVO.id)
-                ?.let(::restoreCachedProfile)
+            try {
+                val profileCache = userProfileCacheStore.load(cacheOwnerUserId, userProfileVO.id)
+                profileCache?.let(::restoreCachedProfile)
+                if (userProfileVO.id == cacheOwnerUserId) {
+                    restoreSelfFavoriteWorldCache(profileCache)
+                }
+            } finally {
+                cacheRestoreCompleted.complete(Unit)
+            }
         }
         if (userProfileVO.id == cacheOwnerUserId) {
             viewModelScope.launch {
@@ -366,6 +392,34 @@ class UserProfileScreenModel(
         setFavoritedWorldGroups(cache.favoritedWorlds)
     }
 
+    private suspend fun restoreSelfFavoriteWorldCache(profileCache: UserProfileCache?) {
+        if (!isProfileSessionCurrent()) return
+        val sharedCache = try {
+            favoriteListCacheStore.load(cacheOwnerUserId)
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            handleError(error)
+            return
+        }
+        if (!isProfileSessionCurrent()) return
+
+        if (sharedCache != null) {
+            setFavoritedWorldGroups(sharedCache.favoritedWorlds)
+        } else {
+            val legacyWorlds = profileCache?.favoritedWorlds.orEmpty()
+            if (legacyWorlds.isNotEmpty()) {
+                accountCacheManager.saveFavoriteWorldsIfCurrent(
+                    favoriteCacheWriteToken,
+                    legacyWorlds,
+                )
+            }
+        }
+    }
+
+    private fun isProfileSessionCurrent(): Boolean =
+        profileSessionToken?.let(SharedFlowCentre::isCurrentSession) == true
+
     private suspend fun saveCache(user: UserData? = null) {
         cacheMutex.withLock {
             user?.let { cachedUserData = it }
@@ -379,7 +433,11 @@ class UserProfileScreenModel(
                     mutualGroups = _mutualGroups.value,
                     createdWorlds = _createdWorlds.value,
                     createdAvatars = _createdAvatars.value,
-                    favoritedWorlds = favoritedWorldGroups,
+                    favoritedWorlds = if (cachedUser.id == cacheOwnerUserId) {
+                        emptyList()
+                    } else {
+                        favoritedWorldGroups
+                    },
                 ),
             )
         }
@@ -653,6 +711,7 @@ class UserProfileScreenModel(
         _isLoadingFavoritedWorlds.value = true
         viewModelScope.launch(Dispatchers.IO) {
             try {
+                cacheRestoreCompleted.await()
                 val groups = authService.reTryAuthCatching {
                     favoriteApi.getFavoriteGroupsByType(
                         favoriteType = FavoriteType.World,
@@ -660,7 +719,6 @@ class UserProfileScreenModel(
                         n = 100
                     )
                 }.getOrNull() ?: run {
-                    _isLoadingFavoritedWorlds.value = false
                     return@launch
                 }
 
@@ -685,9 +743,20 @@ class UserProfileScreenModel(
                     loads = deferreds.map { it.await() },
                 )
                 setFavoritedWorldGroups(mergedGroups)
+                if (userId == cacheOwnerUserId && isProfileSessionCurrent()) {
+                    accountCacheManager.saveFavoriteWorldsIfCurrent(
+                        favoriteCacheWriteToken,
+                        mergedGroups,
+                    )
+                }
                 saveCache()
-            } catch (_: Exception) {}
-            _isLoadingFavoritedWorlds.value = false
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Exception) {
+                handleError(error)
+            } finally {
+                _isLoadingFavoritedWorlds.value = false
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/storage/AccountCacheManager.kt
+++ b/composeApp/src/commonMain/kotlin/storage/AccountCacheManager.kt
@@ -1,6 +1,8 @@
 package io.github.vrcmteam.vrcm.storage
 
 import io.github.vrcmteam.vrcm.storage.data.FriendListCache
+import io.github.vrcmteam.vrcm.storage.data.FavoritedWorldGroup
+import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
 import io.github.vrcmteam.vrcm.storage.meetup.MeetupAssetRef
 import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardAssetStore
 import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardConfigDao
@@ -36,6 +38,7 @@ class AccountCacheManager(
     private val friendActivityStore: FriendActivityCacheStore,
     private val meetupCardConfigDao: MeetupCardConfigDao,
     private val meetupCardAssetStore: MeetupCardAssetStore,
+    private val favoriteListCacheStore: FavoriteListCacheStore = NoOpFavoriteListCacheStore,
 ) {
     private val lock = SynchronizedObject()
     private var globalGeneration = 0L
@@ -174,6 +177,20 @@ class AccountCacheManager(
         friendListCacheStore.save(token.userId, cache)
     }
 
+    internal suspend fun saveFavoriteWorldsIfCurrent(
+        token: AccountCacheWriteToken,
+        worlds: List<FavoritedWorldGroup>,
+    ): Boolean = mutateIfCurrent(token) {
+        favoriteListCacheStore.saveWorlds(token.userId, worlds)
+    }
+
+    internal suspend fun saveFavoriteAvatarsIfCurrent(
+        token: AccountCacheWriteToken,
+        avatars: List<AvatarData>,
+    ): Boolean = mutateIfCurrent(token) {
+        favoriteListCacheStore.saveAvatars(token.userId, avatars)
+    }
+
     suspend fun clearAccount(userId: String) {
         var invalidation: AccountCacheInvalidation? = null
         accountMutationMutex.lock()
@@ -186,6 +203,7 @@ class AccountCacheManager(
             }
             // Room 的清理是挂起调用，只能放在 synchronized 之外。
             friendListCacheStore.clear(userId)
+            favoriteListCacheStore.clear(userId)
             userProfileCacheStore.clearOwner(userId)
             meetupCardAssetStore.deleteAccount(userId)
             friendActivityStore.clearAccount(userId)
@@ -207,6 +225,7 @@ class AccountCacheManager(
                 invalidation = AccountCacheInvalidation(null, invalidationEpoch)
             }
             friendListCacheStore.clearAll()
+            favoriteListCacheStore.clearAll()
             userProfileCacheStore.clearAll()
             friendActivityStore.clearAll()
         } finally {
@@ -247,4 +266,16 @@ class AccountCacheManager(
         val ownerId: String,
         val assets: MutableSet<MeetupAssetRef> = mutableSetOf(),
     )
+}
+
+private object NoOpFavoriteListCacheStore : FavoriteListCacheStore {
+    override suspend fun load(userId: String) = null
+
+    override suspend fun saveWorlds(userId: String, worlds: List<FavoritedWorldGroup>) = Unit
+
+    override suspend fun saveAvatars(userId: String, avatars: List<AvatarData>) = Unit
+
+    override suspend fun clear(userId: String) = Unit
+
+    override suspend fun clearAll() = Unit
 }

--- a/composeApp/src/commonMain/kotlin/storage/CacheStores.kt
+++ b/composeApp/src/commonMain/kotlin/storage/CacheStores.kt
@@ -1,10 +1,28 @@
 package io.github.vrcmteam.vrcm.storage
 
+import io.github.vrcmteam.vrcm.storage.data.FavoriteListCache
+import io.github.vrcmteam.vrcm.storage.data.FavoritedWorldGroup
 import io.github.vrcmteam.vrcm.storage.data.FriendListCache
 import io.github.vrcmteam.vrcm.storage.data.FriendNetworkCache
 import io.github.vrcmteam.vrcm.storage.data.GroupProfileCache
 import io.github.vrcmteam.vrcm.storage.data.UserProfileCache
 import io.github.vrcmteam.vrcm.storage.data.WorldProfileCache
+import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/** 收藏页列表缓存：按当前账号存取世界分组和模型列表。 */
+interface FavoriteListCacheStore {
+    suspend fun load(userId: String): FavoriteListCache?
+
+    suspend fun saveWorlds(userId: String, worlds: List<FavoritedWorldGroup>)
+
+    suspend fun saveAvatars(userId: String, avatars: List<AvatarData>)
+
+    suspend fun clear(userId: String)
+
+    suspend fun clearAll()
+}
 
 /** 资料页缓存：按“当前账号 × 被查看用户”存取。 */
 interface UserProfileCacheStore {
@@ -105,6 +123,48 @@ internal class RoomFriendListCacheStore(
     override suspend fun load(userId: String): FriendListCache? = cache.load(userId)
 
     override suspend fun save(userId: String, cache: FriendListCache) = this.cache.save(userId, cache)
+
+    override suspend fun clear(userId: String) = cache.delete(userId)
+
+    override suspend fun clearAll() = cache.clear()
+}
+
+internal class RoomFavoriteListCacheStore(
+    dao: CachedBlobDao,
+    nowMillis: () -> Long,
+    retained: Int = 8,
+) : FavoriteListCacheStore {
+    private val mutationMutex = Mutex()
+    private val cache = JsonBlobCache(
+        dao = dao,
+        scope = CacheScopes.FAVORITE_LIST,
+        serializer = FavoriteListCache.serializer(),
+        nowMillis = nowMillis,
+        retained = retained,
+        prune = { favoriteCache ->
+            favoriteCache.copy(
+                favoritedWorlds = favoriteCache.favoritedWorlds.map { group ->
+                    group.copy(worlds = group.worlds.map { it.prunedForCache() })
+                },
+            )
+        },
+    )
+
+    override suspend fun load(userId: String): FavoriteListCache? = cache.load(userId)
+
+    override suspend fun saveWorlds(userId: String, worlds: List<FavoritedWorldGroup>) {
+        mutationMutex.withLock {
+            val current = cache.load(userId) ?: FavoriteListCache()
+            cache.save(userId, current.copy(favoritedWorlds = worlds))
+        }
+    }
+
+    override suspend fun saveAvatars(userId: String, avatars: List<AvatarData>) {
+        mutationMutex.withLock {
+            val current = cache.load(userId) ?: FavoriteListCache()
+            cache.save(userId, current.copy(favoritedAvatars = avatars))
+        }
+    }
 
     override suspend fun clear(userId: String) = cache.delete(userId)
 

--- a/composeApp/src/commonMain/kotlin/storage/CachedBlobStore.kt
+++ b/composeApp/src/commonMain/kotlin/storage/CachedBlobStore.kt
@@ -111,6 +111,7 @@ internal class JsonBlobCache<T>(
 
 internal object CacheScopes {
     const val USER_PROFILE = "user_profile"
+    const val FAVORITE_LIST = "favorite_list"
     const val FRIEND_LIST = "friend_list"
     const val FRIEND_NETWORK = "friend_network"
     const val WORLD_PROFILE = "world_profile"

--- a/composeApp/src/commonMain/kotlin/storage/data/FavoriteListCache.kt
+++ b/composeApp/src/commonMain/kotlin/storage/data/FavoriteListCache.kt
@@ -1,0 +1,11 @@
+package io.github.vrcmteam.vrcm.storage.data
+
+import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
+import kotlinx.serialization.Serializable
+
+/** 当前账号收藏页的可恢复列表快照。 */
+@Serializable
+data class FavoriteListCache(
+    val favoritedWorlds: List<FavoritedWorldGroup> = emptyList(),
+    val favoritedAvatars: List<AvatarData> = emptyList(),
+)

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FavoritedWorldCacheTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FavoritedWorldCacheTest.kt
@@ -1,5 +1,7 @@
 package io.github.vrcmteam.vrcm.presentation.screens.home.pager
 
+import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteGroupData
+import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteData
 import io.github.vrcmteam.vrcm.network.api.worlds.data.FavoritedWorld
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -51,10 +53,39 @@ class FavoritedWorldCacheTest {
         )
     }
 
+    @Test
+    fun sharedCacheKeepsGroupNamesAndSuccessfulEmptyGroups() {
+        val groups: Map<FavoriteGroupData, List<FavoriteData>> = linkedMapOf(
+            group("worlds1", "First group") to emptyList(),
+            group("worlds2", "Second group") to emptyList(),
+        )
+        val worlds = listOf(
+            world(id = "wrld_one", favoriteId = "fvrt_one", group = "worlds1"),
+        )
+
+        val cachedGroups = groupFavoritedWorlds(worlds, groups)
+
+        assertEquals(listOf("worlds1", "worlds2"), cachedGroups.map { it.groupKey })
+        assertEquals(listOf("First group", "Second group"), cachedGroups.map { it.name })
+        assertEquals(listOf("wrld_one"), cachedGroups.first().worlds.map { it.id })
+        assertEquals(emptyList(), cachedGroups.last().worlds)
+    }
+
     private fun world(id: String, favoriteId: String, group: String) = FavoritedWorld(
         id = id,
         name = id,
         favoriteId = favoriteId,
         favoriteGroup = group,
+    )
+
+    private fun group(name: String, displayName: String) = FavoriteGroupData(
+        id = "group-$name",
+        ownerId = "usr_owner",
+        type = "world",
+        visibility = "private",
+        displayName = displayName,
+        name = name,
+        ownerDisplayName = "Owner",
+        tags = emptyList(),
     )
 }

--- a/composeApp/src/commonTest/kotlin/presentation/screens/user/UserProfileFavoriteWorldMergeTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/user/UserProfileFavoriteWorldMergeTest.kt
@@ -48,6 +48,28 @@ class UserProfileFavoriteWorldMergeTest {
         assertTrue(merged.single().worlds.isEmpty())
     }
 
+    @Test
+    fun selfProfileRefreshKeepsTheLocalWorldGroupFromTheSharedCache() {
+        val local = group(
+            "__local_world__",
+            "Local",
+            world("wrld_local", favoriteId = "local|world|wrld_local"),
+        )
+
+        val merged = mergeFavoritedWorldGroups(
+            cachedGroups = listOf(
+                group("worlds1", "Group one", world("wrld_old")),
+                local,
+            ),
+            loads = listOf(
+                load("worlds1", "Group one", Result.success(listOf(world("wrld_new")))),
+            ),
+        )
+
+        assertEquals(listOf("worlds1", "__local_world__"), merged.map { it.groupKey })
+        assertEquals("wrld_local", merged.last().worlds.single().id)
+    }
+
     private fun load(
         groupKey: String,
         displayName: String,
@@ -57,10 +79,10 @@ class UserProfileFavoriteWorldMergeTest {
     private fun group(groupKey: String, name: String, vararg worlds: FavoritedWorld) =
         FavoritedWorldGroup(name = name, worlds = worlds.toList(), groupKey = groupKey)
 
-    private fun world(id: String) = FavoritedWorld(
+    private fun world(id: String, favoriteId: String = "fvrt_$id") = FavoritedWorld(
         id = id,
         name = id,
-        favoriteId = "fvrt_$id",
+        favoriteId = favoriteId,
         favoriteGroup = "worlds1",
     )
 }

--- a/composeApp/src/commonTest/kotlin/presentation/screens/user/UserProfileFavoriteWorldMergeTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/user/UserProfileFavoriteWorldMergeTest.kt
@@ -70,6 +70,29 @@ class UserProfileFavoriteWorldMergeTest {
         assertEquals("wrld_local", merged.last().worlds.single().id)
     }
 
+    @Test
+    fun failedSelfMigrationKeepsLegacyFavoriteWorldsForTheNextSave() {
+        val legacy = listOf(group("worlds1", "Group one", world("wrld_old")))
+
+        assertEquals(
+            legacy,
+            profileFavoritedWorldsForCache(
+                userId = "usr_owner",
+                cacheOwnerUserId = "usr_owner",
+                migrationSucceeded = false,
+                favoritedWorldGroups = legacy,
+            ),
+        )
+        assertTrue(
+            profileFavoritedWorldsForCache(
+                userId = "usr_owner",
+                cacheOwnerUserId = "usr_owner",
+                migrationSucceeded = true,
+                favoritedWorldGroups = legacy,
+            ).isEmpty(),
+        )
+    }
+
     private fun load(
         groupKey: String,
         displayName: String,

--- a/composeApp/src/commonTest/kotlin/storage/AccountCacheManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/storage/AccountCacheManagerTest.kt
@@ -75,11 +75,18 @@ class AccountCacheManagerTest {
     fun clearingOneAccountDoesNotRemoveAnotherAccountsCaches() = runTest {
         val friendStore = InMemoryFriendListCacheStore()
         val profileStore = InMemoryUserProfileCacheStore()
-        val manager = accountCacheManager(friendStore, profileStore)
+        val favoriteStore = InMemoryFavoriteListCacheStore()
+        val manager = accountCacheManager(
+            friendStore,
+            profileStore,
+            favoriteStore = favoriteStore,
+        )
         friendStore.save("usr_a", FriendListCache(emptyList()))
         friendStore.save("usr_b", FriendListCache(emptyList()))
         profileStore.save("usr_a", "usr_profile", profileCache("A"))
         profileStore.save("usr_b", "usr_profile", profileCache("B"))
+        favoriteStore.saveWorlds("usr_a", emptyList())
+        favoriteStore.saveAvatars("usr_b", emptyList())
 
         manager.clearAccount("usr_a")
 
@@ -87,20 +94,31 @@ class AccountCacheManagerTest {
         assertNotNull(friendStore.load("usr_b"))
         assertNull(profileStore.load("usr_a", "usr_profile"))
         assertNotNull(profileStore.load("usr_b", "usr_profile"))
+        assertNull(favoriteStore.load("usr_a"))
+        assertNotNull(favoriteStore.load("usr_b"))
     }
 
     @Test
     fun clearingAllRemovesBothCacheTypesForEveryAccount() = runTest {
         val friendStore = InMemoryFriendListCacheStore()
         val profileStore = InMemoryUserProfileCacheStore()
+        val favoriteStore = InMemoryFavoriteListCacheStore()
         val fileSystem = FakeFileSystem()
         val assetStore = MeetupCardAssetStore(fileSystem, "/meetup-assets".toPath())
         val configDao = MeetupCardConfigDao(MapSettings())
-        val manager = accountCacheManager(friendStore, profileStore, configDao, assetStore)
+        val manager = accountCacheManager(
+            friendStore,
+            profileStore,
+            configDao,
+            assetStore,
+            favoriteStore,
+        )
         friendStore.save("usr_a", FriendListCache(emptyList()))
         friendStore.save("usr_b", FriendListCache(emptyList()))
         profileStore.save("usr_a", "usr_profile", profileCache("A"))
         profileStore.save("usr_b", "usr_profile", profileCache("B"))
+        favoriteStore.saveWorlds("usr_a", emptyList())
+        favoriteStore.saveAvatars("usr_b", emptyList())
         val photoBytes = "local-photo".encodeToByteArray()
         val photo = assetStore.writePhoto("usr_a", photoBytes, "png")
         val decorationBytes = "decoration".encodeToByteArray()
@@ -125,6 +143,8 @@ class AccountCacheManagerTest {
         assertNull(friendStore.load("usr_b"))
         assertNull(profileStore.load("usr_a", "usr_profile"))
         assertNull(profileStore.load("usr_b", "usr_profile"))
+        assertNull(favoriteStore.load("usr_a"))
+        assertNull(favoriteStore.load("usr_b"))
         assertNotNull(configDao.load("usr_a"))
         assertContentEquals(photoBytes, assetStore.read(photo))
         assertContentEquals(decorationBytes, assetStore.read(decoration))
@@ -409,11 +429,13 @@ class AccountCacheManagerTest {
             FakeFileSystem(),
             "/meetup-assets".toPath(),
         ),
+        favoriteStore: FavoriteListCacheStore = InMemoryFavoriteListCacheStore(),
     ) = AccountCacheManager(
         friendListCacheStore = friendStore,
         userProfileCacheStore = profileStore,
         friendActivityStore = NoOpFriendActivityCacheStore,
         meetupCardConfigDao = configDao,
         meetupCardAssetStore = assetStore,
+        favoriteListCacheStore = favoriteStore,
     )
 }

--- a/composeApp/src/commonTest/kotlin/storage/InMemoryUserProfileCacheStore.kt
+++ b/composeApp/src/commonTest/kotlin/storage/InMemoryUserProfileCacheStore.kt
@@ -1,5 +1,8 @@
 package io.github.vrcmteam.vrcm.storage
 
+import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
+import io.github.vrcmteam.vrcm.storage.data.FavoriteListCache
+import io.github.vrcmteam.vrcm.storage.data.FavoritedWorldGroup
 import io.github.vrcmteam.vrcm.storage.data.FriendListCache
 import io.github.vrcmteam.vrcm.storage.data.UserProfileCache
 
@@ -16,6 +19,27 @@ class InMemoryUserProfileCacheStore : UserProfileCacheStore {
 
     override suspend fun clearOwner(ownerUserId: String) {
         entries.keys.filter { it.first == ownerUserId }.forEach(entries::remove)
+    }
+
+    override suspend fun clearAll() = entries.clear()
+}
+
+/** 内存版收藏列表缓存，保留世界与模型的局部更新语义。 */
+class InMemoryFavoriteListCacheStore : FavoriteListCacheStore {
+    private val entries = mutableMapOf<String, FavoriteListCache>()
+
+    override suspend fun load(userId: String): FavoriteListCache? = entries[userId]
+
+    override suspend fun saveWorlds(userId: String, worlds: List<FavoritedWorldGroup>) {
+        entries[userId] = (entries[userId] ?: FavoriteListCache()).copy(favoritedWorlds = worlds)
+    }
+
+    override suspend fun saveAvatars(userId: String, avatars: List<AvatarData>) {
+        entries[userId] = (entries[userId] ?: FavoriteListCache()).copy(favoritedAvatars = avatars)
+    }
+
+    override suspend fun clear(userId: String) {
+        entries.remove(userId)
     }
 
     override suspend fun clearAll() = entries.clear()

--- a/composeApp/src/desktopTest/kotlin/storage/RoomFavoriteListCacheStoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/storage/RoomFavoriteListCacheStoreTest.kt
@@ -1,0 +1,76 @@
+package io.github.vrcmteam.vrcm.storage
+
+import androidx.room.Room
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
+import io.github.vrcmteam.vrcm.network.api.worlds.data.FavoritedWorld
+import io.github.vrcmteam.vrcm.storage.data.FavoritedWorldGroup
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class RoomFavoriteListCacheStoreTest {
+    @Test
+    fun worldAndAvatarRefreshesDoNotOverwriteEachOther() = withStore { store ->
+        val worlds = listOf(
+            FavoritedWorldGroup(
+                name = "Worlds",
+                groupKey = "worlds1",
+                worlds = listOf(
+                    FavoritedWorld(
+                        id = "wrld_cached",
+                        name = "Cached world",
+                        favoriteId = "fvrt_cached",
+                        favoriteGroup = "worlds1",
+                    ),
+                ),
+            ),
+        )
+        val avatars = listOf(AvatarData(id = "avtr_cached", name = "Cached avatar"))
+
+        store.saveWorlds("usr_owner", worlds)
+        store.saveAvatars("usr_owner", avatars)
+
+        val cached = assertNotNull(store.load("usr_owner"))
+        assertEquals(worlds, cached.favoritedWorlds)
+        assertEquals(avatars, cached.favoritedAvatars)
+
+        store.saveWorlds("usr_owner", emptyList())
+
+        val afterEmptyRefresh = assertNotNull(store.load("usr_owner"))
+        assertEquals(emptyList(), afterEmptyRefresh.favoritedWorlds)
+        assertEquals(avatars, afterEmptyRefresh.favoritedAvatars)
+    }
+
+    @Test
+    fun clearingOneAccountKeepsAnotherAccountsFavorites() = withStore { store ->
+        store.saveAvatars("usr_a", listOf(AvatarData(id = "avtr_a", name = "A")))
+        store.saveAvatars("usr_b", listOf(AvatarData(id = "avtr_b", name = "B")))
+
+        store.clear("usr_a")
+
+        assertNull(store.load("usr_a"))
+        assertEquals("avtr_b", assertNotNull(store.load("usr_b")).favoritedAvatars.single().id)
+    }
+
+    private fun withStore(block: suspend (FavoriteListCacheStore) -> Unit) = runTest {
+        val database = Room.inMemoryDatabaseBuilder<VrcmDatabase>()
+            .setDriver(BundledSQLiteDriver())
+            .setQueryCoroutineContext(Dispatchers.IO)
+            .build()
+        try {
+            var clock = 0L
+            block(
+                RoomFavoriteListCacheStore(
+                    dao = database.cachedBlobDao(),
+                    nowMillis = { ++clock },
+                ),
+            )
+        } finally {
+            database.close()
+        }
+    }
+}


### PR DESCRIPTION
关联 #90

## 实现思路
- 新增按登录账号隔离的收藏列表持久缓存，世界按收藏分组保存，模型列表独立保存。
- 收藏页打开时先展示缓存，再请求最新世界和模型；请求成功后替换并保存，成功返回空列表会清空旧列表，失败保留当前已展示内容。
- 个人资料页与收藏页共用本人账号的世界缓存；旧资料缓存中的收藏世界只在共享缓存不存在时迁移一次。
- 账号删除和清除全部缓存会同步清理收藏列表缓存，写入受账号会话代次保护，避免切换账号后旧请求回填。

## Issue #90 验收标准自查
- [x] 第二页收藏世界列表优先显示上次成功加载的内容。验证：收藏列表模型启动时先从账号缓存恢复世界分组，再发起网络刷新；相关缓存测试通过。
- [x] 个人资料页收藏世界与收藏页使用同一份缓存。验证：本人资料页读取和写入同一个账号收藏列表缓存，旧资料缓存仅作为迁移回退。
- [x] 收藏模型列表增加缓存并在下次打开时优先显示。验证：收藏模型刷新成功后独立保存模型列表，打开时先恢复模型缓存；Room 缓存测试覆盖世界和模型局部更新互不覆盖。
- [x] 每次打开仍请求最新内容，并在成功后更新列表。验证：世界和模型的刷新入口保留，每次成功结果替换内存列表并落盘。
- [x] 无缓存、空结果和失败结果行为保持可判断。验证：无缓存继续走现有加载流程，成功空结果写入空列表，失败仅提示错误且不覆盖已有内容。
- [x] 缓存按账号隔离，清除账号后不残留。验证：账号缓存管理器新增账号级清理；账号隔离和清理测试通过。

## 自测结果
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:compileKotlinDesktop`：BUILD SUCCESSFUL
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests ...`：定向测试通过，覆盖 4 个受影响测试类
- `~/ai/bin/check-gate.sh implement-issue 90`：quality gate: pass
- 完整 `desktopTest`：713 个测试中 712 个通过；唯一失败为 Linux 无图形会话下既有的 `DesktopWindowTitleBarLocaleTest`（`HeadlessException`），与本次改动无关。

## 代码逻辑图
```mermaid
sequenceDiagram
    participant Pager as FriendListPagerModel
    participant Profile as UserProfileScreenModel
    participant Cache as FavoriteListCacheStore
    participant API as VRChat 收藏接口
    participant Manager as AccountCacheManager
    participant Room as RoomFavoriteListCacheStore
    Pager->>Cache: 打开页面读取账号缓存
    Cache-->>Pager: 世界分组和模型列表
    Pager->>API: 请求最新收藏世界或模型
    API-->>Pager: 成功列表或失败结果
    Pager->>Manager: 以当前会话代次提交成功结果
    Manager->>Room: 局部保存世界或模型
    Profile->>Cache: 打开本人资料读取同一世界缓存
    Profile->>API: 请求本人收藏世界
    API-->>Profile: 各分组结果
    Profile->>Manager: 以当前会话代次提交世界分组
    Manager->>Room: 保存共享世界缓存
```

## 实现假设清单
- 收藏世界返回的 `favoriteGroup` 与收藏分组接口的 `name` 对应。依据：现有收藏页按这两个值过滤，且现有 API 数据模型如此定义。
- 本地收藏世界分组名称为 `__local_world__`。依据：`FavoriteService` 的本地分组实现。
- “获取失败保留缓存”只针对网络和解析失败；账号切换或账号清除属于会话失效，旧请求结果不写入。依据：Issue 评论中的边界约定及现有账号代次机制。
- 本轮不扩展好友收藏、搜索结果或详情页缓存。依据：Issue #90 的“ 不做 ”范围确认。

## 实现说明(供追问)
### 关键决策
采用一份账号级收藏快照，并对世界和模型进行局部写入，避免两个刷新任务互相覆盖。本人资料页不再把收藏世界继续写回旧资料缓存，防止形成第二个可失效来源；旧数据仅用于首次迁移。

### 覆盖的场景
覆盖有缓存和无缓存打开、刷新成功、成功返回空列表、请求失败、多个收藏分组、本人资料页与收藏页交替打开、账号切换和清除账号缓存。

### 明确未覆盖
未处理好友收藏列表、搜索页和详情页缓存；未做 Android 真机视觉验证，因为本次没有 Android 专属交互或系统能力改动。完整桌面测试的无头窗口失败仍需在有图形会话环境复测。

### 关键假设
依赖 VRChat 收藏分组键和本地收藏组命名保持现有接口约定；依赖当前登录账号代次作为缓存写入有效性的边界。

## 评审修复说明
本轮修复了本人资料缓存初始化与旧收藏世界迁移之间的竞态。资料保存现在等待迁移屏障；共享缓存读取成功或旧收藏成功迁移后才清空旧资料字段，迁移失败、读取异常或会话失效时保留旧收藏，避免旧资料中的唯一收藏被空列表覆盖。

### 评审后的代码逻辑图
~~~mermaid
sequenceDiagram
    participant Profile as UserProfileScreenModel
    participant Legacy as UserProfileCache
    participant Shared as FavoriteListCacheStore
    participant Manager as AccountCacheManager
    participant Save as saveCache
    Profile->>Legacy: 异步读取本人资料缓存
    Profile->>Shared: 读取账号收藏世界缓存
    alt 共享缓存存在
        Shared-->>Profile: 返回共享收藏世界
        Profile->>Profile: 标记迁移成功
    else 共享缓存不存在
        Profile->>Manager: 尝试把旧收藏迁移到共享缓存
        Manager-->>Profile: 返回迁移成功或失败
    end
    Profile-->>Save: 释放迁移屏障
    Save->>Profile: 等待迁移结果
    alt 迁移成功
        Save->>Legacy: 保存本人资料并清空旧收藏字段
    else 迁移失败或会话失效
        Save->>Legacy: 保存本人资料并保留旧收藏字段
    end
~~~

### 本轮验证
- gradle-run 定向 desktopTest：BUILD SUCCESSFUL
- check-gate fix-review 93：quality gate: pass
