### PR TITLE
feat(ui): 支持首页与列表页横向滑动切换

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/compoments/PagerAnimation.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/PagerAnimation.kt
@@ -1,0 +1,15 @@
+package io.github.vrcmteam.vrcm.presentation.compoments
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.pager.PagerState
+
+private val TabPagerAnimationSpec = spring<Float>(
+    dampingRatio = Spring.DampingRatioLowBouncy,
+    stiffness = Spring.StiffnessLow,
+)
+
+internal suspend fun PagerState.animateScrollToTab(page: Int) {
+    if (page == currentPage && !isScrollInProgress) return
+    animateScrollToPage(page, animationSpec = TabPagerAnimationSpec)
+}

--- a/composeApp/src/commonMain/kotlin/presentation/screens/activity/FriendActivityTimelineScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/activity/FriendActivityTimelineScreen.kt
@@ -222,12 +222,18 @@ private fun ActivityTimelineList(
 
         when (state) {
             FriendActivityTimelineState.Loading -> item(key = "activity-loading") {
-                TimelineMessage(Modifier.fillParentMaxHeight()) {
+                TimelineMessage(
+                    if (includeControls) Modifier.padding(vertical = 48.dp)
+                    else Modifier.fillParentMaxHeight(),
+                ) {
                     CircularProgressIndicator()
                 }
             }
             FriendActivityTimelineState.Error -> item(key = "activity-error") {
-                TimelineMessage(Modifier.fillParentMaxHeight()) {
+                TimelineMessage(
+                    if (includeControls) Modifier.padding(vertical = 48.dp)
+                    else Modifier.fillParentMaxHeight(),
+                ) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Text(strings.friendActivityTimelineError)
                         TextButton(onClick = onRetry) { Text(strings.retry) }
@@ -236,7 +242,10 @@ private fun ActivityTimelineList(
             }
             is FriendActivityTimelineState.Content -> if (state.events.isEmpty()) {
                 item(key = "activity-empty") {
-                    TimelineMessage(Modifier.fillParentMaxHeight()) {
+                    TimelineMessage(
+                        if (includeControls) Modifier.padding(vertical = 48.dp)
+                        else Modifier.fillParentMaxHeight(),
+                    ) {
                         Text(strings.friendActivityTimelineEmpty)
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/activity/FriendActivityTimelineScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/activity/FriendActivityTimelineScreen.kt
@@ -149,10 +149,61 @@ fun FriendActivityTimelineContent(
         onLoadMore()
     }
 
+    if (headerContent == null) {
+        Column(modifier = modifier.fillMaxSize()) {
+            ActivityTimelineFilters(filter, onFilterSelected)
+            ActivityTimelineObservedHint()
+            ActivityTimelineList(
+                state = state,
+                filter = filter,
+                onFilterSelected = onFilterSelected,
+                onRetry = onRetry,
+                onRetryLoadMore = onRetryLoadMore,
+                onUserClick = onUserClick,
+                onWorldClick = onWorldClick,
+                listState = listState,
+                modifier = Modifier.weight(1f),
+                includeControls = false,
+            )
+        }
+    } else {
+        ActivityTimelineList(
+            state = state,
+            filter = filter,
+            onFilterSelected = onFilterSelected,
+            onRetry = onRetry,
+            onRetryLoadMore = onRetryLoadMore,
+            onUserClick = onUserClick,
+            onWorldClick = onWorldClick,
+            listState = listState,
+            modifier = modifier,
+            headerContent = headerContent,
+            includeControls = true,
+        )
+    }
+}
+
+@Composable
+private fun ActivityTimelineList(
+    state: FriendActivityTimelineState,
+    filter: FriendActivityTimelineFilter,
+    onFilterSelected: (FriendActivityTimelineFilter) -> Unit,
+    onRetry: () -> Unit,
+    onRetryLoadMore: () -> Unit,
+    onUserClick: (FriendActivityEvent) -> Unit,
+    onWorldClick: (FriendActivityEvent) -> Unit,
+    listState: LazyListState,
+    modifier: Modifier,
+    headerContent: (@Composable () -> Unit)? = null,
+    includeControls: Boolean,
+) {
     LazyColumn(
         modifier = modifier.fillMaxSize().navigationBarsPadding(),
         state = listState,
-        contentPadding = PaddingValues(bottom = 16.dp),
+        contentPadding = PaddingValues(
+            top = if (includeControls) 0.dp else 16.dp,
+            bottom = 16.dp,
+        ),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         if (headerContent != null) {
@@ -160,28 +211,13 @@ fun FriendActivityTimelineContent(
                 headerContent()
             }
         }
-        item(key = "activity-filters") {
-            LazyRow(
-                modifier = Modifier.fillMaxWidth(),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                items(FriendActivityTimelineFilter.entries, key = { it.name }) { option ->
-                    FilterChip(
-                        selected = option == filter,
-                        onClick = { onFilterSelected(option) },
-                        label = { Text(option.label()) },
-                    )
-                }
+        if (includeControls) {
+            item(key = "activity-filters") {
+                ActivityTimelineFilters(filter, onFilterSelected)
             }
-        }
-        item(key = "activity-observed-hint") {
-            Text(
-                text = strings.friendActivityObservedHint,
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            item(key = "activity-observed-hint") {
+                ActivityTimelineObservedHint()
+            }
         }
 
         when (state) {
@@ -261,6 +297,36 @@ fun FriendActivityTimelineContent(
             }
         }
     }
+}
+
+@Composable
+private fun ActivityTimelineFilters(
+    filter: FriendActivityTimelineFilter,
+    onFilterSelected: (FriendActivityTimelineFilter) -> Unit,
+) {
+    LazyRow(
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        items(FriendActivityTimelineFilter.entries, key = { it.name }) { option ->
+            FilterChip(
+                selected = option == filter,
+                onClick = { onFilterSelected(option) },
+                label = { Text(option.label()) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActivityTimelineObservedHint() {
+    Text(
+        text = strings.friendActivityObservedHint,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/presentation/screens/activity/FriendActivityTimelineScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/activity/FriendActivityTimelineScreen.kt
@@ -129,73 +129,17 @@ fun FriendActivityTimelineContent(
     onWorldClick: (FriendActivityEvent) -> Unit,
     modifier: Modifier = Modifier,
     listState: LazyListState = rememberLazyListState(),
+    headerContent: (@Composable () -> Unit)? = null,
 ) {
-    Column(modifier = modifier.fillMaxSize()) {
-        LazyRow(
-            modifier = Modifier.fillMaxWidth(),
-            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            items(FriendActivityTimelineFilter.entries, key = { it.name }) { option ->
-                FilterChip(
-                    selected = option == filter,
-                    onClick = { onFilterSelected(option) },
-                    label = { Text(option.label()) },
-                )
-            }
-        }
-
-        Text(
-            text = strings.friendActivityObservedHint,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-
-        when (state) {
-            FriendActivityTimelineState.Loading -> TimelineMessage {
-                CircularProgressIndicator()
-            }
-            FriendActivityTimelineState.Error -> TimelineMessage {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(strings.friendActivityTimelineError)
-                    TextButton(onClick = onRetry) { Text(strings.retry) }
-                }
-            }
-            is FriendActivityTimelineState.Content -> if (state.events.isEmpty()) {
-                TimelineMessage { Text(strings.friendActivityTimelineEmpty) }
-            } else {
-                ActivityTimelineList(
-                    state = state,
-                    listState = listState,
-                    onUserClick = onUserClick,
-                    onWorldClick = onWorldClick,
-                    onLoadMore = onLoadMore,
-                    onRetryLoadMore = onRetryLoadMore,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun TimelineMessage(content: @Composable () -> Unit) {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { content() }
-}
-
-@Composable
-private fun ActivityTimelineList(
-    state: FriendActivityTimelineState.Content,
-    listState: LazyListState,
-    onUserClick: (FriendActivityEvent) -> Unit,
-    onWorldClick: (FriendActivityEvent) -> Unit,
-    onLoadMore: () -> Unit,
-    onRetryLoadMore: () -> Unit,
-) {
-    val events = state.events
-    val groups = events.groupBy(FriendActivityEvent::activityDate)
-    LaunchedEffect(listState, state.hasMore, state.isLoadingMore, state.loadMoreError) {
-        if (!state.hasMore || state.isLoadingMore || state.loadMoreError) return@LaunchedEffect
+    val contentState = state as? FriendActivityTimelineState.Content
+    LaunchedEffect(
+        listState,
+        contentState?.hasMore,
+        contentState?.isLoadingMore,
+        contentState?.loadMoreError,
+    ) {
+        val content = contentState ?: return@LaunchedEffect
+        if (!content.hasMore || content.isLoadingMore || content.loadMoreError) return@LaunchedEffect
         snapshotFlow {
             val layoutInfo = listState.layoutInfo
             val lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1
@@ -204,55 +148,132 @@ private fun ActivityTimelineList(
         }.filter { it }.first()
         onLoadMore()
     }
+
     LazyColumn(
-        modifier = Modifier.fillMaxSize().navigationBarsPadding(),
+        modifier = modifier.fillMaxSize().navigationBarsPadding(),
         state = listState,
-        contentPadding = PaddingValues(16.dp),
+        contentPadding = PaddingValues(bottom = 16.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        groups.forEach { (date, dateEvents) ->
-            item(key = "date:$date") {
-                Text(
-                    text = date,
-                    modifier = Modifier.padding(top = 8.dp, bottom = 2.dp),
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-            }
-            itemsIndexed(dateEvents, key = { _, event -> event.id }) { _, event ->
-                FriendTimelineEvent(
-                    event = event,
-                    onUserClick = { onUserClick(event) },
-                    onWorldClick = if (event.navigableWorldId() != null) {
-                        { onWorldClick(event) }
-                    } else {
-                        null
-                    },
-                )
+        if (headerContent != null) {
+            item(key = "activity-header") {
+                headerContent()
             }
         }
-        if (state.isLoadingMore) {
-            item(key = "activity-load-more") {
-                Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
-                    CircularProgressIndicator(Modifier.size(24.dp), strokeWidth = 2.dp)
-                }
-            }
-        } else if (state.loadMoreError) {
-            item(key = "activity-load-more-error") {
-                Row(
-                    Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Text(
-                        strings.friendActivityLoadMoreError,
-                        Modifier.weight(1f),
-                        color = MaterialTheme.colorScheme.error,
-                        style = MaterialTheme.typography.bodySmall,
+        item(key = "activity-filters") {
+            LazyRow(
+                modifier = Modifier.fillMaxWidth(),
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(FriendActivityTimelineFilter.entries, key = { it.name }) { option ->
+                    FilterChip(
+                        selected = option == filter,
+                        onClick = { onFilterSelected(option) },
+                        label = { Text(option.label()) },
                     )
-                    TextButton(onClick = onRetryLoadMore) { Text(strings.retry) }
                 }
             }
+        }
+        item(key = "activity-observed-hint") {
+            Text(
+                text = strings.friendActivityObservedHint,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        when (state) {
+            FriendActivityTimelineState.Loading -> item(key = "activity-loading") {
+                TimelineMessage(Modifier.fillParentMaxHeight()) {
+                    CircularProgressIndicator()
+                }
+            }
+            FriendActivityTimelineState.Error -> item(key = "activity-error") {
+                TimelineMessage(Modifier.fillParentMaxHeight()) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(strings.friendActivityTimelineError)
+                        TextButton(onClick = onRetry) { Text(strings.retry) }
+                    }
+                }
+            }
+            is FriendActivityTimelineState.Content -> if (state.events.isEmpty()) {
+                item(key = "activity-empty") {
+                    TimelineMessage(Modifier.fillParentMaxHeight()) {
+                        Text(strings.friendActivityTimelineEmpty)
+                    }
+                }
+            } else {
+                state.events.groupBy(FriendActivityEvent::activityDate).forEach { (date, dateEvents) ->
+                    item(key = "date:$date") {
+                        Text(
+                            text = date,
+                            modifier = Modifier.padding(
+                                start = 16.dp,
+                                top = 8.dp,
+                                end = 16.dp,
+                                bottom = 2.dp,
+                            ),
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                    itemsIndexed(dateEvents, key = { _, event -> event.id }) { _, event ->
+                        FriendTimelineEvent(
+                            event = event,
+                            onUserClick = { onUserClick(event) },
+                            onWorldClick = if (event.navigableWorldId() != null) {
+                                { onWorldClick(event) }
+                            } else {
+                                null
+                            },
+                            modifier = Modifier.padding(horizontal = 16.dp),
+                        )
+                    }
+                }
+                if (state.isLoadingMore) {
+                    item(key = "activity-load-more") {
+                        Box(
+                            Modifier.fillMaxWidth().padding(16.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            CircularProgressIndicator(Modifier.size(24.dp), strokeWidth = 2.dp)
+                        }
+                    }
+                } else if (state.loadMoreError) {
+                    item(key = "activity-load-more-error") {
+                        Row(
+                            Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Text(
+                                strings.friendActivityLoadMoreError,
+                                Modifier.weight(1f),
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                            TextButton(onClick = onRetryLoadMore) { Text(strings.retry) }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimelineMessage(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(Modifier.padding(24.dp), contentAlignment = Alignment.Center) {
+            content()
         }
     }
 }
@@ -262,9 +283,10 @@ private fun FriendTimelineEvent(
     event: FriendActivityEvent,
     onUserClick: () -> Unit,
     onWorldClick: (() -> Unit)?,
+    modifier: Modifier = Modifier,
 ) {
     Surface(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.medium,
         color = MaterialTheme.colorScheme.surfaceContainerLowest,
     ) {

--- a/composeApp/src/commonMain/kotlin/presentation/screens/favorites/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/favorites/FavoritesScreen.kt
@@ -61,7 +61,8 @@ private fun FavoritesScreenContent(
     val avatarOptions by favoritesModel.avatarGroupOptions.collectAsState()
     val worldTotal by favoritesModel.worldTotal.collectAsState()
     val avatarTotal by favoritesModel.avatarTotal.collectAsState()
-    val modelTabIndex = pagerState.currentPage + 1
+    val settledPage = pagerState.settledPage
+    val modelTabIndex = settledPage + 1
 
     SideEffect {
         favoritesModel.updateFavoriteLocale(favoriteLocale)
@@ -70,7 +71,7 @@ private fun FavoritesScreenContent(
         favoritesModel.activateFavoritesPage()
     }
     LaunchedEffect(pagerState, favoritesModel) {
-        snapshotFlow { pagerState.currentPage }
+        snapshotFlow { pagerState.settledPage }
             .distinctUntilChanged()
             .collect { page -> favoritesModel.syncSelectedTabIndex(page + 1) }
     }
@@ -129,7 +130,7 @@ private fun FavoritesScreenContent(
                 value = searchText,
                 onValueChange = favoritesModel::setSearchText,
             )
-            when (pagerState.currentPage) {
+            when (settledPage) {
                 0 -> GroupOptionsUI(worldOptions, FavoriteType.World, worldGroups, worldTotal, strings.friendListPagerAllWorlds, favoritesModel::updateWorldGroupOptions, { it.selectedGroup }, { o, g -> o.copy(selectedGroup = g) })
                 1 -> GroupOptionsUI(avatarOptions, FavoriteType.Avatar, avatarGroups, avatarTotal, strings.friendListPagerAllAvatars, favoritesModel::updateAvatarGroupOptions, { it.selectedGroup }, { o, g -> o.copy(selectedGroup = g) })
             }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/favorites/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/favorites/FavoritesScreen.kt
@@ -3,9 +3,10 @@ package io.github.vrcmteam.vrcm.presentation.screens.favorites
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
@@ -24,6 +25,9 @@ import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
 import io.github.vrcmteam.vrcm.presentation.navigation.AppRoute
 import kotlinx.serialization.Serializable
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
 
 @Serializable
@@ -41,11 +45,13 @@ private fun FavoritesScreenContent(
 ) {
     val navigator = currentNavigator
     val favoriteLocale = strings
-    var selectedTab by rememberSaveable { mutableIntStateOf(0) }
+    val pagerState = rememberPagerState(pageCount = { 2 })
+    val coroutineScope = rememberCoroutineScope()
     val searchText by favoritesModel.searchText.collectAsState()
     val refreshingTabs by favoritesModel.refreshingTabs.collectAsState()
     val refreshErrors by favoritesModel.refreshErrors.collectAsState()
-    val listStates = List(2) { rememberLazyListState() }
+    val worldListState = rememberLazyListState()
+    val avatarListState = rememberLazyListState()
 
     val worlds by favoritesModel.worldList.collectAsState()
     val avatars by favoritesModel.avatarList.collectAsState()
@@ -55,7 +61,7 @@ private fun FavoritesScreenContent(
     val avatarOptions by favoritesModel.avatarGroupOptions.collectAsState()
     val worldTotal by favoritesModel.worldTotal.collectAsState()
     val avatarTotal by favoritesModel.avatarTotal.collectAsState()
-    val modelTabIndex = selectedTab + 1
+    val modelTabIndex = pagerState.currentPage + 1
 
     SideEffect {
         favoritesModel.updateFavoriteLocale(favoriteLocale)
@@ -63,8 +69,21 @@ private fun FavoritesScreenContent(
     LaunchedEffect(Unit) {
         favoritesModel.activateFavoritesPage()
     }
-    LaunchedEffect(selectedTab) {
-        favoritesModel.syncSelectedTabIndex(modelTabIndex)
+    LaunchedEffect(pagerState, favoritesModel) {
+        snapshotFlow { pagerState.currentPage }
+            .distinctUntilChanged()
+            .collect { page -> favoritesModel.syncSelectedTabIndex(page + 1) }
+    }
+    LaunchedEffect(pagerState, favoritesModel) {
+        snapshotFlow { pagerState.settledPage }
+            .distinctUntilChanged()
+            .drop(1)
+            .collect { page ->
+                favoritesModel.refreshCurrentTabCacheData(
+                    showRefreshing = false,
+                    tabIndex = page + 1,
+                )
+            }
     }
 
     Scaffold(
@@ -87,13 +106,12 @@ private fun FavoritesScreenContent(
     ) { padding ->
         Column(Modifier.fillMaxSize().padding(padding)) {
             val tabs = listOf(strings.worlds, strings.avatars)
-            PrimaryTabRow(selectedTabIndex = selectedTab) {
+            PrimaryTabRow(selectedTabIndex = pagerState.currentPage) {
                 tabs.forEachIndexed { index, title ->
                     Tab(
-                        selected = selectedTab == index,
+                        selected = pagerState.currentPage == index,
                         onClick = {
-                            selectedTab = index
-                            favoritesModel.setSelectedTabIndex(index + 1)
+                            coroutineScope.launch { pagerState.animateScrollToTab(index) }
                         },
                         text = {
                             Text(
@@ -111,36 +129,60 @@ private fun FavoritesScreenContent(
                 value = searchText,
                 onValueChange = favoritesModel::setSearchText,
             )
-            when (selectedTab) {
+            when (pagerState.currentPage) {
                 0 -> GroupOptionsUI(worldOptions, FavoriteType.World, worldGroups, worldTotal, strings.friendListPagerAllWorlds, favoritesModel::updateWorldGroupOptions, { it.selectedGroup }, { o, g -> o.copy(selectedGroup = g) })
                 1 -> GroupOptionsUI(avatarOptions, FavoriteType.Avatar, avatarGroups, avatarTotal, strings.friendListPagerAllAvatars, favoritesModel::updateAvatarGroupOptions, { it.selectedGroup }, { o, g -> o.copy(selectedGroup = g) })
             }
             val loading = modelTabIndex in refreshingTabs
-            val error = refreshErrors[modelTabIndex]
-            if (loading) LinearProgressIndicator(Modifier.fillMaxWidth())
-            Box(Modifier.fillMaxSize()) {
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    state = listStates[selectedTab],
-                    contentPadding = PaddingValues(bottom = 24.dp),
-                    verticalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    when (selectedTab) {
-                        0 -> renderWorldItems(worlds) { world, suffix -> if (!world.isHiddenWorld()) navigator push WorldProfileScreen(WorldProfileVo(world), suffix, world.safeImageUrl().orEmpty()) }
-                        1 -> renderAvatarItems(avatars) { avatar, suffix -> if (avatar.releaseStatus != "hidden") navigator push AvatarProfileScreen(AvatarProfileVo(avatar), suffix) }
+            Box(Modifier.fillMaxWidth().height(4.dp)) {
+                if (loading) LinearProgressIndicator(Modifier.fillMaxWidth())
+            }
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.weight(1f),
+                key = { if (it == 0) "favorites-worlds" else "favorites-avatars" },
+            ) { page ->
+                val pageModelTabIndex = page + 1
+                val pageLoading = pageModelTabIndex in refreshingTabs
+                val pageError = refreshErrors[pageModelTabIndex]
+                val pageItemsEmpty = if (page == 0) worlds.isEmpty() else avatars.isEmpty()
+                Box(Modifier.fillMaxSize()) {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        state = if (page == 0) worldListState else avatarListState,
+                        contentPadding = PaddingValues(bottom = 24.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        when (page) {
+                            0 -> renderWorldItems(worlds) { world, suffix ->
+                                if (!world.isHiddenWorld()) {
+                                    navigator push WorldProfileScreen(
+                                        WorldProfileVo(world),
+                                        suffix,
+                                        world.safeImageUrl().orEmpty(),
+                                    )
+                                }
+                            }
+                            1 -> renderAvatarItems(avatars) { avatar, suffix ->
+                                if (avatar.releaseStatus != "hidden") {
+                                    navigator push AvatarProfileScreen(AvatarProfileVo(avatar), suffix)
+                                }
+                            }
+                        }
                     }
-                }
-                val empty = when (selectedTab) {
-                    0 -> worlds.isEmpty()
-                    else -> avatars.isEmpty()
-                }
-                if (loading && empty) CircularProgressIndicator(Modifier.align(Alignment.Center))
-                else if (error != null && empty) StateMessage(strings.favoritesLoadFailed, strings.retry) {
-                    favoritesModel.refreshCurrentTabCacheData(tabIndex = modelTabIndex)
-                }
-                else if (empty) StateMessage(strings.favoritesEmpty, null, null)
-                else if (error != null) ErrorBanner(strings.favoritesLoadFailed) {
-                    favoritesModel.refreshCurrentTabCacheData(tabIndex = modelTabIndex)
+                    if (pageLoading && pageItemsEmpty) {
+                        CircularProgressIndicator(Modifier.align(Alignment.Center))
+                    } else if (pageError != null && pageItemsEmpty) {
+                        StateMessage(strings.favoritesLoadFailed, strings.retry) {
+                            favoritesModel.refreshCurrentTabCacheData(tabIndex = pageModelTabIndex)
+                        }
+                    } else if (pageItemsEmpty) {
+                        StateMessage(strings.favoritesEmpty, null, null)
+                    } else if (pageError != null) {
+                        ErrorBanner(strings.favoritesLoadFailed) {
+                            favoritesModel.refreshCurrentTabCacheData(tabIndex = pageModelTabIndex)
+                        }
+                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/GalleryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/GalleryScreen.kt
@@ -1,7 +1,5 @@
 package io.github.vrcmteam.vrcm.presentation.screens.gallery
 
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.Box
@@ -26,6 +24,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.vrcmteam.vrcm.presentation.navigation.AppRoute
+import io.github.vrcmteam.vrcm.presentation.compoments.animateScrollToTab
 import org.koin.compose.viewmodel.koinViewModel
 import io.github.vrcmteam.vrcm.presentation.navigation.LocalNavigator
 import io.github.vrcmteam.vrcm.presentation.navigation.currentOrThrow
@@ -121,13 +120,7 @@ object GalleryScreen : AppRoute {
                             selected = pagerState.currentPage == index,
                             onClick = {
                                 coroutineScope.launch {
-                                    pagerState.animateScrollToPage(
-                                        index,
-                                        animationSpec = spring(
-                                            dampingRatio = Spring.DampingRatioLowBouncy,
-                                            stiffness = Spring.StiffnessLow
-                                        )
-                                    )
+                                    pagerState.animateScrollToTab(index)
                                 }
                             },
                             text = {

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
@@ -235,8 +235,8 @@ private fun HomeDestinationContent(
     }
     LaunchedEffect(timelineListState) {
         SharedFlowCentre.toPagerTop.collect {
-            if (pagerState.currentPage == HomeTab.Activity.ordinal) {
-                runCatching { timelineListState.animateScrollToItem(0) }
+            if (pagerState.settledPage == HomeTab.Activity.ordinal) {
+                launch { timelineListState.animateScrollToItem(0) }
             }
         }
     }
@@ -258,7 +258,7 @@ private fun HomeDestinationContent(
                     CompositionLocalProvider(LocalSharedSuffixKey provides FriendLocationPager.title) {
                         FriendLocationPager.Content(
                             headerContent = tabRow,
-                            isActive = { pagerState.currentPage == HomeTab.Location.ordinal },
+                            isActive = { pagerState.settledPage == HomeTab.Location.ordinal },
                         )
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
@@ -220,6 +220,7 @@ private fun HomeDestinationContent(
     hasBottomNavigation: Boolean,
 ) {
     val timelineListState = rememberLazyListState()
+    val stateHolder = rememberSaveableStateHolder()
     val navigator = currentNavigator
     val scope = rememberCoroutineScope()
     val pagerState = rememberPagerState(
@@ -245,51 +246,53 @@ private fun HomeDestinationContent(
         modifier = Modifier.fillMaxSize(),
         key = { HomeTab.entries[it].name },
     ) { page ->
-        val tabRow: @Composable () -> Unit = {
-            HomeTabRow(
-                pagerState = pagerState,
-                onReselect = { scope.launch { SharedFlowCentre.toPagerTop.emit(Unit) } },
-            )
-        }
-        when (HomeTab.entries[page]) {
-            HomeTab.Location -> Box(Modifier.fillMaxSize()) {
-                CompositionLocalProvider(LocalSharedSuffixKey provides FriendLocationPager.title) {
-                    FriendLocationPager.Content(
-                        headerContent = tabRow,
-                        isActive = { pagerState.currentPage == HomeTab.Location.ordinal },
-                    )
-                }
+        stateHolder.SaveableStateProvider(HomeTab.entries[page].name) {
+            val tabRow: @Composable () -> Unit = {
+                HomeTabRow(
+                    pagerState = pagerState,
+                    onReselect = { scope.launch { SharedFlowCentre.toPagerTop.emit(Unit) } },
+                )
             }
-            HomeTab.Activity -> FriendActivityTimelineContent(
-                state = timelineState,
-                filter = timelineFilter,
-                onFilterSelected = timelineModel::selectFilter,
-                onLoadMore = timelineModel::loadMore,
-                onRetry = timelineModel::retry,
-                onRetryLoadMore = timelineModel::retryLoadMore,
-                onUserClick = { event ->
-                    navigator push UserProfileScreen(
-                        UserProfileVo(
-                            id = event.friendUserId,
-                            displayName = event.displayName,
-                            profileImageUrl = event.profileImageUrl,
+            when (HomeTab.entries[page]) {
+                HomeTab.Location -> Box(Modifier.fillMaxSize()) {
+                    CompositionLocalProvider(LocalSharedSuffixKey provides FriendLocationPager.title) {
+                        FriendLocationPager.Content(
+                            headerContent = tabRow,
+                            isActive = { pagerState.currentPage == HomeTab.Location.ordinal },
                         )
-                    )
-                },
-                onWorldClick = { event ->
-                    val worldId = event.navigableWorldId() ?: return@FriendActivityTimelineContent
-                    navigator push WorldProfileScreen(
-                        WorldProfileVo(worldId = worldId, worldName = event.worldName.orEmpty())
-                    )
-                },
-                listState = timelineListState,
-                headerContent = tabRow,
-                modifier = Modifier
-                    .windowInsetsPadding(
-                        WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom),
-                    )
-                    .padding(bottom = if (hasBottomNavigation) 80.dp else 0.dp),
-            )
+                    }
+                }
+                HomeTab.Activity -> FriendActivityTimelineContent(
+                    state = timelineState,
+                    filter = timelineFilter,
+                    onFilterSelected = timelineModel::selectFilter,
+                    onLoadMore = timelineModel::loadMore,
+                    onRetry = timelineModel::retry,
+                    onRetryLoadMore = timelineModel::retryLoadMore,
+                    onUserClick = { event ->
+                        navigator push UserProfileScreen(
+                            UserProfileVo(
+                                id = event.friendUserId,
+                                displayName = event.displayName,
+                                profileImageUrl = event.profileImageUrl,
+                            )
+                        )
+                    },
+                    onWorldClick = { event ->
+                        val worldId = event.navigableWorldId() ?: return@FriendActivityTimelineContent
+                        navigator push WorldProfileScreen(
+                            WorldProfileVo(worldId = worldId, worldName = event.worldName.orEmpty())
+                        )
+                    },
+                    listState = timelineListState,
+                    headerContent = tabRow,
+                    modifier = Modifier
+                        .windowInsetsPadding(
+                            WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom),
+                        )
+                        .padding(bottom = if (hasBottomNavigation) 80.dp else 0.dp),
+                )
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
@@ -5,6 +5,9 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -216,78 +219,106 @@ private fun HomeDestinationContent(
     timelineFilter: FriendActivityTimelineFilter,
     hasBottomNavigation: Boolean,
 ) {
-    val selectedTab = HomeTab.entries[model.selectedHomeTabIndex]
-    val stateHolder = rememberSaveableStateHolder()
     val timelineListState = rememberLazyListState()
     val navigator = currentNavigator
     val scope = rememberCoroutineScope()
+    val pagerState = rememberPagerState(
+        initialPage = model.selectedHomeTabIndex,
+        pageCount = { HomeTab.entries.size },
+    )
 
-    if (selectedTab == HomeTab.Activity) {
-        LaunchedEffect(timelineListState) {
-            SharedFlowCentre.toPagerTop.collect {
+    LaunchedEffect(pagerState, model) {
+        snapshotFlow { pagerState.settledPage }
+            .distinctUntilChanged()
+            .collect { page -> model.selectHomeTab(HomeTab.entries[page]) }
+    }
+    LaunchedEffect(timelineListState) {
+        SharedFlowCentre.toPagerTop.collect {
+            if (pagerState.currentPage == HomeTab.Activity.ordinal) {
                 runCatching { timelineListState.animateScrollToItem(0) }
             }
         }
     }
 
-    Column(Modifier.fillMaxSize()) {
-        PrimaryTabRow(selectedTabIndex = selectedTab.ordinal) {
-            HomeTab.entries.forEach { tab ->
-                Tab(
-                    selected = tab == selectedTab,
-                    onClick = {
-                        if (tab == selectedTab) scope.launch { SharedFlowCentre.toPagerTop.emit(Unit) }
-                        else model.selectHomeTab(tab)
-                    },
-                    text = {
-                        Text(
-                            if (tab == HomeTab.Location) strings.homeTabLocation else strings.homeTabActivity,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    },
-                )
-            }
+    HorizontalPager(
+        state = pagerState,
+        modifier = Modifier.fillMaxSize(),
+        key = { HomeTab.entries[it].name },
+    ) { page ->
+        val tabRow: @Composable () -> Unit = {
+            HomeTabRow(
+                pagerState = pagerState,
+                onReselect = { scope.launch { SharedFlowCentre.toPagerTop.emit(Unit) } },
+            )
         }
-        Box(Modifier.weight(1f)) {
-            stateHolder.SaveableStateProvider(selectedTab.name) {
-                when (selectedTab) {
-                    HomeTab.Location -> Box(Modifier.fillMaxSize()) {
-                        CompositionLocalProvider(LocalSharedSuffixKey provides FriendLocationPager.title) {
-                            FriendLocationPager.Content()
-                        }
-                    }
-                    HomeTab.Activity -> FriendActivityTimelineContent(
-                        state = timelineState,
-                        filter = timelineFilter,
-                        onFilterSelected = timelineModel::selectFilter,
-                        onLoadMore = timelineModel::loadMore,
-                        onRetry = timelineModel::retry,
-                        onRetryLoadMore = timelineModel::retryLoadMore,
-                        onUserClick = { event ->
-                            navigator push UserProfileScreen(
-                                UserProfileVo(
-                                    id = event.friendUserId,
-                                    displayName = event.displayName,
-                                    profileImageUrl = event.profileImageUrl,
-                                )
-                            )
-                        },
-                        onWorldClick = { event ->
-                            val worldId = event.navigableWorldId() ?: return@FriendActivityTimelineContent
-                            navigator push WorldProfileScreen(
-                                WorldProfileVo(worldId = worldId, worldName = event.worldName.orEmpty())
-                            )
-                        },
-                        listState = timelineListState,
-                        modifier = Modifier
-                            .windowInsetsPadding(
-                                WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom),
-                            )
-                            .padding(bottom = if (hasBottomNavigation) 80.dp else 0.dp),
+        when (HomeTab.entries[page]) {
+            HomeTab.Location -> Box(Modifier.fillMaxSize()) {
+                CompositionLocalProvider(LocalSharedSuffixKey provides FriendLocationPager.title) {
+                    FriendLocationPager.Content(
+                        headerContent = tabRow,
+                        isActive = { pagerState.currentPage == HomeTab.Location.ordinal },
                     )
                 }
             }
+            HomeTab.Activity -> FriendActivityTimelineContent(
+                state = timelineState,
+                filter = timelineFilter,
+                onFilterSelected = timelineModel::selectFilter,
+                onLoadMore = timelineModel::loadMore,
+                onRetry = timelineModel::retry,
+                onRetryLoadMore = timelineModel::retryLoadMore,
+                onUserClick = { event ->
+                    navigator push UserProfileScreen(
+                        UserProfileVo(
+                            id = event.friendUserId,
+                            displayName = event.displayName,
+                            profileImageUrl = event.profileImageUrl,
+                        )
+                    )
+                },
+                onWorldClick = { event ->
+                    val worldId = event.navigableWorldId() ?: return@FriendActivityTimelineContent
+                    navigator push WorldProfileScreen(
+                        WorldProfileVo(worldId = worldId, worldName = event.worldName.orEmpty())
+                    )
+                },
+                listState = timelineListState,
+                headerContent = tabRow,
+                modifier = Modifier
+                    .windowInsetsPadding(
+                        WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom),
+                    )
+                    .padding(bottom = if (hasBottomNavigation) 80.dp else 0.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun HomeTabRow(
+    pagerState: PagerState,
+    onReselect: () -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    PrimaryTabRow(selectedTabIndex = pagerState.currentPage) {
+        HomeTab.entries.forEachIndexed { index, tab ->
+            Tab(
+                selected = index == pagerState.currentPage,
+                onClick = {
+                    if (index == pagerState.currentPage && !pagerState.isScrollInProgress) {
+                        onReselect()
+                    } else {
+                        scope.launch { pagerState.animateScrollToTab(index) }
+                    }
+                },
+                text = {
+                    Text(
+                        if (tab == HomeTab.Location) strings.homeTabLocation else strings.homeTabActivity,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                },
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
@@ -266,6 +266,17 @@ class FriendListPagerModel(
         val sessionToken = activeSessionToken ?: return null
         val generation = accountGeneration
         val tabIndex = favoriteType.tabIndex
+        refreshJobsByTab[tabIndex]?.takeIf { it.isActive }?.let { activeJob ->
+            if (showRefreshing) {
+                _refreshingTabs.update { tabs -> tabs + tabIndex }
+                activeJob.invokeOnCompletion {
+                    if (acceptsAccount(sessionToken, generation)) {
+                        _refreshingTabs.update { tabs -> tabs - tabIndex }
+                    }
+                }
+            }
+            return activeJob
+        }
         refreshJobsByTab.remove(tabIndex)?.cancel()
         return viewModelScope.launch(Dispatchers.IO) {
             try {

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendLocationPager.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendLocationPager.kt
@@ -32,6 +32,7 @@ import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
 import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
 import io.github.vrcmteam.vrcm.presentation.supports.Pager
+import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
 
@@ -77,10 +78,8 @@ object FriendLocationPager : Pager {
         }
         LaunchedEffect(Unit) {
             SharedFlowCentre.toPagerTop.collect {
-                // 防止滑动时手动阻止滑动动画导致任务取消,监听失效的bug
-                if (currentIsActive()) kotlin.runCatching {
-                    lazyListState.animateScrollToFirst()
-                }
+                // 子任务承接手势取消，避免终止长期 Flow 监听。
+                if (currentIsActive()) launch { lazyListState.animateScrollToFirst() }
             }
         }
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendLocationPager.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendLocationPager.kt
@@ -49,7 +49,26 @@ object FriendLocationPager : Pager {
     @ExperimentalSharedTransitionApi
     @Composable
     override fun Content() {
+        ContentInternal(headerContent = null, isActive = { true })
+    }
+
+    @ExperimentalSharedTransitionApi
+    @Composable
+    fun Content(
+        headerContent: @Composable () -> Unit,
+        isActive: () -> Boolean,
+    ) {
+        ContentInternal(headerContent = headerContent, isActive = isActive)
+    }
+
+    @ExperimentalSharedTransitionApi
+    @Composable
+    private fun ContentInternal(
+        headerContent: (@Composable () -> Unit)?,
+        isActive: () -> Boolean,
+    ) {
         val friendLocationPagerModel: FriendLocationPagerModel = koinInject()
+        val currentIsActive by rememberUpdatedState(isActive)
         // 控制只有第一次跳转到当前页面时自动刷新
         val lazyListState = rememberLazyListState()
         LaunchedEffect(Unit) {
@@ -59,7 +78,7 @@ object FriendLocationPager : Pager {
         LaunchedEffect(Unit) {
             SharedFlowCentre.toPagerTop.collect {
                 // 防止滑动时手动阻止滑动动画导致任务取消,监听失效的bug
-                kotlin.runCatching {
+                if (currentIsActive()) kotlin.runCatching {
                     lazyListState.animateScrollToFirst()
                 }
             }
@@ -71,6 +90,7 @@ object FriendLocationPager : Pager {
             isRefreshing = friendLocationPagerModel.isRefreshing,
             lazyListState = lazyListState,
             doRefresh = friendLocationPagerModel::refreshFriendLocation,
+            headerContent = headerContent,
         )
 
     }
@@ -87,6 +107,7 @@ fun Pager.FriendLocationPager(
     isRefreshing: Boolean,
     lazyListState: LazyListState = rememberLazyListState(),
     doRefresh: suspend () -> Unit,
+    headerContent: (@Composable () -> Unit)? = null,
 ) {
     val navigator = currentNavigator
     // 只会有一个实例被打开
@@ -114,7 +135,7 @@ fun Pager.FriendLocationPager(
             sharedImageCacheKey = currentLocation.worldImageUrl,
         )
     }
-    val topPadding = 12.dp
+    val topPadding = if (headerContent == null) 12.dp else 0.dp
     val onClickUserIcon = { user: FriendData, sharedSuffixKey: String ->
         navigator push UserProfileScreen(
             userProfileVO = UserProfileVo(user),
@@ -146,6 +167,12 @@ fun Pager.FriendLocationPager(
                 bottom = bottomPadding
             )
         ) {
+
+            if (headerContent != null) {
+                item(key = "friend-location-header") {
+                    headerContent()
+                }
+            }
 
             if (!instanceFriendLocations.isNullOrEmpty()) {
                 item(key = LocationType.Instance) {

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/SearchListPager.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/SearchListPager.kt
@@ -3,19 +3,29 @@ package io.github.vrcmteam.vrcm.presentation.screens.home.pager
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -26,20 +36,28 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.presentation.compoments.AdvancedOptionsPanel
-import io.github.vrcmteam.vrcm.presentation.compoments.GenericSearchList
+import io.github.vrcmteam.vrcm.presentation.compoments.SearchTextField
+import io.github.vrcmteam.vrcm.presentation.compoments.animateScrollToTab
 import io.github.vrcmteam.vrcm.presentation.compoments.renderGroupItems
 import io.github.vrcmteam.vrcm.presentation.compoments.renderUserItems
 import io.github.vrcmteam.vrcm.presentation.compoments.renderWorldItems
 import io.github.vrcmteam.vrcm.presentation.compoments.safeImageUrl
+import io.github.vrcmteam.vrcm.presentation.compoments.shouldLoadNextPage
 import io.github.vrcmteam.vrcm.presentation.adaptive.AppWindowWidthClass
 import io.github.vrcmteam.vrcm.presentation.adaptive.LocalAppWindowWidthClass
+import io.github.vrcmteam.vrcm.presentation.extensions.animateScrollToFirst
 import io.github.vrcmteam.vrcm.presentation.extensions.currentNavigator
+import io.github.vrcmteam.vrcm.presentation.extensions.getInsetPadding
 import io.github.vrcmteam.vrcm.presentation.screens.group.GroupProfileScreen
 import io.github.vrcmteam.vrcm.presentation.screens.group.data.GroupProfileVo
 import io.github.vrcmteam.vrcm.presentation.screens.home.compoments.WorldSearchOptionsUI
@@ -51,6 +69,7 @@ import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
 import io.github.vrcmteam.vrcm.presentation.supports.Pager
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.distinctUntilChanged
 import org.koin.compose.viewmodel.koinViewModel
 
 object SearchListPager : Pager {
@@ -77,6 +96,7 @@ fun PublicSearchContent(
     val navigator = currentNavigator
     val searchType by model.searchType.collectAsState()
     val searchText by model.searchText.collectAsState()
+    val queriesByType by model.queriesByType.collectAsState()
     val loadStates by model.loadStates.collectAsState()
     val users by model.userSearchList.collectAsState()
     val worlds by model.worldSearchList.collectAsState()
@@ -86,12 +106,6 @@ fun PublicSearchContent(
     val isLoadingGroups by model.isLoadingGroups.collectAsState()
     val groupLoadMoreFailed by model.groupLoadMoreFailed.collectAsState()
     val selectedTab = PublicSearchTab.fromSearchType(searchType)
-    val selectedResultsCount = when (selectedTab) {
-        PublicSearchTab.User -> users.size
-        PublicSearchTab.World -> worlds.size
-        PublicSearchTab.Group -> groups.size
-    }
-    val loadState = loadStates.getValue(searchType)
     val promptText = strings.publicSearchPrompt
     val noResultsText = strings.publicSearchNoResults
     val failedText = strings.publicSearchFailed
@@ -100,104 +114,232 @@ fun PublicSearchContent(
     val userListState = rememberLazyListState()
     val worldListState = rememberLazyListState()
     val groupListState = rememberLazyListState()
-    val selectedListState = when (selectedTab) {
-        PublicSearchTab.User -> userListState
-        PublicSearchTab.World -> worldListState
-        PublicSearchTab.Group -> groupListState
-    }
+    val pagerState = rememberPagerState(
+        initialPage = selectedTab.tabIndex,
+        pageCount = { PublicSearchTab.entries.size },
+    )
     var showAdvancedOptions by remember { mutableStateOf(false) }
     val bottomNavigationPadding = if (
         LocalAppWindowWidthClass.current == AppWindowWidthClass.Compact
     ) 80.dp else 0.dp
 
+    LaunchedEffect(pagerState, model) {
+        snapshotFlow { pagerState.currentPage }
+            .distinctUntilChanged()
+            .collect { page ->
+                model.setSearchType(PublicSearchTab.fromTabIndex(page).searchType)
+            }
+    }
     LaunchedEffect(searchType, searchText) {
         model.loadSearchListIfNeeded()
     }
+    LaunchedEffect(pagerState, userListState, worldListState, groupListState) {
+        SharedFlowCentre.toPagerTop.collect {
+            val listState = when (pagerState.currentPage) {
+                PublicSearchTab.World.tabIndex -> worldListState
+                PublicSearchTab.Group.tabIndex -> groupListState
+                else -> userListState
+            }
+            runCatching { listState.animateScrollToFirst() }
+        }
+    }
+    LaunchedEffect(
+        groupListState,
+        groups.size,
+        groupHasMore,
+        isLoadingGroups,
+        groupLoadMoreFailed,
+        searchType,
+    ) {
+        snapshotFlow {
+            groupListState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1
+        }.distinctUntilChanged().collect { lastVisibleIndex ->
+            if (
+                searchType == PublicSearchTab.Group.searchType &&
+                !groupLoadMoreFailed &&
+                shouldEnableGroupLoadMore(
+                    searchType = PublicSearchTab.Group.searchType,
+                    hasMore = groupHasMore,
+                    isLoading = isLoadingGroups,
+                    itemCount = groups.size,
+                ) &&
+                shouldLoadNextPage(lastVisibleIndex, groups.size)
+            ) {
+                model.loadMoreGroups()
+            }
+        }
+    }
 
-    GenericSearchList(
-        key = "PublicSearchContent",
-        searchText = searchText,
-        updateSearchText = model::setSearchText,
-        tabs = listOf(strings.users, strings.worlds, strings.groups),
-        selectedTabIndex = selectedTab.tabIndex,
-        onTabSelected = { model.setSearchType(PublicSearchTab.fromTabIndex(it).searchType) },
-        advancedOptionsContent = {
-            if (selectedTab == PublicSearchTab.World) {
-                AdvancedOptionsPanel(
-                    title = strings.worldSearchAdvancedOptions,
-                    expanded = showAdvancedOptions,
-                    onExpandToggle = { showAdvancedOptions = !showAdvancedOptions },
-                ) {
-                    WorldSearchOptionsUI(
-                        options = worldSearchOptions,
-                        onOptionsChanged = { options ->
-                            coroutineScope.launch { model.updateWorldSearchOptions(options) }
-                        },
-                    )
+    Column(Modifier.fillMaxSize()) {
+        SearchTextField(
+            modifier = Modifier.fillMaxWidth().padding(start = 16.dp, top = 12.dp, end = 16.dp),
+            value = searchText,
+            onValueChange = model::setSearchText,
+        )
+        PublicSearchTabRow(
+            pagerState = pagerState,
+            tabs = listOf(strings.users, strings.worlds, strings.groups),
+        )
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.weight(1f),
+            key = { PublicSearchTab.fromTabIndex(it).name },
+        ) { page ->
+            val tab = PublicSearchTab.fromTabIndex(page)
+            val query = queriesByType.getValue(tab.searchType)
+            val loadState = loadStates.getValue(tab.searchType)
+            val resultCount = when (tab) {
+                PublicSearchTab.User -> users.size
+                PublicSearchTab.World -> worlds.size
+                PublicSearchTab.Group -> groups.size
+            }
+            val listState = when (tab) {
+                PublicSearchTab.User -> userListState
+                PublicSearchTab.World -> worldListState
+                PublicSearchTab.Group -> groupListState
+            }
+            PublicSearchPage(
+                query = query,
+                loadState = loadState,
+                resultCount = resultCount,
+                lazyListState = listState,
+                bottomNavigationPadding = bottomNavigationPadding,
+                promptText = promptText,
+                noResultsText = noResultsText,
+                failedText = failedText,
+                refreshFailedText = refreshFailedText,
+                retryText = retryText,
+                retry = { coroutineScope.launch { model.refreshSearchList(tab.searchType) } },
+                advancedOptionsContent = if (tab == PublicSearchTab.World) {
+                    {
+                        AdvancedOptionsPanel(
+                            title = strings.worldSearchAdvancedOptions,
+                            expanded = showAdvancedOptions,
+                            onExpandToggle = { showAdvancedOptions = !showAdvancedOptions },
+                        ) {
+                            WorldSearchOptionsUI(
+                                options = worldSearchOptions,
+                                onOptionsChanged = { options ->
+                                    coroutineScope.launch { model.updateWorldSearchOptions(options) }
+                                },
+                            )
+                        }
+                    }
+                } else {
+                    null
+                },
+            ) {
+                when (tab) {
+                    PublicSearchTab.User -> renderUserItems(users) { user, suffix ->
+                        coroutineScope.launch {
+                            navigator push UserProfileScreen(
+                                userProfileVO = UserProfileVo(user),
+                                sharedSuffixKey = suffix,
+                            )
+                        }
+                    }
+                    PublicSearchTab.World -> renderWorldItems(worlds) { world, suffix ->
+                        coroutineScope.launch {
+                            navigator push WorldProfileScreen(
+                                worldProfileVO = WorldProfileVo(world),
+                                sharedSuffixKey = suffix,
+                                sharedImageCacheKey = world.safeImageUrl(),
+                            )
+                        }
+                    }
+                    PublicSearchTab.Group -> {
+                        renderGroupItems(groups) { group, suffix ->
+                            coroutineScope.launch {
+                                navigator push GroupProfileScreen(
+                                    groupProfileVo = GroupProfileVo(group),
+                                    sharedSuffixKey = suffix,
+                                )
+                            }
+                        }
+                        renderGroupPagingStatus(
+                            isLoading = groups.isNotEmpty() && isLoadingGroups &&
+                                loadState.phase != SearchLoadPhase.Loading,
+                            failed = shouldShowGroupLoadMoreRetry(
+                                searchType = tab.searchType,
+                                loadMoreFailed = groupLoadMoreFailed,
+                                itemCount = groups.size,
+                            ),
+                            retryText = retryText,
+                            retry = { model.retryLoadMoreGroups() },
+                        )
+                    }
                 }
             }
-        },
-        onLoadMore = if (
-            shouldEnableGroupLoadMore(searchType, groupHasMore, isLoadingGroups, groups.size)
-        ) {
-            { model.loadMoreGroups() }
-        } else {
-            null
-        },
-        totalItemsCount = groups.size.takeIf { selectedTab == PublicSearchTab.Group } ?: 0,
-        lazyListState = selectedListState,
-        topContentPadding = 12.dp,
-        bottomNavigationPadding = bottomNavigationPadding,
+        }
+    }
+}
+
+@Composable
+private fun PublicSearchTabRow(
+    pagerState: PagerState,
+    tabs: List<String>,
+) {
+    val scope = rememberCoroutineScope()
+    PrimaryTabRow(selectedTabIndex = pagerState.currentPage) {
+        tabs.forEachIndexed { index, title ->
+            Tab(
+                selected = index == pagerState.currentPage,
+                onClick = { scope.launch { pagerState.animateScrollToTab(index) } },
+                text = {
+                    Text(
+                        text = title,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun PublicSearchPage(
+    query: String,
+    loadState: PublicSearchLoadState,
+    resultCount: Int,
+    lazyListState: LazyListState,
+    bottomNavigationPadding: Dp,
+    promptText: String,
+    noResultsText: String,
+    failedText: String,
+    refreshFailedText: String,
+    retryText: String,
+    retry: () -> Unit,
+    advancedOptionsContent: (@Composable () -> Unit)?,
+    itemContent: LazyListScope.() -> Unit,
+) {
+    val bottomPadding = getInsetPadding(12, WindowInsets::getBottom) + bottomNavigationPadding
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        state = lazyListState,
+        contentPadding = PaddingValues(
+            top = 8.dp,
+            bottom = bottomPadding,
+        ),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
+        if (advancedOptionsContent != null) {
+            item(key = "public-search-advanced-options") {
+                advancedOptionsContent()
+            }
+        }
         renderPublicSearchStatus(
-            query = searchText,
+            query = query,
             loadState = loadState,
-            resultCount = selectedResultsCount,
+            resultCount = resultCount,
             promptText = promptText,
             noResultsText = noResultsText,
             failedText = failedText,
             refreshFailedText = refreshFailedText,
             retryText = retryText,
-            retry = { coroutineScope.launch { model.refreshSearchList() } },
+            retry = retry,
         )
-        if (searchText.isNotBlank()) {
-            when (selectedTab) {
-                PublicSearchTab.User -> renderUserItems(users) { user, suffix ->
-                    coroutineScope.launch {
-                        navigator push UserProfileScreen(
-                            userProfileVO = UserProfileVo(user),
-                            sharedSuffixKey = suffix,
-                        )
-                    }
-                }
-                PublicSearchTab.World -> renderWorldItems(worlds) { world, suffix ->
-                    coroutineScope.launch {
-                        navigator push WorldProfileScreen(
-                            worldProfileVO = WorldProfileVo(world),
-                            sharedSuffixKey = suffix,
-                            sharedImageCacheKey = world.safeImageUrl(),
-                        )
-                    }
-                }
-                PublicSearchTab.Group -> {
-                    renderGroupItems(groups) { group, suffix ->
-                        coroutineScope.launch {
-                            navigator push GroupProfileScreen(
-                                groupProfileVo = GroupProfileVo(group),
-                                sharedSuffixKey = suffix,
-                            )
-                        }
-                    }
-                    renderGroupPagingStatus(
-                        isLoading = groups.isNotEmpty() && isLoadingGroups &&
-                            loadState.phase != SearchLoadPhase.Loading,
-                        failed = shouldShowGroupLoadMoreRetry(searchType, groupLoadMoreFailed, groups.size),
-                        retryText = retryText,
-                        retry = { model.retryLoadMoreGroups() },
-                    )
-                }
-            }
-        }
+        if (query.isNotBlank()) itemContent()
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/SearchListPager.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/SearchListPager.kt
@@ -124,7 +124,7 @@ fun PublicSearchContent(
     ) 80.dp else 0.dp
 
     LaunchedEffect(pagerState, model) {
-        snapshotFlow { pagerState.currentPage }
+        snapshotFlow { pagerState.settledPage }
             .distinctUntilChanged()
             .collect { page ->
                 model.setSearchType(PublicSearchTab.fromTabIndex(page).searchType)
@@ -135,12 +135,12 @@ fun PublicSearchContent(
     }
     LaunchedEffect(pagerState, userListState, worldListState, groupListState) {
         SharedFlowCentre.toPagerTop.collect {
-            val listState = when (pagerState.currentPage) {
+            val listState = when (pagerState.settledPage) {
                 PublicSearchTab.World.tabIndex -> worldListState
                 PublicSearchTab.Group.tabIndex -> groupListState
                 else -> userListState
             }
-            runCatching { listState.animateScrollToFirst() }
+            launch { listState.animateScrollToFirst() }
         }
     }
     LaunchedEffect(

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/SearchListPagerModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/SearchListPagerModel.kt
@@ -75,6 +75,7 @@ class SearchListPagerModel(
     private val _queriesByType = MutableStateFlow(
         PublicSearchTab.entries.associate { it.searchType to "" },
     )
+    internal val queriesByType = _queriesByType.asStateFlow()
     private val _searchText = MutableStateFlow("")
     val searchText: StateFlow<String> = _searchText.asStateFlow()
 
@@ -163,7 +164,7 @@ class SearchListPagerModel(
 
     suspend fun refreshSearchList(): Boolean = refreshSearchList(_searchType.value)
 
-    private suspend fun refreshSearchList(type: Int): Boolean {
+    internal suspend fun refreshSearchList(type: Int): Boolean {
         val requestKey = requestKeyFor(type)
         if (requestKey.searchText.isBlank()) {
             updateLoadState(type, PublicSearchLoadState())


### PR DESCRIPTION
## 改动概述

- 首页“位置/动态”改用 `HorizontalPager`，支持左右滑动和标签点击切换。
- 两个首页标签栏分别进入对应纵向列表的首项，随内容滚动隐藏，并保留各页独立滚动位置。
- 搜索页的用户、世界、群组结果支持横向切换，查询、结果、加载状态和群组分页仍按类型隔离。
- 收藏页的世界、模型列表支持横向切换，保留各自列表位置、搜索条件、分组选项和刷新/错误状态。
- 提取图库现有的弹簧分页动画供上述页面和图库共同使用，未改动路由、shared key 或页面过渡规则。

## 代码流程

```mermaid
flowchart TD
    A[标签点击或横向拖动] --> B[PagerState 更新]
    B --> C{当前页面}
    C -->|首页| D[同步 HomeTab]
    C -->|搜索| E[同步 SearchType]
    C -->|收藏| F[同步收藏类型]
    D --> G[位置或动态 LazyColumn]
    E --> H[读取该类型查询/结果/加载状态]
    F --> I[读取世界或模型列表状态]
    G --> J[保留独立滚动位置]
    H --> J
    I --> J
    B --> K[图库同款弹簧标签动画]
```

## 实现假设

- “第二页的搜索页”指首页主导航中的公开搜索页，其切换范围为用户、世界、群组三个标签。
- 侧滑菜单中的收藏页切换范围为世界和模型两个标签，不包含已拆分的“我的群组”页面。
- 首页身份顶栏继续保持原有固定行为；本次仅让“位置/动态”切换栏随各自纵向内容滚动。
- 页面内已有的横向控件（例如动态筛选行、好友头像行）保留自身手势优先级；其余区域由 `HorizontalPager` 处理横向切换，纵向列表继续处理上下滚动。
- Navigation 3 路由、返回策略、shared key/suffix key 和宽屏 list-detail 规则保持不变。

## 实现假设清单

- 本 PR 的实现假设仍为上方 `## 实现假设` 中冻结的五项；本节仅补齐送审所需的固定说明结构，没有新增未经验证假设，也不改变原始需求或实现行为。

## 验证

- `./gradlew :composeApp:compileKotlinDesktop`
- `./gradlew :composeApp:desktopTest`
- `./gradlew :composeApp:assembleDebug --no-daemon --max-workers=2 -Pkotlin.compiler.execution.strategy=in-process -Dorg.gradle.jvmargs=-Xmx4096M`（进程内设置本机 `ANDROID_HOME`）
- `git diff --check`

以上命令均通过。Android 默认 2 GB Kotlin daemon 在完整模块编译时会 OOM，因此验证命令使用进程内编译；未修改仓库构建配置。

## 尚需人工确认

- 真实触控设备上的快速连续横滑、斜向拖动和页面内横向控件的手势边界。
- 不同系统字体倍率及窄/宽窗口下，页间滑动过程中标签与内容的视觉连续性。
