### PR TITLE
fix(android): 限制窄屏手机自动旋转

### DIFF
--- a/composeApp/src/androidMain/kotlin/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/MainActivity.kt
@@ -1,7 +1,9 @@
 package io.github.vrcmteam.vrcm
 
-import android.graphics.Color
 import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.content.res.Configuration
+import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
@@ -18,6 +20,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge(navigationBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
         super.onCreate(savedInstanceState)
+        updateRequestedOrientation(resources.configuration)
         if (savedInstanceState == null) {
             submitOfficialLink(intent)
             intent.submitNotificationLaunch(notificationLaunchInbox)
@@ -36,6 +39,11 @@ class MainActivity : ComponentActivity() {
                 notificationLaunchInbox = notificationLaunchInbox,
             )
         }
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        updateRequestedOrientation(newConfig)
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -61,7 +69,23 @@ class MainActivity : ComponentActivity() {
         intent.dataString?.let(officialLinkInbox::submit)
     }
 
+    private fun updateRequestedOrientation(configuration: Configuration) {
+        val smallestWidthDp = configuration.smallestScreenWidthDp
+        val targetOrientation = if (
+            smallestWidthDp != Configuration.SMALLEST_SCREEN_WIDTH_DP_UNDEFINED &&
+            smallestWidthDp < WIDE_SCREEN_MIN_WIDTH_DP
+        ) {
+            ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        } else {
+            ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+        }
+        if (requestedOrientation != targetOrientation) {
+            requestedOrientation = targetOrientation
+        }
+    }
+
     private companion object {
+        const val WIDE_SCREEN_MIN_WIDTH_DP = 600
         const val PENDING_OFFICIAL_LINK_KEY = "pending-official-link"
         const val PENDING_NOTIFICATION_DESTINATION_KEY = "pending-notification-destination"
         const val PENDING_NOTIFICATION_TARGET_ID_KEY = "pending-notification-target-id"

--- a/composeApp/src/androidUnitTest/kotlin/MainActivityOrientationTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/MainActivityOrientationTest.kt
@@ -1,0 +1,49 @@
+package io.github.vrcmteam.vrcm
+
+import android.app.Application
+import android.content.pm.ActivityInfo
+import android.content.res.Configuration
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [24, 35])
+class MainActivityOrientationTest {
+    @Test
+    @Config(qualifiers = "sw411dp-w411dp-h891dp-port")
+    fun locksNarrowScreenWhenActivityIsCreated() {
+        val controller = Robolectric.buildActivity(MainActivity::class.java)
+
+        val activity = controller.create().get()
+
+        assertEquals(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT, activity.requestedOrientation)
+        controller.destroy()
+    }
+
+    @Test
+    fun updatesOrientationPolicyWhenDeviceWidthClassChanges() {
+        val activity = Robolectric.buildActivity(MainActivity::class.java).get()
+
+        activity.onConfigurationChanged(
+            Configuration(activity.resources.configuration).apply {
+                screenWidthDp = 891
+                screenHeightDp = 411
+                smallestScreenWidthDp = 411
+            },
+        )
+        assertEquals(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT, activity.requestedOrientation)
+
+        activity.onConfigurationChanged(
+            Configuration(activity.resources.configuration).apply {
+                screenWidthDp = 840
+                screenHeightDp = 673
+                smallestScreenWidthDp = 673
+            },
+        )
+        assertEquals(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED, activity.requestedOrientation)
+    }
+}


### PR DESCRIPTION
## 变更说明

- 在 Android `MainActivity` 创建时，根据当前配置的最小宽度应用方向策略。
- 窄屏手机（`smallestScreenWidthDp < 600`）锁定竖屏；平板、展开态折叠屏及其他宽屏设备恢复系统默认方向策略。
- 在 `onConfigurationChanged` 中同步折叠/展开等宽度变化，并跳过重复的方向请求。
- 增加 Robolectric 回归测试，覆盖首次创建、横放窄屏手机识别、折叠屏展开后解锁，以及 API 24/35。

## 代码流程

```mermaid
flowchart TD
    A[MainActivity 创建或收到配置变化] --> B[读取 smallestScreenWidthDp]
    B --> C{宽度已定义且小于 600dp?}
    C -->|是| D[目标方向为 PORTRAIT]
    C -->|否| E[目标方向为 UNSPECIFIED]
    D --> F{目标与当前请求一致?}
    E --> F
    F -->|是| G[保持现状]
    F -->|否| H[更新 requestedOrientation]
```

## 实现假设

- 600dp 沿用项目现有 Compact/Medium 窗口宽度分界，并与 Android 大屏设备的常用边界一致。
- `smallestScreenWidthDp` 用于避免普通手机横放后因 `screenWidthDp` 变大而被误判为宽屏；折叠/展开导致的可用显示区域变化会通过现有 `smallestScreenSize|screenSize` 配置回调送达 Activity。
- 未定义最小宽度时保持 `SCREEN_ORIENTATION_UNSPECIFIED`，优先避免对未知形态或宽屏设备施加错误限制。
- 现有 Manifest 已由 `MainActivity` 处理相关配置变化，因此策略更新不会依赖 Activity 重建，也不需要新增 Manifest 固定方向声明。
- 本次变更仅位于 Android 源集，不影响 Compose Desktop 与其他平台。

## 验证

- `./gradlew :composeApp:testDebugUnitTest`：通过，716 项测试，0 失败。
- `./gradlew :composeApp:assembleDebug`：通过，Debug APK 成功生成。
- `git diff --check`：通过。

## 实现假设清单

以下清单同步前文已冻结的实现假设，不新增或改变需求：

- 600dp 沿用项目现有 Compact/Medium 窗口宽度分界，并与 Android 大屏设备的常用边界一致。
- `smallestScreenWidthDp` 用于避免普通手机横放后因 `screenWidthDp` 变大而被误判为宽屏；折叠/展开导致的可用显示区域变化会通过现有 `smallestScreenSize|screenSize` 配置回调送达 Activity。
- 未定义最小宽度时保持 `SCREEN_ORIENTATION_UNSPECIFIED`，优先避免对未知形态或宽屏设备施加错误限制。
- 现有 Manifest 已由 `MainActivity` 处理相关配置变化，因此策略更新不会依赖 Activity 重建，也不需要新增 Manifest 固定方向声明。
- 本次变更仅位于 Android 源集，不影响 Compose Desktop 与其他平台。
