### PR TITLE
feat(update): 检查更新失败时使用镜像源，安卓端更新时直接下载安装包

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <application
         android:name=".VRCMApplication"
         android:enableOnBackInvokedCallback="true"
@@ -61,5 +62,12 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+        <receiver
+            android:name=".UpdateDownloadReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.DOWNLOAD_NOTIFICATION_CLICKED" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/composeApp/src/androidMain/kotlin/AppPlatform.android.kt
+++ b/composeApp/src/androidMain/kotlin/AppPlatform.android.kt
@@ -75,4 +75,10 @@ class AndroidAppPlatform(val context: Context, private val logger: Logger) : App
             )
         }.onFailure { logger.error("Failed to open battery optimization settings: ${it.message.orEmpty()}") }
     }
+
+    override suspend fun installAppUpdate(
+        tagName: String,
+        downloadUrls: List<String>,
+        onProgress: (Float?) -> Unit,
+    ): Result<Unit> = downloadAndInstallAppUpdate(context, tagName, downloadUrls, onProgress)
 }

--- a/composeApp/src/androidMain/kotlin/AppUpdate.android.kt
+++ b/composeApp/src/androidMain/kotlin/AppUpdate.android.kt
@@ -1,0 +1,184 @@
+package io.github.vrcmteam.vrcm
+
+import android.app.DownloadManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import androidx.core.content.FileProvider
+import io.github.vrcmteam.vrcm.core.shared.AppConst
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.head
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.ktor.http.isSuccess
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+
+internal suspend fun downloadAndInstallAppUpdate(
+    context: Context,
+    tagName: String,
+    downloadUrls: List<String>,
+    onProgress: (Float?) -> Unit,
+): Result<Unit> = runCatching {
+    val source = downloadUrls.firstOrNull { it.endsWith(".apk", ignoreCase = true) }
+        ?: error("This release has no Android APK")
+    onProgress(null)
+    val fastestMirror = findFastestMirror(source) ?: error("No available APK download source")
+    val appContext = context.applicationContext
+    val fileName = "VRCM-${tagName.replace(Regex("[^A-Za-z0-9._-]"), "_")}.apk"
+    val downloadDirectory = requireNotNull(appContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)) {
+        "External download directory is unavailable"
+    }
+    val target = File(downloadDirectory, fileName)
+    check(!target.exists() || target.delete()) { "Unable to replace the previous APK" }
+    val manager = appContext.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+    val request = DownloadManager.Request(Uri.parse(mirrorUrl(fastestMirror, source)))
+        .setTitle("VRCM $tagName")
+        .setMimeType(APK_MIME_TYPE)
+        .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+        .setAllowedOverMetered(true)
+        .setAllowedOverRoaming(false)
+        .setDestinationInExternalFilesDir(appContext, Environment.DIRECTORY_DOWNLOADS, fileName)
+    val downloadId = manager.enqueue(request)
+    appContext.getSharedPreferences(UPDATE_PREFS, Context.MODE_PRIVATE).edit()
+        .putLong(DOWNLOAD_ID, downloadId)
+        .putString(DOWNLOAD_FILE, target.path)
+        .apply()
+    awaitDownload(manager, downloadId, onProgress)
+    verifyApk(appContext, target)
+    openInstaller(appContext, target)
+}
+
+private suspend fun findFastestMirror(source: String): String? {
+    val client = HttpClient {
+        expectSuccess = false
+        install(HttpTimeout) {
+            requestTimeoutMillis = 8_000
+            connectTimeoutMillis = 5_000
+            socketTimeoutMillis = 8_000
+        }
+    }
+    return try {
+        coroutineScope {
+            val winners = Channel<String>(Channel.UNLIMITED)
+            downloadMirrors.forEach { prefix ->
+                launch(Dispatchers.IO) {
+                    runCatching {
+                        client.head(mirrorUrl(prefix, source)) {
+                            header(HttpHeaders.UserAgent, "VRCM/${AppConst.APP_VERSION}")
+                        }
+                    }.getOrNull()?.takeIf { it.status.isSuccess() }?.let { winners.send(prefix) }
+                }
+            }
+            val winner = withTimeoutOrNull(8_000) { winners.receive() }
+            coroutineContext.cancelChildren()
+            winners.close()
+            winner
+        }
+    } finally {
+        client.close()
+    }
+}
+
+private suspend fun awaitDownload(
+    manager: DownloadManager,
+    downloadId: Long,
+    onProgress: (Float?) -> Unit,
+) {
+    while (true) {
+        val state = withContext(Dispatchers.IO) {
+            manager.query(DownloadManager.Query().setFilterById(downloadId)).use { cursor ->
+                check(cursor.moveToFirst()) { "Download task disappeared" }
+                Triple(
+                    cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS)),
+                    cursor.getLong(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR)),
+                    cursor.getLong(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_TOTAL_SIZE_BYTES)),
+                )
+            }
+        }
+        onProgress(if (state.third > 0) (state.second.toFloat() / state.third).coerceIn(0f, 1f) else null)
+        when (state.first) {
+            DownloadManager.STATUS_SUCCESSFUL -> return
+            DownloadManager.STATUS_FAILED -> error("APK download failed")
+        }
+        delay(500)
+    }
+}
+
+private fun verifyApk(context: Context, apk: File) {
+    check(apk.isFile && apk.length() > 0) { "Downloaded APK is empty" }
+    val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        PackageManager.GET_SIGNING_CERTIFICATES
+    } else {
+        @Suppress("DEPRECATION")
+        PackageManager.GET_SIGNATURES
+    }
+    val archive = context.packageManager.getPackageArchiveInfo(apk.path, flags)
+    check(archive?.packageName == context.packageName) { "Downloaded APK package does not match" }
+    val installed = context.packageManager.getPackageInfo(context.packageName, flags)
+    check(signatures(archive).contentDeepEquals(signatures(installed))) { "Downloaded APK signature does not match" }
+}
+
+private fun signatures(info: PackageInfo): Array<ByteArray> =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        info.signingInfo?.apkContentsSigners.orEmpty().map { it.toByteArray() }.toTypedArray()
+    } else {
+        @Suppress("DEPRECATION")
+        info.signatures.orEmpty().map { it.toByteArray() }.toTypedArray()
+    }
+
+private fun openInstaller(context: Context, apk: File) {
+    val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", apk)
+    context.startActivity(
+        Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, APK_MIME_TYPE)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        },
+    )
+}
+
+class UpdateDownloadReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != DownloadManager.ACTION_NOTIFICATION_CLICKED) return
+        val preferences = context.getSharedPreferences(UPDATE_PREFS, Context.MODE_PRIVATE)
+        val expectedId = preferences.getLong(DOWNLOAD_ID, -1L)
+        val clickedIds = intent.getLongArrayExtra(DownloadManager.EXTRA_NOTIFICATION_CLICK_DOWNLOAD_IDS)
+        if (expectedId < 0 || clickedIds?.contains(expectedId) != true) return
+        val apk = preferences.getString(DOWNLOAD_FILE, null)?.let(::File) ?: return
+        runCatching {
+            verifyApk(context, apk)
+            openInstaller(context, apk)
+        }
+    }
+}
+
+private fun mirrorUrl(prefix: String, source: String) = if (prefix.isEmpty()) source else prefix + source
+private val downloadMirrors = listOf(
+    "",
+    "https://ghfast.top/",
+    "https://git.yylx.win/",
+    "https://gh-proxy.com/",
+    "https://ghfile.geekertao.top/",
+    "https://gh-proxy.net/",
+    "https://ghm.078465.xyz/",
+    "https://gitproxy.127731.xyz/",
+    "https://jiashu.1win.eu.org/",
+    "https://github.tbedu.top/",
+)
+private const val APK_MIME_TYPE = "application/vnd.android.package-archive"
+private const val UPDATE_PREFS = "vrcm_update"
+private const val DOWNLOAD_ID = "download_id"
+private const val DOWNLOAD_FILE = "download_file"

--- a/composeApp/src/androidMain/kotlin/AppUpdate.android.kt
+++ b/composeApp/src/androidMain/kotlin/AppUpdate.android.kt
@@ -18,6 +18,7 @@ import io.ktor.client.request.header
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
 import java.io.File
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.channels.Channel
@@ -32,34 +33,49 @@ internal suspend fun downloadAndInstallAppUpdate(
     tagName: String,
     downloadUrls: List<String>,
     onProgress: (Float?) -> Unit,
-): Result<Unit> = runCatching {
-    val source = downloadUrls.firstOrNull { it.endsWith(".apk", ignoreCase = true) }
-        ?: error("This release has no Android APK")
-    onProgress(null)
-    val fastestMirror = findFastestMirror(source) ?: error("No available APK download source")
-    val appContext = context.applicationContext
-    val fileName = "VRCM-${tagName.replace(Regex("[^A-Za-z0-9._-]"), "_")}.apk"
-    val downloadDirectory = requireNotNull(appContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)) {
-        "External download directory is unavailable"
+): Result<Unit> {
+    var appContext: Context? = null
+    var manager: DownloadManager? = null
+    var downloadId: Long? = null
+    var target: File? = null
+    return try {
+        val source = downloadUrls.firstOrNull { it.endsWith(".apk", ignoreCase = true) }
+            ?: error("This release has no Android APK")
+        onProgress(null)
+        val fastestMirror = findFastestMirror(source) ?: error("No available APK download source")
+        appContext = context.applicationContext
+        val fileName = "VRCM-${tagName.replace(Regex("[^A-Za-z0-9._-]"), "_")}.apk"
+        val downloadDirectory = requireNotNull(appContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)) {
+            "External download directory is unavailable"
+        }
+        target = File(downloadDirectory, fileName)
+        check(!target.exists() || target.delete()) { "Unable to replace the previous APK" }
+        val downloadManager = appContext.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+        manager = downloadManager
+        val request = DownloadManager.Request(Uri.parse(mirrorUrl(fastestMirror, source)))
+            .setTitle("VRCM $tagName")
+            .setMimeType(APK_MIME_TYPE)
+            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+            .setAllowedOverMetered(true)
+            .setAllowedOverRoaming(false)
+            .setDestinationInExternalFilesDir(appContext, Environment.DIRECTORY_DOWNLOADS, fileName)
+        val id = downloadManager.enqueue(request)
+        downloadId = id
+        appContext.getSharedPreferences(UPDATE_PREFS, Context.MODE_PRIVATE).edit()
+            .putLong(DOWNLOAD_ID, id)
+            .putString(DOWNLOAD_FILE, target.path)
+            .apply()
+        awaitDownload(downloadManager, id, onProgress)
+        verifyApk(appContext, target)
+        openInstaller(appContext, target)
+        Result.success(Unit)
+    } catch (cause: CancellationException) {
+        cleanupDownload(appContext, manager, downloadId, target, cause)
+        throw cause
+    } catch (cause: Throwable) {
+        cleanupDownload(appContext, manager, downloadId, target, cause)
+        Result.failure(cause)
     }
-    val target = File(downloadDirectory, fileName)
-    check(!target.exists() || target.delete()) { "Unable to replace the previous APK" }
-    val manager = appContext.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
-    val request = DownloadManager.Request(Uri.parse(mirrorUrl(fastestMirror, source)))
-        .setTitle("VRCM $tagName")
-        .setMimeType(APK_MIME_TYPE)
-        .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-        .setAllowedOverMetered(true)
-        .setAllowedOverRoaming(false)
-        .setDestinationInExternalFilesDir(appContext, Environment.DIRECTORY_DOWNLOADS, fileName)
-    val downloadId = manager.enqueue(request)
-    appContext.getSharedPreferences(UPDATE_PREFS, Context.MODE_PRIVATE).edit()
-        .putLong(DOWNLOAD_ID, downloadId)
-        .putString(DOWNLOAD_FILE, target.path)
-        .apply()
-    awaitDownload(manager, downloadId, onProgress)
-    verifyApk(appContext, target)
-    openInstaller(appContext, target)
 }
 
 private suspend fun findFastestMirror(source: String): String? {
@@ -76,11 +92,16 @@ private suspend fun findFastestMirror(source: String): String? {
             val winners = Channel<String>(Channel.UNLIMITED)
             downloadMirrors.forEach { prefix ->
                 launch(Dispatchers.IO) {
-                    runCatching {
+                    val response = try {
                         client.head(mirrorUrl(prefix, source)) {
                             header(HttpHeaders.UserAgent, "VRCM/${AppConst.APP_VERSION}")
                         }
-                    }.getOrNull()?.takeIf { it.status.isSuccess() }?.let { winners.send(prefix) }
+                    } catch (cause: CancellationException) {
+                        throw cause
+                    } catch (_: Throwable) {
+                        null
+                    }
+                    response?.takeIf { it.status.isSuccess() }?.let { winners.send(prefix) }
                 }
             }
             val winner = withTimeoutOrNull(8_000) { winners.receive() }
@@ -98,23 +119,49 @@ private suspend fun awaitDownload(
     downloadId: Long,
     onProgress: (Float?) -> Unit,
 ) {
-    while (true) {
-        val state = withContext(Dispatchers.IO) {
-            manager.query(DownloadManager.Query().setFilterById(downloadId)).use { cursor ->
-                check(cursor.moveToFirst()) { "Download task disappeared" }
-                Triple(
-                    cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS)),
-                    cursor.getLong(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR)),
-                    cursor.getLong(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_TOTAL_SIZE_BYTES)),
-                )
+    withTimeoutOrNull(DOWNLOAD_TIMEOUT_MILLIS) {
+        while (true) {
+            val state = withContext(Dispatchers.IO) {
+                manager.query(DownloadManager.Query().setFilterById(downloadId)).use { cursor ->
+                    check(cursor.moveToFirst()) { "Download task disappeared" }
+                    Triple(
+                        cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS)),
+                        cursor.getLong(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR)),
+                        cursor.getLong(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_TOTAL_SIZE_BYTES)),
+                    )
+                }
             }
+            onProgress(if (state.third > 0) (state.second.toFloat() / state.third).coerceIn(0f, 1f) else null)
+            when (state.first) {
+                DownloadManager.STATUS_SUCCESSFUL -> return@withTimeoutOrNull
+                DownloadManager.STATUS_FAILED -> error("APK download failed")
+                DownloadManager.STATUS_PENDING,
+                DownloadManager.STATUS_PAUSED,
+                DownloadManager.STATUS_RUNNING,
+                -> Unit
+                else -> error("APK download entered an unexpected state: ${state.first}")
+            }
+            delay(DOWNLOAD_POLL_INTERVAL_MILLIS)
         }
-        onProgress(if (state.third > 0) (state.second.toFloat() / state.third).coerceIn(0f, 1f) else null)
-        when (state.first) {
-            DownloadManager.STATUS_SUCCESSFUL -> return
-            DownloadManager.STATUS_FAILED -> error("APK download failed")
-        }
-        delay(500)
+    } ?: error("APK download timed out")
+}
+
+private fun cleanupDownload(
+    context: Context?,
+    manager: DownloadManager?,
+    downloadId: Long?,
+    target: File?,
+    cause: Throwable,
+) {
+    try {
+        if (downloadId != null) manager?.remove(downloadId)
+        target?.delete()
+        context?.getSharedPreferences(UPDATE_PREFS, Context.MODE_PRIVATE)?.edit()
+            ?.remove(DOWNLOAD_ID)
+            ?.remove(DOWNLOAD_FILE)
+            ?.apply()
+    } catch (cleanupFailure: Throwable) {
+        cause.addSuppressed(cleanupFailure)
     }
 }
 
@@ -182,3 +229,5 @@ private const val APK_MIME_TYPE = "application/vnd.android.package-archive"
 private const val UPDATE_PREFS = "vrcm_update"
 private const val DOWNLOAD_ID = "download_id"
 private const val DOWNLOAD_FILE = "download_file"
+private const val DOWNLOAD_POLL_INTERVAL_MILLIS = 500L
+private const val DOWNLOAD_TIMEOUT_MILLIS = 15 * 60 * 1000L

--- a/composeApp/src/androidMain/res/xml/file_paths.xml
+++ b/composeApp/src/androidMain/res/xml/file_paths.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <cache-path name="shared_images" path="share/" />
+    <external-files-path name="updates" path="Download/" />
 </paths>

--- a/composeApp/src/commonMain/kotlin/AppPlatform.kt
+++ b/composeApp/src/commonMain/kotlin/AppPlatform.kt
@@ -22,6 +22,12 @@ interface AppPlatform : KoinComponent {
     val supportsBatteryOptimizationSettings: Boolean get() = false
     fun isIgnoringBatteryOptimizations(): Boolean = true
     fun openBatteryOptimizationSettings() = Unit
+
+    suspend fun installAppUpdate(
+        tagName: String,
+        downloadUrls: List<String>,
+        onProgress: (Float?) -> Unit,
+    ): Result<Unit> = Result.failure(UnsupportedOperationException("In-app updates are not supported on $name"))
 }
 
 enum class BackgroundFriendMonitoringResult { Started, Stopped, PermissionRequired, Unsupported }

--- a/composeApp/src/commonMain/kotlin/network/api/github/GitHubApi.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/github/GitHubApi.kt
@@ -13,8 +13,10 @@ class GitHubApi(
     suspend fun latestRelease(releaseUrl: String): Result<ReleaseData> =
         runCatching {
             client.get(releaseUrl) {
-                githubAuthToken()?.let { token ->
-                    header(HttpHeaders.Authorization, "Bearer $token")
+                if (url.host == "api.github.com") {
+                    githubAuthToken()?.let { token ->
+                        header(HttpHeaders.Authorization, "Bearer $token")
+                    }
                 }
             }.checkSuccess<ReleaseData>()
         }

--- a/composeApp/src/commonMain/kotlin/presentation/compoments/UpdateDialog.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/UpdateDialog.kt
@@ -14,6 +14,7 @@ import io.github.vrcmteam.vrcm.getAppPlatform
 import io.github.vrcmteam.vrcm.presentation.extensions.openUrl
 import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
+import kotlinx.coroutines.launch
 import presentation.screens.auth.data.VersionVo
 
 @Composable
@@ -24,7 +25,10 @@ fun UpdateDialog(
 ) {
     if (version.hasNewVersion) {
         val appPlatform = getAppPlatform()
+        val scope = rememberCoroutineScope()
         var rememberVersionChecked by remember { mutableStateOf(false) }
+        var isUpdating by remember { mutableStateOf(false) }
+        var updateProgress by remember { mutableStateOf<Float?>(null) }
         val url = remember {
             when (appPlatform.type) {
                 AppPlatformType.Android -> version.downloadUrl.firstOrNull {
@@ -68,24 +72,56 @@ fun UpdateDialog(
                     }
                 }
             },
-            onDismissRequest = onDismissRequest,
+            onDismissRequest = { if (!isUpdating) onDismissRequest() },
             confirmButton = {
                 FilledTonalButton(
                     colors = ButtonDefaults.filledTonalButtonColors(
                         containerColor = MaterialTheme.colorScheme.primaryContainer,
                         contentColor = MaterialTheme.colorScheme.onPrimaryContainer
                     ),
+                    enabled = !isUpdating,
                     onClick = {
-                        appPlatform.openUrl(url)
+                        val hasApk = version.downloadUrl.any { it.endsWith(".apk", ignoreCase = true) }
+                        if (appPlatform.type != AppPlatformType.Android || !hasApk) {
+                            appPlatform.openUrl(url)
+                        } else {
+                            isUpdating = true
+                            scope.launch {
+                                appPlatform.installAppUpdate(
+                                    tagName = version.tagName,
+                                    downloadUrls = version.downloadUrl,
+                                    onProgress = { updateProgress = it },
+                                )
+                                    .onSuccess { onDismissRequest() }
+                                    .onFailure {
+                                        appPlatform.openUrl(version.htmlUrl)
+                                        onDismissRequest()
+                                    }
+                                isUpdating = false
+                                updateProgress = null
+                            }
+                        }
                     }
                 ) {
-                    Text(strings.startupDialogUpdate)
+                    if (isUpdating) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(18.dp),
+                            strokeWidth = 2.dp,
+                        )
+                        updateProgress?.let { progress ->
+                            Spacer(Modifier.width(8.dp))
+                            Text("${(progress * 100).toInt()}%")
+                        }
+                    } else {
+                        Text(strings.startupDialogUpdate)
+                    }
                 }
                 FilledTonalButton(
                     colors = ButtonDefaults.filledTonalButtonColors(
                         containerColor = MaterialTheme.colorScheme.tertiaryContainer,
                         contentColor = MaterialTheme.colorScheme.onTertiaryContainer
                     ),
+                    enabled = !isUpdating,
                     onClick = {
                         // 关闭弹窗
                         onDismissRequest()
@@ -101,6 +137,7 @@ fun UpdateDialog(
                 ) {
                     Checkbox(
                         checked = rememberVersionChecked,
+                        enabled = !isUpdating,
                         onCheckedChange = {
                             rememberVersionChecked = it
                             // 记住或清除此版本更新提示

--- a/composeApp/src/commonMain/kotlin/service/VersionService.kt
+++ b/composeApp/src/commonMain/kotlin/service/VersionService.kt
@@ -11,34 +11,43 @@ class VersionService(
 ) {
 
     /**
-     * 获取最新的版本号,和版本链接
-     * @param checkRemember 是否检查记住版本
-     * @return 最新版本号和最新版本链接
+     * 获取最新版本信息。GitHub 直连失败时会依次尝试镜像。
+     *
+     * @param checkRemember 是否忽略用户已记住的版本
      */
-    suspend fun checkVersion(checkRemember: Boolean): Result<VersionDto> =
-        gitHubApi.latestRelease(AppConst.APP_GITHUB_LATEST_RELEASE_URL).let { it ->
-            when {
-                it.isSuccess -> {
-                    val releaseData = it.getOrNull()!!
-                    val tagName = releaseData.tagName
-                    val downloadUrl = releaseData.assets.map { asset -> asset.browserDownloadUrl }
-                    if (AppConst.APP_VERSION == tagName
-                        || (checkRemember && settingsDao.rememberVersion == tagName)
-                    ) {
-                        // 当前版本是最新版本
-                        Result.success(VersionDto(tagName, releaseData.htmlUrl, releaseData.body, false,downloadUrl))
-                    } else {
-                        // 当前版本不是最新版本
-                        Result.success(VersionDto(tagName, releaseData.htmlUrl, releaseData.body, true,downloadUrl))
-                    }
-                }
-
-                else -> Result.failure(it.exceptionOrNull()!!)
+    suspend fun checkVersion(checkRemember: Boolean): Result<VersionDto> {
+        var lastFailure: Throwable? = null
+        for (releaseUrl in releaseUrls) {
+            val result = gitHubApi.latestRelease(releaseUrl)
+            val releaseData = result.getOrNull()
+            if (releaseData == null) {
+                lastFailure = result.exceptionOrNull()
+                continue
             }
+
+            val tagName = releaseData.tagName
+            val hasNewVersion = AppConst.APP_VERSION != tagName &&
+                (!checkRemember || settingsDao.rememberVersion != tagName)
+            return Result.success(
+                VersionDto(
+                    tagName = tagName,
+                    htmlUrl = releaseData.htmlUrl,
+                    body = releaseData.body,
+                    hasNewVersion = hasNewVersion,
+                    downloadUrl = releaseData.assets.map { it.browserDownloadUrl },
+                ),
+            )
         }
+        return Result.failure(lastFailure ?: IllegalStateException("Unable to reach GitHub release service"))
+    }
 
     fun rememberVersion(version: String?) {
         settingsDao.rememberVersion = version
     }
-
 }
+
+private val releaseUrls = listOf(
+    AppConst.APP_GITHUB_LATEST_RELEASE_URL,
+    "https://ghfast.top/${AppConst.APP_GITHUB_LATEST_RELEASE_URL}",
+    "https://gh-proxy.com/${AppConst.APP_GITHUB_LATEST_RELEASE_URL}",
+)

--- a/composeApp/src/commonTest/kotlin/service/VersionServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/VersionServiceTest.kt
@@ -1,0 +1,34 @@
+package io.github.vrcmteam.vrcm.service
+
+import com.russhwolf.settings.MapSettings
+import io.github.vrcmteam.vrcm.network.api.github.GitHubApi
+import io.github.vrcmteam.vrcm.storage.SettingsDao
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class VersionServiceTest {
+    @Test
+    fun triesMirrorsWhenOfficialReleaseCheckFails() = runBlocking {
+        val requestedHosts = mutableListOf<String>()
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    requestedHosts += request.url.host
+                    respond("unavailable", HttpStatusCode.ServiceUnavailable)
+                }
+            }
+        }
+
+        val result = VersionService(GitHubApi(client), SettingsDao(MapSettings())).checkVersion(false)
+
+        assertEquals(listOf("api.github.com", "ghfast.top", "gh-proxy.com"), requestedHosts)
+        assertTrue(result.isFailure)
+        client.close()
+    }
+}


### PR DESCRIPTION
本 PR 的原始目标（送审时冻结的需求基线）：**检查更新失败时使用镜像源，安卓端更新时直接下载安装包**。

原正文为空，本次仅按评审前置检查的要求补齐说明结构（含 `## 实现假设清单`），不改动代码行为，也不改变上述目标。

## 实现思路

- **检查更新加镜像回退**：`VersionService.checkVersion` 由单次请求改为按顺序尝试三个地址——官方 `api.github.com` 的 `releases/latest`、`ghfast.top` 前缀、`gh-proxy.com` 前缀；任一地址返回可解析结果即立即返回，全部失败才返回最后一次的异常。`GitHubApi.latestRelease` 相应改为**只在请求主机是 `api.github.com` 时**附带 GitHub token，避免把凭据发送给第三方代理。
- **安卓端直接下载安装**：`AppPlatform` 新增 `installAppUpdate`，默认实现在非安卓平台直接返回失败；安卓实现先用并发 HEAD 请求探测 10 个下载源（官方直连 + 9 个公共 GitHub 代理），取最先响应成功的一个，交由系统 `DownloadManager` 下载到应用外部私有 `Download` 目录，按 500ms 轮询上报进度并设置 15 分钟总时限，完成后校验 APK 的包名与签名，再经 `FileProvider` 打开系统安装器。下载失败或超时会移除任务、删除临时 APK 并清理通知点击记录；页面协程取消时会先执行同样的清理，再传播取消，不会把页面销毁误报成下载失败。
- **弹窗交互**：`UpdateDialog` 在「平台为安卓且 release 资产含 `.apk`」时改为触发应用内更新，下载期间禁用确认/忽略按钮与「记住此版本」勾选并屏蔽弹窗关闭，同时显示下载百分比；下载或安装任一步骤失败时回退为打开 release 页面。其他平台以及没有 APK 资产的 release 保持原有「打开链接」行为。
- **通知点击兜底**：新增 `UpdateDownloadReceiver`，用户点击 DownloadManager 通知时按 SharedPreferences 记录的下载 ID 匹配，重新校验后再次打开安装器。
- **清单与资源**：`AndroidManifest.xml` 新增 `REQUEST_INSTALL_PACKAGES` 权限与 receiver 声明，`file_paths.xml` 新增 `external-files-path` 以便 FileProvider 暴露下载目录。

## 代码逻辑图

检查更新的镜像回退：

```mermaid
sequenceDiagram
    participant UI as StartupAnimeScreen / SettingsBottomSheet
    participant Service as VersionService
    participant Api as GitHubApi
    participant Origin as api.github.com
    participant Mirror as ghfast.top / gh-proxy.com
    UI->>Service: checkVersion(checkRemember)
    Service->>Api: latestRelease(官方地址)
    Api->>Origin: GET releases/latest（附带 GitHub token）
    Origin-->>Api: 结果或异常
    alt 官方地址成功
        Api-->>Service: ReleaseData
    else 官方地址失败
        Service->>Api: latestRelease(镜像地址)
        Api->>Mirror: GET 代理前缀+官方地址（不附带 token）
        Mirror-->>Api: 结果或异常
        Api-->>Service: ReleaseData 或记录 lastFailure 后继续下一个地址
    end
    Service-->>UI: VersionDto(tagName, htmlUrl, downloadUrl, hasNewVersion) 或最后一次失败
```

安卓端下载与安装：

```mermaid
sequenceDiagram
    participant Dialog as UpdateDialog
    participant Platform as AndroidAppPlatform
    participant Update as downloadAndInstallAppUpdate
    participant Race as findFastestMirror
    participant DM as DownloadManager
    participant Verify as verifyApk
    participant Installer as 系统安装器
    participant Receiver as UpdateDownloadReceiver
    Dialog->>Dialog: 判定平台为安卓且资产含 .apk
    Dialog->>Platform: installAppUpdate(tagName, downloadUrls, onProgress)
    Platform->>Update: 执行下载与安装
    Update->>Race: 对全部下载源并发 HEAD 探测
    Race-->>Update: 最先成功的源前缀，或无可用源
    Update->>DM: enqueue（下载到外部私有 Download 目录）
    Update->>Update: 将 downloadId 与文件路径写入 SharedPreferences
    loop 每 500ms，最多 15 分钟
        Update->>DM: query 下载状态与字节数
        Update-->>Dialog: onProgress(进度或未知)
        alt 成功
            DM-->>Update: STATUS_SUCCESSFUL
        else 失败、未知状态或超时
            Update->>DM: remove(downloadId)
            Update->>Update: 删除临时 APK 与 SharedPreferences 记录
            Update-->>Dialog: Result.failure，回退 release 页面
        else 外部取消
            Update->>DM: remove(downloadId)
            Update->>Update: 删除临时 APK 与 SharedPreferences 记录
            Update-->>Dialog: 传播 CancellationException，不执行跳转
        end
    end
    Update->>Verify: 校验包名与已安装应用签名
    Verify-->>Update: 通过或抛出异常
    Update->>Installer: FileProvider URI + ACTION_VIEW
    alt 任一步骤失败
        Platform-->>Dialog: Result.failure
        Dialog->>Dialog: 打开 release 页面并关闭弹窗
    end
    Receiver->>Verify: 用户点击下载通知时重新校验
    Receiver->>Installer: 重新打开安装器
```

## 实现假设清单

- **两个检查更新镜像能代理 GitHub REST API**：假设 `https://ghfast.top/<完整 api.github.com 地址>` 与 `https://gh-proxy.com/<完整 api.github.com 地址>` 会返回与官方 `releases/latest` 结构一致的 JSON。依据：这两个前缀沿用了 APK 下载源同一批公共 GitHub 代理的拼接写法。**尚无真实网络回执**：本 PR 新增的单元测试只断言三个地址被依次请求，不能证明镜像确实可用。
- **硬编码的公共代理域名长期有效**：下载源中的 9 个第三方代理域名写在 `AppUpdate.android.kt` 里。依据：与检查更新镜像同源的社区代理约定。这些域名不由本项目控制，全部失效时的表现是竞速阶段拿不到可用源，最终回退为打开 release 页面。
- **HEAD 请求成功即代表该源能完整下载 APK**：竞速只看响应状态码，不校验 `Content-Length` 或响应内容。依据：`findFastestMirror` 的实现；下载产物的正确性由后续包名与签名校验兜底。
- **release 资产中第一个 `.apk` 结尾的资产就是要安装的安卓包**：依据：改动前的 `UpdateDialog` 已按 `.apk` 关键字挑选下载链接。注意新代码使用 `endsWith(".apk")`，比原来的 `contains(".apk")` 更严格，要求下载 URL 以 `.apk` 结尾。
- **以本机已安装签名作为信任根足以验证下载产物**：`verifyApk` 只比较下载包与当前已安装应用的包名和签名，不校验官方发布哈希。依据：应用内更新时当前应用必然已安装，签名一致即可排除被代理替换过的安装包。仓库的 Debug 变体使用 `io.github.vrcmteam.vrcm.debug` 和 Android Debug 证书，而官方发布 APK 使用 `io.github.vrcmteam.vrcm` 和发布证书；因此 Debug 包不能把官方 APK 当作自身更新，必须用生产包名且具有同一发布签名的已安装应用验证真实更新链路，不能通过放宽校验让不同应用互相覆盖。
- **系统 `DownloadManager` 与外部私有 Download 目录可用**：依据：取不到目录或 DownloadManager 不可用时会返回失败并由弹窗回退到 release 页面；下载任务还会在失败或 15 分钟超时后清理。裁剪 ROM 上禁用 DownloadManager 走的就是这条回退路径，**未在真机验证**。
- **“安装未知应用”授权由系统安装器自行引导**：清单声明了 `REQUEST_INSTALL_PACKAGES`，但代码没有 `canRequestPackageInstalls` 预检或跳转设置。依据：安卓实现直接 `startActivity(ACTION_VIEW)`。未授权时用户实际看到的提示与流程**未在真机验证**。
- **下载期间进程与弹窗存活**：进度轮询与安装动作都跑在 `UpdateDialog` 的 composition 协程里；弹窗销毁会取消该协程，取消路径会清理当前 DownloadManager 任务并传播取消，不会在页面销毁后打开 release 页面。进程被杀后若 DownloadManager 已完成，仍依赖 `UpdateDownloadReceiver` 在用户点击下载通知时补上安装入口。依据：`UpdateDialog` 使用 `rememberCoroutineScope().launch`，receiver 只处理 `ACTION_NOTIFICATION_CLICKED`。
- **非安卓平台不引入应用内更新**：桌面与 iOS 继续走浏览器打开链接。依据：`AppPlatform.installAppUpdate` 的默认实现返回 `UnsupportedOperationException` 失败，且弹窗对非安卓分支保持原逻辑。

## 自测结果

以下三条基线命令是在 PR head `c0b453a` 上实跑的；本轮修复后的验证命令另列如下：

- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:compileKotlinDesktop`：BUILD SUCCESSFUL
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.service.VersionServiceTest"`：BUILD SUCCESSFUL，新增的镜像回退顺序测试通过
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:assembleDebug`：BUILD SUCCESSFUL，可确认新增权限与 receiver 的清单合并通过、安卓源集编译通过
- 本轮修复后 `~/ai/bin/gradle-run.sh ./gradlew :composeApp:compileDebugKotlinAndroid`：BUILD SUCCESSFUL
- 本轮修复后 `~/ai/bin/gradle-run.sh ./gradlew :composeApp:testDebugUnitTest`：BUILD SUCCESSFUL
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:assembleRelease`：BUILD SUCCESSFUL
- 官方 1.1.1 APK 的 GitHub `digest` 与下载文件 SHA-256 一致；`aapt`/`apksigner` 确认官方 APK 为生产包名和发布证书，PR Debug APK 为 `.debug` 包名和 Android Debug 证书，两者不能构成 Android 更新关系
- 真机反馈：PR 作者报告 APK 下载完成后未弹出安装器而回退 GitHub；当前证据说明若测试安装的是 PR Debug 包，包名与签名校验必然拒绝官方生产 APK，后续需以生产包名和发布签名一致的安装包复测真实更新路径

尚未自动验证的风险：生产签名应用上的真机下载与安装全链路、`REQUEST_INSTALL_PACKAGES` 未授权时的系统引导、DownloadManager 被禁用时的回退表现；这些不能由 Debug 包替代验证。
