### PR TITLE
fix(auth): recover expired realtime sessions

### DIFF
--- a/composeApp/src/commonMain/kotlin/di/modules/NetworkModule.kt
+++ b/composeApp/src/commonMain/kotlin/di/modules/NetworkModule.kt
@@ -61,7 +61,10 @@ internal fun createNetworkJson() = Json {
 
 private val apiClientDefinition: Definition<HttpClient> = {
     HttpClient {
-        configureApiClient(get())
+        configureApiClient(
+            apiNoticeCenter = get(),
+            webSocketJson = get(),
+        )
         // api的json序列化器
         install(ContentNegotiation) {
             json(get())

--- a/composeApp/src/commonMain/kotlin/di/modules/ServiceModule.kt
+++ b/composeApp/src/commonMain/kotlin/di/modules/ServiceModule.kt
@@ -1,6 +1,7 @@
 package io.github.vrcmteam.vrcm.di.modules
 
 import io.github.vrcmteam.vrcm.service.*
+import io.github.vrcmteam.vrcm.network.websocket.WebSocketSessionRecovery
 import io.github.vrcmteam.vrcm.service.meetup.DecorationResolver
 import io.github.vrcmteam.vrcm.service.meetup.DecorationTemplateSource
 import io.github.vrcmteam.vrcm.service.meetup.DefaultMeetupCardRemoteDataSource
@@ -24,7 +25,7 @@ import org.koin.dsl.module
 
 val serviceModule: Module = module {
     singleOf(::VersionService)
-    singleOf(::AuthService)
+    singleOf(::AuthService) bind WebSocketSessionRecovery::class
     singleOf(::FavoriteService)
     singleOf(::FriendService)
     singleOf(::FriendActivityService)

--- a/composeApp/src/commonMain/kotlin/network/api/auth/AuthApi.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/auth/AuthApi.kt
@@ -9,6 +9,7 @@ import io.github.vrcmteam.vrcm.network.api.auth.data.CurrentUserData
 import io.github.vrcmteam.vrcm.network.extensions.checkSuccess
 import io.github.vrcmteam.vrcm.network.extensions.checkSuccessResult
 import io.github.vrcmteam.vrcm.network.extensions.urlEncode
+import io.github.vrcmteam.vrcm.network.supports.VRCApiException
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
@@ -56,7 +57,11 @@ class AuthApi(
 
             HttpStatusCode.Unauthorized -> AuthState.Unauthorized(response.bodyAsText())
 
-            else -> AuthState.Unauthorized(response.bodyAsText())
+            else -> throw VRCApiException(
+                description = response.status.description,
+                code = response.status.value,
+                bodyText = response.bodyAsText(),
+            )
 
         }
     }
@@ -83,7 +88,6 @@ class AuthApi(
     }
 
 }
-
 
 
 

--- a/composeApp/src/commonMain/kotlin/network/supports/ApiClientDefaultBuilder.kt
+++ b/composeApp/src/commonMain/kotlin/network/supports/ApiClientDefaultBuilder.kt
@@ -19,6 +19,7 @@ private const val RATE_LIMIT_MAX_DELAY_MILLIS = 60_000L
  */
 internal fun HttpClientConfig<*>.configureApiClient(
     apiNoticeCenter: ApiNoticeCenter,
+    webSocketJson: Json = Json,
     retryDelay: (suspend (Long) -> Unit)? = null,
 ) {
     defaultRequest { url.takeFrom(VRC_API_URL) }
@@ -60,11 +61,10 @@ internal fun HttpClientConfig<*>.configureApiClient(
     // websocket
     install(WebSockets){
         // json 序列化配置
-        contentConverter = KotlinxWebsocketSerializationConverter(Json)
+        contentConverter = KotlinxWebsocketSerializationConverter(webSocketJson)
         // ping间隔（保持连接活跃，必须小于 socketTimeoutMillis）
         pingInterval = 30.seconds
     }
     // user agent用户代理信息 (就是添加一个header)
     install(UserAgent)
 }
-

--- a/composeApp/src/commonMain/kotlin/network/websocket/WebSocketApi.kt
+++ b/composeApp/src/commonMain/kotlin/network/websocket/WebSocketApi.kt
@@ -6,7 +6,8 @@ import io.github.vrcmteam.vrcm.core.shared.AccountWebSocketEvent
 import io.github.vrcmteam.vrcm.network.api.attributes.AUTH_API_PREFIX
 import io.github.vrcmteam.vrcm.network.api.attributes.VRC_WSS_URL
 import io.github.vrcmteam.vrcm.network.api.auth.data.AuthData
-import io.github.vrcmteam.vrcm.network.websocket.data.WebSocketEvent
+import io.github.vrcmteam.vrcm.network.websocket.data.WebSocketMessage
+import io.github.vrcmteam.vrcm.network.websocket.data.WebSocketSessionRejectedException
 import io.github.vrcmteam.vrcm.presentation.compoments.ToastText
 import io.ktor.client.*
 import io.ktor.client.plugins.websocket.*
@@ -21,6 +22,7 @@ import org.koin.core.logger.Logger
 
 class WebSocketApi(
     private val apiClient: HttpClient,
+    private val sessionRecovery: WebSocketSessionRecovery,
     private val logger: Logger,
 ) {
 
@@ -80,7 +82,9 @@ class WebSocketApi(
     private suspend fun startWebSocket(sessionToken: AccountSessionToken) {
         retryWebSocketConnection(
             maxRetryDelayMillis = MAX_RETRY_DELAY_MILLIS,
-            onFailure = ::reportConnectionFailure,
+            onFailure = { error, consecutiveFailures ->
+                handleConnectionFailure(sessionToken, error, consecutiveFailures)
+            },
         ) { markConnected ->
             val authResponse = apiClient.get(AUTH_API_PREFIX)
             check(authResponse.status == HttpStatusCode.OK) {
@@ -98,7 +102,7 @@ class WebSocketApi(
                 markConnected()
                 try {
                     while (true) {
-                        val othersMessage = receiveDeserialized<WebSocketEvent>()
+                        val othersMessage = receiveDeserialized<WebSocketMessage>().requireEvent()
                         SharedFlowCentre.emitWebSocket(
                             AccountWebSocketEvent(sessionToken, othersMessage)
                         )
@@ -107,6 +111,26 @@ class WebSocketApi(
                     connectedSessionToken.value = null
                 }
             }
+        }
+    }
+
+    private suspend fun handleConnectionFailure(
+        sessionToken: AccountSessionToken,
+        error: Exception,
+        consecutiveFailures: Int,
+    ) {
+        if (error !is WebSocketSessionRejectedException) {
+            reportConnectionFailure(error, consecutiveFailures)
+            return
+        }
+
+        logger.warn("Pipeline rejected the current session; attempting authentication recovery")
+        try {
+            sessionRecovery.recoverExpiredSession(sessionToken)
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (recoveryError: Exception) {
+            reportConnectionFailure(recoveryError, consecutiveFailures)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/network/websocket/WebSocketSessionRecovery.kt
+++ b/composeApp/src/commonMain/kotlin/network/websocket/WebSocketSessionRecovery.kt
@@ -1,0 +1,8 @@
+package io.github.vrcmteam.vrcm.network.websocket
+
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+
+/** Restores or invalidates an authenticated account after Pipeline rejects its session. */
+fun interface WebSocketSessionRecovery {
+    suspend fun recoverExpiredSession(sessionToken: AccountSessionToken)
+}

--- a/composeApp/src/commonMain/kotlin/network/websocket/data/WebSocketEvent.kt
+++ b/composeApp/src/commonMain/kotlin/network/websocket/data/WebSocketEvent.kt
@@ -7,3 +7,21 @@ data class WebSocketEvent(
     val type: String,
     val content: String,
 )
+
+@Serializable
+internal data class WebSocketMessage(
+    val type: String? = null,
+    val content: String? = null,
+    val err: String? = null,
+) {
+    fun requireEvent(): WebSocketEvent {
+        if (err != null) throw WebSocketSessionRejectedException()
+        return WebSocketEvent(
+            type = requireNotNull(type) { "Pipeline message did not contain an event type" },
+            content = requireNotNull(content) { "Pipeline message did not contain event content" },
+        )
+    }
+}
+
+internal class WebSocketSessionRejectedException :
+    Exception("Pipeline rejected the authenticated session")

--- a/composeApp/src/commonMain/kotlin/network/websocket/data/WebSocketEvent.kt
+++ b/composeApp/src/commonMain/kotlin/network/websocket/data/WebSocketEvent.kt
@@ -2,6 +2,9 @@ package io.github.vrcmteam.vrcm.network.websocket.data
 
 import kotlinx.serialization.Serializable
 
+private const val SESSION_REJECTED_ERROR =
+    "authToken doesn't correspond with an active session"
+
 @Serializable
 data class WebSocketEvent(
     val type: String,
@@ -15,7 +18,10 @@ internal data class WebSocketMessage(
     val err: String? = null,
 ) {
     fun requireEvent(): WebSocketEvent {
-        if (err != null) throw WebSocketSessionRejectedException()
+        err?.let { error ->
+            if (error == SESSION_REJECTED_ERROR) throw WebSocketSessionRejectedException()
+            throw WebSocketPipelineException(error)
+        }
         return WebSocketEvent(
             type = requireNotNull(type) { "Pipeline message did not contain an event type" },
             content = requireNotNull(content) { "Pipeline message did not contain event content" },
@@ -25,3 +31,6 @@ internal data class WebSocketMessage(
 
 internal class WebSocketSessionRejectedException :
     Exception("Pipeline rejected the authenticated session")
+
+internal class WebSocketPipelineException(error: String) :
+    Exception("Pipeline error: $error")

--- a/composeApp/src/commonMain/kotlin/service/AuthService.kt
+++ b/composeApp/src/commonMain/kotlin/service/AuthService.kt
@@ -289,16 +289,21 @@ class AuthService(
         loginLocked(username, password)
     }
 
-    private suspend fun loginLocked(username: String, password: String): AuthState {
+    private suspend fun loginLocked(
+        username: String,
+        password: String,
+        restoreStoredCookies: Boolean = true,
+        invalidateOnIncompleteAuth: Boolean = true,
+    ): AuthState {
         val activeUserId = SharedFlowCentre.currentSession.value?.account?.userId
         val targetUserId = accountDao.accountDtoByUserName(username)?.userId
         val isAccountSwitch = activeUserId != null && activeUserId != targetUserId
-        applyAuthCookie(username)
+        if (restoreStoredCookies) applyAuthCookie(username)
         return try {
             authApi.login(username, password).also {
                 if (it is AuthState.Authed) {
                     emitAuthed(password).getOrThrow()
-                } else {
+                } else if (invalidateOnIncompleteAuth) {
                     invalidateCurrentSessionLocked()
                 }
             }
@@ -344,8 +349,36 @@ class AuthService(
 
     override suspend fun recoverExpiredSession(sessionToken: AccountSessionToken) = authMutex.withLock {
         if (!SharedFlowCentre.isCurrentSession(sessionToken)) return@withLock
-        val recovered = doReTryAuthLocked(sessionToken.userId)
-        if (!recovered && SharedFlowCentre.isCurrentSession(sessionToken)) {
+
+        val account = accountDao.currentAccountDtoOrNull()
+            ?.takeIf { it.userId == sessionToken.userId }
+        val password = account?.password
+        if (account == null || password == null) {
+            clearAuthCookie(sessionToken.userId)
+            invalidateCurrentSessionLocked()
+            return@withLock
+        }
+
+        // Pipeline rejected this cookie. Keep the two-factor cookie available for the
+        // credential request, but do not send the rejected auth cookie again.
+        val rejectedAuthCookie = cookiesStorage.cookieValue(AUTH_COOKIE)
+        cookiesStorage.removeCookie(AUTH_COOKIE)
+        val authState = try {
+            loginLocked(
+                username = account.username,
+                password = password,
+                restoreStoredCookies = false,
+                invalidateOnIncompleteAuth = false,
+            )
+        } catch (error: Throwable) {
+            // A temporary HTTP or I/O failure must leave the current session intact and
+            // allow the next WebSocket attempt to use the existing authenticated state.
+            rejectedAuthCookie?.let { cookiesStorage.addCookie(AUTH_COOKIE, it) }
+            throw error
+        }
+
+        if (authState !is AuthState.Authed && SharedFlowCentre.isCurrentSession(sessionToken)) {
+            clearAuthCookie(account.userId)
             invalidateCurrentSessionLocked()
         }
     }

--- a/composeApp/src/commonMain/kotlin/service/AuthService.kt
+++ b/composeApp/src/commonMain/kotlin/service/AuthService.kt
@@ -370,10 +370,19 @@ class AuthService(
                 restoreStoredCookies = false,
                 invalidateOnIncompleteAuth = false,
             )
+        } catch (cancellation: CancellationException) {
+            // Successful auth publishes a new session before the old connection job is
+            // cancelled. Do not roll the rejected cookie back after that session change.
+            if (SharedFlowCentre.isCurrentSession(sessionToken)) {
+                rejectedAuthCookie?.let { cookiesStorage.addCookie(AUTH_COOKIE, it) }
+            }
+            throw cancellation
         } catch (error: Throwable) {
             // A temporary HTTP or I/O failure must leave the current session intact and
             // allow the next WebSocket attempt to use the existing authenticated state.
-            rejectedAuthCookie?.let { cookiesStorage.addCookie(AUTH_COOKIE, it) }
+            if (SharedFlowCentre.isCurrentSession(sessionToken)) {
+                rejectedAuthCookie?.let { cookiesStorage.addCookie(AUTH_COOKIE, it) }
+            }
             throw error
         }
 

--- a/composeApp/src/commonMain/kotlin/service/AuthService.kt
+++ b/composeApp/src/commonMain/kotlin/service/AuthService.kt
@@ -14,6 +14,7 @@ import io.github.vrcmteam.vrcm.network.api.users.data.UserData
 import io.github.vrcmteam.vrcm.network.extensions.checkSuccess
 import io.github.vrcmteam.vrcm.network.supports.VRCApiException
 import io.github.vrcmteam.vrcm.network.websocket.data.content.UserContent
+import io.github.vrcmteam.vrcm.network.websocket.WebSocketSessionRecovery
 import io.github.vrcmteam.vrcm.presentation.screens.auth.data.AuthCardPage
 import io.github.vrcmteam.vrcm.service.data.AccountDto
 import io.github.vrcmteam.vrcm.storage.AccountCacheManager
@@ -47,7 +48,7 @@ class AuthService(
     private val accountDao: AccountDao,
     private val cookiesStorage: PersistentCookiesStorage,
     private val accountCacheManager: AccountCacheManager,
-) {
+) : WebSocketSessionRecovery {
     private var scope = CoroutineScope(Job())
     private val authMutex = Mutex()
     private val currentUserLock = SynchronizedObject()
@@ -339,6 +340,14 @@ class AuthService(
         if (expectedUserId != null && accountInfo.userId != expectedUserId) return false
         val password = accountInfo.password ?: return false
         return loginLocked(accountInfo.username, password) is AuthState.Authed
+    }
+
+    override suspend fun recoverExpiredSession(sessionToken: AccountSessionToken) = authMutex.withLock {
+        if (!SharedFlowCentre.isCurrentSession(sessionToken)) return@withLock
+        val recovered = doReTryAuthLocked(sessionToken.userId)
+        if (!recovered && SharedFlowCentre.isCurrentSession(sessionToken)) {
+            invalidateCurrentSessionLocked()
+        }
     }
 
     internal suspend fun <T> runSessionBoundCatching(

--- a/composeApp/src/commonTest/kotlin/network/websocket/data/WebSocketMessageTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/websocket/data/WebSocketMessageTest.kt
@@ -1,0 +1,24 @@
+package io.github.vrcmteam.vrcm.network.websocket.data
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+
+class WebSocketMessageTest {
+    @Test
+    fun sessionRejectionFrameIsClassifiedWithoutExposingCredentials() {
+        val credential = "authcookie_sensitive"
+        val message = Json { ignoreUnknownKeys = true }.decodeFromString<WebSocketMessage>(
+            """{"err":"authToken doesn't correspond with an active session","authToken":"$credential","ip":"127.0.0.1"}"""
+        )
+
+        val error = assertFailsWith<WebSocketSessionRejectedException> {
+            message.requireEvent()
+        }
+
+        assertEquals("Pipeline rejected the authenticated session", error.message)
+        assertFalse(error.message.orEmpty().contains(credential))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/network/websocket/data/WebSocketMessageTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/websocket/data/WebSocketMessageTest.kt
@@ -21,4 +21,24 @@ class WebSocketMessageTest {
         assertEquals("Pipeline rejected the authenticated session", error.message)
         assertFalse(error.message.orEmpty().contains(credential))
     }
+
+    @Test
+    fun otherPipelineErrorsDoNotTriggerSessionRecovery() {
+        val errors = listOf(
+            "Error finding user usr_example",
+            "Pipeline: authToken doesn't correspond with an active session",
+        )
+
+        errors.forEach { errorText ->
+            val message = Json.decodeFromString<WebSocketMessage>(
+                """{"err":"$errorText"}"""
+            )
+
+            val error = assertFailsWith<WebSocketPipelineException> {
+                message.requireEvent()
+            }
+
+            assertEquals("Pipeline error: $errorText", error.message)
+        }
+    }
 }

--- a/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
@@ -3,6 +3,7 @@ package io.github.vrcmteam.vrcm.service
 import com.russhwolf.settings.MapSettings
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.di.supports.PersistentCookiesStorage
+import io.github.vrcmteam.vrcm.network.api.attributes.AUTH_COOKIE
 import io.github.vrcmteam.vrcm.network.api.attributes.AuthState
 import io.github.vrcmteam.vrcm.network.api.avatars.AvatarsApi
 import io.github.vrcmteam.vrcm.network.api.auth.AuthApi
@@ -387,8 +388,22 @@ class AuthServiceTest : MainDispatcherTest() {
 
     @Test
     fun expiredRealtimeSessionReauthenticatesSavedAccount() = runTest {
-        val fixture = fixture {
-            jsonResponse(currentUserJson(cachedAccount()))
+        val requests = mutableListOf<Pair<String?, String?>>()
+        var requestCount = 0
+        val fixture = fixture { request ->
+            requestCount++
+            requests += request.headers[HttpHeaders.Cookie] to request.headers[HttpHeaders.Authorization]
+            when (requestCount) {
+                2 -> respond(
+                    content = currentUserJson(cachedAccount()),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(
+                        HttpHeaders.ContentType to listOf("application/json"),
+                        HttpHeaders.SetCookie to listOf("auth=new-auth; Path=/"),
+                    ),
+                )
+                else -> jsonResponse(currentUserJson(cachedAccount()))
+            }
         }
         fixture.service.restoreAuth()
         val expiredSession = assertNotNull(SharedFlowCentre.currentSession.value)
@@ -398,13 +413,20 @@ class AuthServiceTest : MainDispatcherTest() {
         val recoveredSession = assertNotNull(SharedFlowCentre.currentSession.value)
         assertEquals(expiredSession.account.userId, recoveredSession.account.userId)
         assertFalse(expiredSession.token == recoveredSession.token)
+        assertFalse(requests[1].first.orEmpty().contains("auth=cached-auth"))
+        assertTrue(requests[1].first.orEmpty().contains("twoFactorAuth=cached-2fa"))
+        assertTrue(requests[1].second.orEmpty().startsWith("Basic "))
+        assertTrue(requests[2].first.orEmpty().contains("auth=new-auth"))
+        assertEquals("new-auth", fixture.accountDao.currentAccountDtoOrNull()?.authCookie)
         fixture.client.close()
     }
 
     @Test
     fun expiredRealtimeSessionWithoutSavedPasswordInvalidatesSession() = runTest {
         val accountWithoutPassword = cachedAccount().copy(password = null)
+        var requestCount = 0
         val fixture = fixture(accountWithoutPassword) {
+            requestCount++
             jsonResponse(currentUserJson(accountWithoutPassword))
         }
         fixture.service.restoreAuth()
@@ -413,6 +435,36 @@ class AuthServiceTest : MainDispatcherTest() {
         fixture.service.recoverExpiredSession(expiredSession.token)
 
         assertNull(SharedFlowCentre.currentSession.value)
+        assertNull(fixture.accountDao.currentAccountDtoOrNull()?.authCookie)
+        assertNull(fixture.service.restoreAuth())
+        assertEquals(1, requestCount)
+        fixture.client.close()
+    }
+
+    @Test
+    fun temporaryRealtimeReauthenticationFailureKeepsSessionAndStoredCookie() = runTest {
+        var requestCount = 0
+        val fixture = fixture { request ->
+            requestCount++
+            if (requestCount == 2) {
+                respond(
+                    content = "temporarily unavailable",
+                    status = HttpStatusCode.ServiceUnavailable,
+                )
+            } else {
+                jsonResponse(currentUserJson(cachedAccount()))
+            }
+        }
+        fixture.service.restoreAuth()
+        val session = assertNotNull(SharedFlowCentre.currentSession.value)
+
+        assertFailsWith<VRCApiException> {
+            fixture.service.recoverExpiredSession(session.token)
+        }
+
+        assertTrue(SharedFlowCentre.isCurrentSession(session.token))
+        assertEquals("cached-auth", fixture.accountDao.currentAccountDtoOrNull()?.authCookie)
+        assertEquals("cached-auth", fixture.cookies.cookieValue(AUTH_COOKIE))
         fixture.client.close()
     }
 
@@ -518,6 +570,7 @@ class AuthServiceTest : MainDispatcherTest() {
     private data class Fixture(
         val service: AuthService,
         val accountDao: AccountDao,
+        val cookies: PersistentCookiesStorage,
         val client: HttpClient,
     )
 
@@ -550,7 +603,7 @@ class AuthServiceTest : MainDispatcherTest() {
                 ),
             ),
         )
-        return Fixture(service, accountDao, client)
+        return Fixture(service, accountDao, cookies, client)
     }
 
     private fun cachedAccount() = AccountDto(

--- a/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
@@ -33,8 +33,11 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.koin.core.logger.EmptyLogger
@@ -465,6 +468,51 @@ class AuthServiceTest : MainDispatcherTest() {
         assertTrue(SharedFlowCentre.isCurrentSession(session.token))
         assertEquals("cached-auth", fixture.accountDao.currentAccountDtoOrNull()?.authCookie)
         assertEquals("cached-auth", fixture.cookies.cookieValue(AUTH_COOKIE))
+        fixture.client.close()
+    }
+
+    @Test
+    fun successfulRealtimeReauthenticationCancellationKeepsNewCookie() = runTest {
+        var requestCount = 0
+        val fixture = fixture { request ->
+            requestCount++
+            when (requestCount) {
+                2 -> respond(
+                    content = currentUserJson(cachedAccount()),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(
+                        HttpHeaders.ContentType to listOf("application/json"),
+                        HttpHeaders.SetCookie to listOf("auth=new-auth; Path=/"),
+                    ),
+                )
+                else -> jsonResponse(currentUserJson(cachedAccount()))
+            }
+        }
+        fixture.service.restoreAuth()
+        val previousSession = assertNotNull(SharedFlowCentre.currentSession.value)
+        val authenticated = CompletableDeferred<Unit>()
+        lateinit var recoveryJob: Job
+        val cancellationCollector = launch(start = CoroutineStart.UNDISPATCHED) {
+            SharedFlowCentre.authed.collect {
+                if (!authenticated.isCompleted) {
+                    authenticated.complete(Unit)
+                    recoveryJob.cancel()
+                }
+            }
+        }
+
+        recoveryJob = launch(start = CoroutineStart.UNDISPATCHED) {
+            fixture.service.recoverExpiredSession(previousSession.token)
+        }
+        authenticated.await()
+        recoveryJob.join()
+
+        val currentSession = assertNotNull(SharedFlowCentre.currentSession.value)
+        assertFalse(currentSession.token == previousSession.token)
+        assertEquals("new-auth", fixture.cookies.cookieValue(AUTH_COOKIE))
+        assertEquals("new-auth", fixture.accountDao.currentAccountDtoOrNull()?.authCookie)
+
+        cancellationCollector.cancelAndJoin()
         fixture.client.close()
     }
 

--- a/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
@@ -386,6 +386,37 @@ class AuthServiceTest : MainDispatcherTest() {
     }
 
     @Test
+    fun expiredRealtimeSessionReauthenticatesSavedAccount() = runTest {
+        val fixture = fixture {
+            jsonResponse(currentUserJson(cachedAccount()))
+        }
+        fixture.service.restoreAuth()
+        val expiredSession = assertNotNull(SharedFlowCentre.currentSession.value)
+
+        fixture.service.recoverExpiredSession(expiredSession.token)
+
+        val recoveredSession = assertNotNull(SharedFlowCentre.currentSession.value)
+        assertEquals(expiredSession.account.userId, recoveredSession.account.userId)
+        assertFalse(expiredSession.token == recoveredSession.token)
+        fixture.client.close()
+    }
+
+    @Test
+    fun expiredRealtimeSessionWithoutSavedPasswordInvalidatesSession() = runTest {
+        val accountWithoutPassword = cachedAccount().copy(password = null)
+        val fixture = fixture(accountWithoutPassword) {
+            jsonResponse(currentUserJson(accountWithoutPassword))
+        }
+        fixture.service.restoreAuth()
+        val expiredSession = assertNotNull(SharedFlowCentre.currentSession.value)
+
+        fixture.service.recoverExpiredSession(expiredSession.token)
+
+        assertNull(SharedFlowCentre.currentSession.value)
+        fixture.client.close()
+    }
+
+    @Test
     fun failedAccountSwitchInvalidatesPreviousSession() = runTest {
         val secondAccount = AccountDto(
             userId = "usr_second",
@@ -490,7 +521,10 @@ class AuthServiceTest : MainDispatcherTest() {
         val client: HttpClient,
     )
 
-    private fun fixture(handler: MockRequestHandler): Fixture {
+    private fun fixture(
+        account: AccountDto = cachedAccount(),
+        handler: MockRequestHandler,
+    ): Fixture {
         val cookies = PersistentCookiesStorage(EmptyLogger())
         val client = HttpClient(MockEngine) {
             engine { addHandler(handler) }
@@ -498,7 +532,9 @@ class AuthServiceTest : MainDispatcherTest() {
             install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
             install(HttpCookies) { storage = cookies }
         }
-        val accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also { it.saveAccountInfo(cachedAccount()) }
+        val accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also {
+            it.saveAccountInfo(account)
+        }
         val service = AuthService(
             authApi = AuthApi(client),
             accountDao = accountDao,


### PR DESCRIPTION
关联 #95

## 实现思路
实时连接现在使用项目统一的宽容 JSON 配置解析服务器消息，并把带有 `err` 的会话拒绝消息识别为登录会话失效，不再把服务器返回的令牌和地址等原文放进用户提示。识别到当前会话失效后，调用认证服务复用已保存的账号信息重新登录；重新登录成功会通过现有会话流触发新连接，无法恢复时清理失效会话并回到登录流程。普通网络错误仍沿用原有重连退避。

## Issue 验收标准自查
Issue 未提供 checklist，按描述拆分如下：

- [x] 会话过期后不再要求用户每次手动登出再登录。验证：新增 `AuthServiceTest.expiredRealtimeSessionReauthenticatesSavedAccount`，确认同一账号生成新的会话令牌并可继续使用。
- [x] 好友实时连接收到会话拒绝后能够自动恢复。验证：`WebSocketMessageTest` 覆盖截图中的 `err` 消息格式；`WebSocketApi` 将该结果交给认证恢复流程。
- [x] 无法用已保存信息恢复时进入登录流程。验证：新增 `AuthServiceTest.expiredRealtimeSessionWithoutSavedPasswordInvalidatesSession`，确认当前会话被清理，现有导航会回到登录页面。
- [x] 不再显示包含登录凭据片段的底层解析错误。验证：错误帧转换为固定的会话失效异常，异常信息不包含服务器返回的 `authToken` 或 `ip` 字段。
- [x] 普通网络中断的重连行为保持不变。验证：保留并通过现有 WebSocket 重试测试；仅对会话拒绝异常增加单独分支。

## 自测结果
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests io.github.vrcmteam.vrcm.network.websocket.data.WebSocketMessageTest --tests io.github.vrcmteam.vrcm.service.AuthServiceTest`：BUILD SUCCESSFUL。
- `ANDROID_HOME=/home/ubuntu/Android/Sdk ANDROID_SDK_ROOT=/home/ubuntu/Android/Sdk ~/ai/bin/check-gate.sh implement-issue 95`：quality gate: pass。
- `git diff --check`：通过。
- 完整 `:composeApp:desktopTest`：741 个测试中 740 个通过；唯一失败是 Linux 无图形会话下既有的 `DesktopWindowTitleBarLocaleTest` / `HeadlessException`，与本次改动无关，已按项目知识库记录说明。

## 自评风险点
- 自动恢复依赖账号仍保存密码；未保存密码或需要额外验证码时会清理失效会话并让用户重新完成登录。
- 服务器持续拒绝会话且认证接口暂时不可用时，会保留原有重试机制并继续等待网络恢复，期间不会伪造连接成功。
- 本次未在真实 VRChat 账号和设备上复现服务端错误帧，真实服务端回执仍是发布前的补充验证项。

## 代码逻辑图
```mermaid
sequenceDiagram
    participant Pipeline
    participant WebSocketMessage
    participant WebSocketApi
    participant AuthService
    participant AuthApi
    participant SharedFlowCentre

    Pipeline->>WebSocketMessage: 返回包含 err 的消息
    WebSocketMessage->>WebSocketMessage: requireEvent() 精确匹配官方会话拒绝文本
    alt err == authToken doesn't correspond with an active session
        WebSocketMessage-->>WebSocketApi: WebSocketSessionRejectedException
        WebSocketApi->>AuthService: recoverExpiredSession(oldToken)
        AuthService->>AuthService: 移除被拒绝的 auth cookie，保留二次验证 cookie
        AuthService->>AuthApi: 使用账号密码登录（不恢复旧 auth cookie）
        alt 登录成功
            AuthApi-->>AuthService: 200 + 新 Set-Cookie
            AuthService->>SharedFlowCentre: emitAuthenticated(newSession)
            SharedFlowCentre-->>WebSocketApi: authed(newSession)
            WebSocketApi->>WebSocketApi: replaceConnection(newToken)，取消旧连接任务
            WebSocketApi--x AuthService: 旧任务收到 CancellationException
            AuthService->>AuthService: oldToken 已非 current，不回滚旧 cookie
        else 明确需要用户介入
            AuthService->>AuthService: 清除持久化 auth cookie
            AuthService->>SharedFlowCentre: emitLogout()
            SharedFlowCentre-->>WebSocketApi: logout
        else 临时 HTTP 或 I/O 故障
            AuthService->>AuthService: oldToken 仍 current 时恢复旧 auth cookie
            AuthService-->>WebSocketApi: 抛出带状态码的 VRCApiException
            WebSocketApi->>WebSocketApi: 沿用现有退避重试
        end
    else 其他 err 或普通连接异常
        WebSocketMessage-->>WebSocketApi: WebSocketPipelineException
        WebSocketApi->>WebSocketApi: reportConnectionFailure()
        WebSocketApi->>WebSocketApi: 沿用普通 WebSocket 退避重试
    end
```

## 实现假设清单
- 假设：实时连接的会话拒绝消息以顶层 `err` 字段返回，并可能同时带有 `authToken`、`ip` 等字段。依据：issue #95 截图和当前 `WebSocketEvent` 的消息格式。
- 假设：会话失效后的自动恢复应复用账号保存的密码；没有密码时应结束失效会话并回到登录流程。依据：现有 `AuthService.doReTryAuth` 约定及 issue 所述“只能手动登出后重新登录”的用户行为。
- 核实：重新登录成功后的新会话由 `SharedFlowCentre.emitAuthenticated` 发布，现有 `WebSocketApi` 已监听该事件并重建连接。依据：当前 `WebSocketApi` 初始化监听和 `AuthService.emitAuthed` 实现。
- 核实：仅当错误仍属于原会话时才执行恢复，账号切换或退出后的旧事件不会影响新会话。依据：`SharedFlowCentre.isCurrentSession` 和本次 `recoverExpiredSession` 门控。

## 实现说明(供追问)
### 关键决策
- 在消息解析边界识别会话拒绝，而不是在好友业务层猜测异常；这样可以在错误原文进入提示和日志前完成脱敏，并复用统一认证服务。
- 使用现有认证事件触发重连，不额外维护一份连接状态，避免新旧会话出现两套状态。

### 覆盖的场景
- 会话拒绝消息包含敏感字段。
- 保存密码时的自动重新登录。
- 没有保存密码时清理失效会话。
- 普通网络错误继续按原有退避重试。
- 账号已切换或已退出时拒绝旧会话恢复。

### 明确未覆盖
- 未在真实 VRChat 账号上人为制造服务端会话过期；自动化测试覆盖了同样的消息和状态转换。
- 未处理服务端协议完全改变且不再提供 `err` 字段的情况，这超出本 issue 的证据范围。

### 关键假设
- VRChat Pipeline 会按截图所示返回 `err` 会话拒绝消息。
- 账号密码仍由现有安全存储提供给认证服务，验证码等二次验证仍由现有登录页面处理。