### PR TITLE
test: 修复 ViewModel 测试协程泄漏导致的串行失败

### DIFF
--- a/composeApp/src/commonTest/kotlin/di/modules/PresentationModuleTest.kt
+++ b/composeApp/src/commonTest/kotlin/di/modules/PresentationModuleTest.kt
@@ -64,14 +64,18 @@ class PresentationModuleTest : MainDispatcherTest() {
             )
         }
 
-        val first = application.koin.get<GalleryScreenModel>()
-        val second = application.koin.get<GalleryScreenModel>()
-
+        val models = mutableListOf<ViewModel>()
         try {
+            val first = application.koin.get<GalleryScreenModel>().also { models += it }
+            val second = application.koin.get<GalleryScreenModel>().also { models += it }
+
             assertNotSame(first, second)
         } finally {
-            clearViewModels(first, second)
-            application.close()
+            try {
+                clearViewModels(models)
+            } finally {
+                application.close()
+            }
         }
     }
 
@@ -91,14 +95,18 @@ class PresentationModuleTest : MainDispatcherTest() {
             )
         }
 
-        val first = application.koin.get<AvatarProfileScreenModel>()
-        val second = application.koin.get<AvatarProfileScreenModel>()
-
+        val models = mutableListOf<ViewModel>()
         try {
+            val first = application.koin.get<AvatarProfileScreenModel>().also { models += it }
+            val second = application.koin.get<AvatarProfileScreenModel>().also { models += it }
+
             assertNotSame(first, second)
         } finally {
-            clearViewModels(first, second)
-            application.close()
+            try {
+                clearViewModels(models)
+            } finally {
+                application.close()
+            }
         }
     }
 
@@ -146,19 +154,27 @@ class PresentationModuleTest : MainDispatcherTest() {
             )
         }
 
-        val first = application.koin.get<MeetupCardScreenModel> { parametersOf("usr_a") }
-        val second = application.koin.get<MeetupCardScreenModel> { parametersOf("usr_a") }
-
+        val models = mutableListOf<ViewModel>()
         try {
+            val first = application.koin.get<MeetupCardScreenModel> {
+                parametersOf("usr_a")
+            }.also { models += it }
+            val second = application.koin.get<MeetupCardScreenModel> {
+                parametersOf("usr_a")
+            }.also { models += it }
+
             assertNotSame(first, second)
         } finally {
-            clearViewModels(first, second)
-            application.close()
+            try {
+                clearViewModels(models)
+            } finally {
+                application.close()
+            }
         }
     }
 }
 
-private suspend fun clearViewModels(vararg models: ViewModel) {
+private suspend fun clearViewModels(models: List<ViewModel>) {
     val jobs = models.mapNotNull { it.viewModelScope.coroutineContext[Job] }
     ViewModelStore().apply {
         models.forEachIndexed { index, model -> put(index.toString(), model) }

--- a/composeApp/src/commonTest/kotlin/di/modules/PresentationModuleTest.kt
+++ b/composeApp/src/commonTest/kotlin/di/modules/PresentationModuleTest.kt
@@ -1,6 +1,9 @@
 package io.github.vrcmteam.vrcm.di.modules
 
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.viewModelScope
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.AvatarProfileLoader
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.AvatarProfileScreenModel
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.AvatarCoverFile
@@ -33,8 +36,10 @@ import io.github.vrcmteam.vrcm.storage.meetup.defaultMeetupCardConfig
 import io.github.vrcmteam.vrcm.testing.MainDispatcherTest
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
 import org.koin.core.parameter.parametersOf
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
@@ -48,7 +53,7 @@ import kotlin.test.assertNotNull
 
 class PresentationModuleTest : MainDispatcherTest() {
     @Test
-    fun galleryScreenModelUsesFactoryScope() {
+    fun galleryScreenModelUsesFactoryScope() = runTest {
         val application = koinApplication {
             modules(
                 presentationModule,
@@ -62,12 +67,16 @@ class PresentationModuleTest : MainDispatcherTest() {
         val first = application.koin.get<GalleryScreenModel>()
         val second = application.koin.get<GalleryScreenModel>()
 
-        assertNotSame(first, second)
-        application.close()
+        try {
+            assertNotSame(first, second)
+        } finally {
+            clearViewModels(first, second)
+            application.close()
+        }
     }
 
     @Test
-    fun avatarProfileScreenModelUsesFactoryScope() {
+    fun avatarProfileScreenModelUsesFactoryScope() = runTest {
         val application = koinApplication {
             modules(
                 presentationModule,
@@ -85,8 +94,12 @@ class PresentationModuleTest : MainDispatcherTest() {
         val first = application.koin.get<AvatarProfileScreenModel>()
         val second = application.koin.get<AvatarProfileScreenModel>()
 
-        assertNotSame(first, second)
-        application.close()
+        try {
+            assertNotSame(first, second)
+        } finally {
+            clearViewModels(first, second)
+            application.close()
+        }
     }
 
     @Test
@@ -122,7 +135,7 @@ class PresentationModuleTest : MainDispatcherTest() {
     }
 
     @Test
-    fun meetupCardScreenModelResolvesPerRequestWithOwnerParameter() {
+    fun meetupCardScreenModelResolvesPerRequestWithOwnerParameter() = runTest {
         val application = koinApplication {
             modules(
                 presentationModule,
@@ -136,9 +149,22 @@ class PresentationModuleTest : MainDispatcherTest() {
         val first = application.koin.get<MeetupCardScreenModel> { parametersOf("usr_a") }
         val second = application.koin.get<MeetupCardScreenModel> { parametersOf("usr_a") }
 
-        assertNotSame(first, second)
-        application.close()
+        try {
+            assertNotSame(first, second)
+        } finally {
+            clearViewModels(first, second)
+            application.close()
+        }
     }
+}
+
+private suspend fun clearViewModels(vararg models: ViewModel) {
+    val jobs = models.mapNotNull { it.viewModelScope.coroutineContext[Job] }
+    ViewModelStore().apply {
+        models.forEachIndexed { index, model -> put(index.toString(), model) }
+        clear()
+    }
+    jobs.joinAll()
 }
 
 private data object EmptyFavoriteEntrySource : FavoriteEntrySource {


### PR DESCRIPTION
## 问题

在 `upstream/main` 完整运行 `:composeApp:allTests --continue` 时，Android Debug 与 Release 各有 2 个失败：

- `BoopSubmissionGateTest.accountSwitchMakesCompletedRequestStale`：前序测试遗留协程在 `Dispatchers.resetMain()` 后恢复，访问已被重置的 Main Dispatcher。
- `FriendOfflineLastActivityRefreshTest.previousSessionRefreshCannotCommitWhileNewSessionCacheIsLoading`：受同一测试间生命周期污染影响而超时。

两个用例单独运行均通过。最小复现组合定位到 `PresentationModuleTest.avatarProfileScreenModelUsesFactoryScope`：测试通过 Koin 工厂获取 `ViewModel` 后仅关闭 Koin，没有触发 `ViewModelStore` 清理，因此 `viewModelScope` 仍在收集共享会话流。

## 修复

- 将三个会解析 `ViewModel` 的 Koin 工厂测试改为 `runTest`。
- 使用 `try/finally` 保证断言结束后执行生命周期清理并关闭 Koin。
- 清理时先捕获各 `viewModelScope` 的根 Job，通过 `ViewModelStore.clear()` 触发 `onCleared()` 与协程取消，再用 `joinAll()` 等待取消彻底完成，避免后台 IO 子协程稍后返回已重置的 Main Dispatcher。

## 程序流程图

```mermaid
flowchart TD
    A[从 Koin 工厂获取 ViewModel] --> B[执行工厂作用域断言]
    B --> C[finally 捕获 viewModelScope Job]
    C --> D[将 ViewModel 放入 ViewModelStore]
    D --> E[调用 ViewModelStore.clear]
    E --> F[触发 onCleared 并取消 viewModelScope]
    F --> G[joinAll 等待所有根 Job 结束]
    G --> H[关闭 Koin application]
    H --> I[MainDispatcherTest resetMain]
```

## 实体实现清单

| 实体 | 实现 |
| --- | --- |
| `PresentationModuleTest` | 三个 ViewModel 工厂作用域测试改用可等待清理的 `runTest` |
| `clearViewModels` | 统一收集根 Job、触发生命周期清理并等待协程结束 |
| `ViewModelStore` | 作为测试生命周期所有者调用 `clear()`，确保执行 ViewModel 清理契约 |
| `viewModelScope` Job | 作为 teardown 完成屏障，防止测试结束后的异步恢复污染后续用例 |

## 验证

- `:composeApp:testDebugUnitTest --rerun`：连续两轮均为 677/677 通过
- `:composeApp:testReleaseUnitTest --rerun`：677/677 通过
- `:composeApp:desktopTest --rerun`：744/744 通过
- `:composeApp:allTests --continue`：成功
- `git diff --check`：通过

Windows 环境下 `iosSimulatorArm64Test` 按平台条件跳过，未实际执行 iOS Simulator 测试。