### PR TITLE
fix(friends): 保持好友目录筛选源完整

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
@@ -94,6 +94,11 @@ class FriendListPagerModel(
     private val _friendList = MutableStateFlow(friendService.friendMap.values.toList().sortedUserByStatus())
     val friendList: StateFlow<List<FriendData>> = _friendList.asStateFlow()
 
+    // Directory filters derive from this account-bound source and never write back to it.
+    private val _friendSnapshot = MutableStateFlow(
+        friendService.friendMap.values.toList()
+    )
+
     private val _friendTotal = MutableStateFlow(friendService.friendMap.size)
     val friendTotal: StateFlow<Int> = _friendTotal.asStateFlow()
 
@@ -169,7 +174,7 @@ class FriendListPagerModel(
     private var favoriteLocale: LocaleStrings? = null
 
     val friendDirectoryFriends: StateFlow<List<FriendData>> = combine(
-        _friendList,
+        _friendSnapshot,
         _searchText,
         _friendGroupOptions,
         friendFavoriteGroupsFlow,
@@ -204,7 +209,7 @@ class FriendListPagerModel(
                 val token = activeSessionToken ?: return@collect
                 if (SharedFlowCentre.currentSession.value?.token?.userId != token.userId) return@collect
                 _friendTotal.value = friends.size
-                findFriendList(searchTexts[0])
+                findFriendList(searchTexts[0], friends.values.toList())
             }
         }
     }
@@ -224,6 +229,7 @@ class FriendListPagerModel(
             favoritedAvatarMap.clear()
             offlineStatusDescriptions.clear()
             _friendList.value = emptyList()
+            _friendSnapshot.value = emptyList()
             _friendTotal.value = 0
             _worldList.value = emptyList()
             _worldTotal.value = 0
@@ -522,9 +528,13 @@ class FriendListPagerModel(
      * 基于搜索文本和当前选择的好友组过滤好友列表
      * 使用FriendService提供的方法
      */
-    private fun findFriendList(name: String) {
+    private fun findFriendList(
+        name: String,
+        sourceFriends: List<FriendData> = friendService.friendMap.values.toList(),
+    ) {
         val sessionToken = activeSessionToken ?: run {
             _friendList.value = emptyList()
+            _friendSnapshot.value = emptyList()
             return
         }
         val generation = accountGeneration
@@ -538,7 +548,21 @@ class FriendListPagerModel(
         }
         friendFilterJob?.cancel()
         friendFilterJob = viewModelScope.launch {
-            val friends = findFriendsByName(name, favoriteIds, sessionToken, generation)
+            val friendSnapshot = enrichOfflineStatusDescriptions(
+                friends = sourceFriends,
+                sessionToken = sessionToken,
+                generation = generation,
+            )
+            if (!acceptsAccount(sessionToken, generation)) return@launch
+            _friendSnapshot.value = friendSnapshot
+
+            val friends = findFriendsByName(
+                name = name,
+                favoriteIds = favoriteIds,
+                friendSnapshot = friendSnapshot,
+                sessionToken = sessionToken,
+                generation = generation,
+            )
             if (acceptsAccount(sessionToken, generation)) _friendList.value = friends
         }
     }
@@ -577,6 +601,7 @@ class FriendListPagerModel(
     private suspend fun findFriendsByName(
         name: String,
         favoriteIds: Set<String>?,
+        friendSnapshot: List<FriendData>,
         sessionToken: AccountSessionToken,
         generation: Long,
     ): List<FriendData> {
@@ -587,7 +612,7 @@ class FriendListPagerModel(
         } ?: emptyList()
 
         // 先按名称过滤
-        val nameFilteredList = (friendService.friendMap.values + unFriendData).let { friends ->
+        val nameFilteredList = (friendSnapshot + unFriendData).let { friends ->
             if (name.isEmpty()) friends
             else friends.filter { name.isEmpty() || it.displayName.lowercase().contains(name.lowercase()) }
         }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
@@ -17,7 +17,6 @@ import io.github.vrcmteam.vrcm.network.api.avatars.AvatarsApi
 import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
 import io.github.vrcmteam.vrcm.network.api.files.resolveOriginalImageUrl
 import io.github.vrcmteam.vrcm.network.api.users.UsersApi
-import io.github.vrcmteam.vrcm.network.api.users.data.UserData
 import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
 import io.github.vrcmteam.vrcm.network.api.worlds.data.FavoritedWorld
 import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
@@ -91,9 +90,6 @@ class FriendListPagerModel(
     private val _worldGroupOptions = MutableStateFlow(WorldGroupOptions())
     var worldGroupOptions = _worldGroupOptions.asStateFlow()
 
-    private val _friendList = MutableStateFlow(friendService.friendMap.values.toList().sortedUserByStatus())
-    val friendList: StateFlow<List<FriendData>> = _friendList.asStateFlow()
-
     // Directory filters derive from this account-bound source and never write back to it.
     private val _friendSnapshot = MutableStateFlow(
         friendService.friendMap.values.toList()
@@ -159,7 +155,7 @@ class FriendListPagerModel(
     private val _searchText = MutableStateFlow("")
     val searchText: StateFlow<String> = _searchText.asStateFlow()
 
-    private var friendFilterJob: Job? = null
+    private var friendSnapshotJob: Job? = null
     private val offlineStatusDescriptions = mutableMapOf<String, String>()
 
     private val _directoryRefreshing = MutableStateFlow(true)
@@ -196,6 +192,7 @@ class FriendListPagerModel(
         started = SharingStarted.Eagerly,
         initialValue = emptyList(),
     )
+    val friendList: StateFlow<List<FriendData>> = friendDirectoryFriends
 
     init {
         viewModelScope.launch {
@@ -209,7 +206,7 @@ class FriendListPagerModel(
                 val token = activeSessionToken ?: return@collect
                 if (SharedFlowCentre.currentSession.value?.token?.userId != token.userId) return@collect
                 _friendTotal.value = friends.size
-                findFriendList(searchTexts[0], friends.values.toList())
+                updateFriendSnapshot(friends.values.toList())
             }
         }
     }
@@ -222,13 +219,12 @@ class FriendListPagerModel(
         refreshJobsByTab.clear()
         directoryRefreshJob?.cancel()
         directoryRefreshJob = null
-        friendFilterJob?.cancel()
-        friendFilterJob = null
+        friendSnapshotJob?.cancel()
+        friendSnapshotJob = null
         if (userChanged) {
             favoritedWorldMap.clear()
             favoritedAvatarMap.clear()
             offlineStatusDescriptions.clear()
-            _friendList.value = emptyList()
             _friendSnapshot.value = emptyList()
             _friendTotal.value = 0
             _worldList.value = emptyList()
@@ -446,8 +442,7 @@ class FriendListPagerModel(
     fun setSearchText(text: String) {
         _searchText.value = text
         searchTexts[_selectedTabIndex.value] = text
-        // 当搜索文本改变时，根据当前标签页刷新对应数据
-        refreshCurrentTabListData()
+        if (_selectedTabIndex.value != 0) refreshCurrentTabListData()
     }
 
     fun setFriendDirectorySearchText(text: String) {
@@ -460,10 +455,7 @@ class FriendListPagerModel(
      */
     private fun refreshCurrentTabListData() {
         when (_selectedTabIndex.value) {
-            0 -> {
-                // 好友标签页
-                findFriendList(searchTexts[0])
-            }
+            0 -> Unit
 
             1 -> {
                 // 世界标签页
@@ -501,7 +493,6 @@ class FriendListPagerModel(
      */
     fun updateFriendGroupOptions(options: FriendGroupOptions) {
         _friendGroupOptions.value = options
-        refreshCurrentTabListData()
     }
 
     fun updateFriendDirectoryGroupOptions(options: FriendGroupOptions) {
@@ -524,30 +515,12 @@ class FriendListPagerModel(
         refreshCurrentTabListData()
     }
 
-    /**
-     * 基于搜索文本和当前选择的好友组过滤好友列表
-     * 使用FriendService提供的方法
-     */
-    private fun findFriendList(
-        name: String,
-        sourceFriends: List<FriendData> = friendService.friendMap.values.toList(),
-    ) {
-        val sessionToken = activeSessionToken ?: run {
-            _friendList.value = emptyList()
-            _friendSnapshot.value = emptyList()
-            return
-        }
+    /** Updates the account-bound source snapshot without applying UI filters. */
+    private fun updateFriendSnapshot(sourceFriends: List<FriendData>) {
+        val sessionToken = activeSessionToken ?: return
         val generation = accountGeneration
-        val favoriteIds = if (friendGroupOptions.value.selectedGroup != null) {
-            // 获取选中好友组的favoriteId列表
-            friendFavoriteGroupsFlow.value[friendGroupOptions.value.selectedGroup]
-                ?.map { it.favoriteId }
-                ?.toSet()
-        } else {
-            null
-        }
-        friendFilterJob?.cancel()
-        friendFilterJob = viewModelScope.launch {
+        friendSnapshotJob?.cancel()
+        friendSnapshotJob = viewModelScope.launch {
             val friendSnapshot = enrichOfflineStatusDescriptions(
                 friends = sourceFriends,
                 sessionToken = sessionToken,
@@ -555,74 +528,7 @@ class FriendListPagerModel(
             )
             if (!acceptsAccount(sessionToken, generation)) return@launch
             _friendSnapshot.value = friendSnapshot
-
-            val friends = findFriendsByName(
-                name = name,
-                favoriteIds = favoriteIds,
-                friendSnapshot = friendSnapshot,
-                sessionToken = sessionToken,
-                generation = generation,
-            )
-            if (acceptsAccount(sessionToken, generation)) _friendList.value = friends
         }
-    }
-
-    private fun UserData.toFriendData(): FriendData {
-        return  FriendData(
-            id = id,
-            displayName = displayName,
-            status = status,
-            lastLogin = lastLogin,
-            lastActivity = lastActivity,
-            lastPlatform = lastPlatform,
-            bio = bio,
-            bioLinks = bioLinks,
-            currentAvatarImageUrl = currentAvatarImageUrl,
-            currentAvatarThumbnailImageUrl = currentAvatarThumbnailImageUrl,
-            currentAvatarTags = currentAvatarTags,
-            developerType = developerType,
-            tags = tags,
-            isFriend = false,
-            profilePicOverride = profilePicOverride,
-            friendKey = "",
-            imageUrl = profileImageUrl,
-            location = LocationType.Offline.value,
-            statusDescription = statusDescription,
-            userIcon = userIcon,
-            pronouns = pronouns,
-        )
-    }
-
-    /**
-     * 基于搜索文本和当前选择的世界组过滤世界列表
-     *
-     * @param favoriteIds 为 null 时返回所有好友， 代表没有选择好友组
-     */
-    private suspend fun findFriendsByName(
-        name: String,
-        favoriteIds: Set<String>?,
-        friendSnapshot: List<FriendData>,
-        sessionToken: AccountSessionToken,
-        generation: Long,
-    ): List<FriendData> {
-
-        val unFriendData = favoriteIds?.filterNot { friendService.friendMap.contains(it) }?.map {
-            withContext(Dispatchers.IO) { usersApi.fetchUser(it) }
-                .toFriendData()
-        } ?: emptyList()
-
-        // 先按名称过滤
-        val nameFilteredList = (friendSnapshot + unFriendData).let { friends ->
-            if (name.isEmpty()) friends
-            else friends.filter { name.isEmpty() || it.displayName.lowercase().contains(name.lowercase()) }
-        }
-
-        // 再按好友组过滤
-        val result =
-            if (favoriteIds != null) nameFilteredList.filter { friend -> favoriteIds.contains(friend.id) }
-            else nameFilteredList
-
-        return enrichOfflineStatusDescriptions(result, sessionToken, generation).sortedUserByStatus()
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/service/FavoriteService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FavoriteService.kt
@@ -41,6 +41,7 @@ class FavoriteService(
     private val favoriteLocalDao: FavoriteLocalDao,
 ) {
 
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val favoritesByGroupCache = FavoriteGroupCache()
     private var favoritesOwnerUserId: String? = SharedFlowCentre.currentSession.value?.token?.userId
     private var favoritesOwnerToken: io.github.vrcmteam.vrcm.core.shared.AccountSessionToken? =
@@ -52,7 +53,7 @@ class FavoriteService(
     private var _favoriteLimits: FavoriteLimits? = null
 
     init {
-        CoroutineScope(Dispatchers.Default).launch {
+        serviceScope.launch {
             SharedFlowCentre.currentSession.collect { session ->
                 val nextUserId = session?.token?.userId
                 cacheMutex.withLock {
@@ -76,7 +77,7 @@ class FavoriteService(
 
 
     init {
-        CoroutineScope(Job()).launch(Dispatchers.IO) {
+        serviceScope.launch(Dispatchers.IO) {
             loadFavoriteLimits()
         }
     }
@@ -259,4 +260,7 @@ class FavoriteService(
     fun getFavoriteByFavoriteId(favoriteType: FavoriteType, favoriteId: String): FavoriteData? =
         favoritesByGroup(favoriteType).value.values.flatten().firstOrNull { it.favoriteId == favoriteId }
 
+    internal fun dispose() {
+        serviceScope.cancel()
+    }
 }

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
@@ -1,0 +1,242 @@
+package io.github.vrcmteam.vrcm.presentation.screens.home.pager
+
+import androidx.lifecycle.ViewModelStore
+import com.russhwolf.settings.MapSettings
+import io.github.vrcmteam.vrcm.core.shared.AccountWebSocketEvent
+import io.github.vrcmteam.vrcm.core.shared.AuthenticatedAccount
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
+import io.github.vrcmteam.vrcm.di.supports.PersistentCookiesStorage
+import io.github.vrcmteam.vrcm.network.api.attributes.UserStatus
+import io.github.vrcmteam.vrcm.network.api.auth.AuthApi
+import io.github.vrcmteam.vrcm.network.api.avatars.AvatarsApi
+import io.github.vrcmteam.vrcm.network.api.favorite.FavoriteApi
+import io.github.vrcmteam.vrcm.network.api.friends.FriendsApi
+import io.github.vrcmteam.vrcm.network.api.users.UsersApi
+import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
+import io.github.vrcmteam.vrcm.network.websocket.data.WebSocketEvent
+import io.github.vrcmteam.vrcm.network.websocket.data.content.FriendActiveContent
+import io.github.vrcmteam.vrcm.network.websocket.data.content.UserContent
+import io.github.vrcmteam.vrcm.network.websocket.data.type.FriendEvents
+import io.github.vrcmteam.vrcm.service.AuthService
+import io.github.vrcmteam.vrcm.service.FavoriteService
+import io.github.vrcmteam.vrcm.service.FriendService
+import io.github.vrcmteam.vrcm.service.data.AccountDto
+import io.github.vrcmteam.vrcm.storage.AccountCacheManager
+import io.github.vrcmteam.vrcm.storage.AccountDao
+import io.github.vrcmteam.vrcm.storage.FavoriteLocalDao
+import io.github.vrcmteam.vrcm.storage.InMemoryFavoriteListCacheStore
+import io.github.vrcmteam.vrcm.storage.InMemoryFriendListCacheStore
+import io.github.vrcmteam.vrcm.storage.InMemorySecureStorage
+import io.github.vrcmteam.vrcm.storage.InMemoryUserProfileCacheStore
+import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardAssetStore
+import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardConfigDao
+import io.github.vrcmteam.vrcm.testing.MainDispatcherTest
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.koin.core.logger.EmptyLogger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class FriendListPagerModelTest : MainDispatcherTest() {
+    @Test
+    fun clearingSearchRestoresAllFriendsAfterFilteredFriendStateUpdate() = runBlocking {
+        SharedFlowCentre.emitLogout()
+        val account = AccountDto(userId = "usr_directory_owner", username = "directory-owner")
+        SharedFlowCentre.emitAuthenticated(account)
+        val session = assertNotNull(SharedFlowCentre.currentSession.value)
+        val json = Json { ignoreUnknownKeys = true }
+        val client = testClient(json)
+        val friendListCacheStore = InMemoryFriendListCacheStore()
+        val favoriteListCacheStore = InMemoryFavoriteListCacheStore()
+        val accountCacheManager = AccountCacheManager(
+            friendListCacheStore = friendListCacheStore,
+            userProfileCacheStore = InMemoryUserProfileCacheStore(),
+            friendActivityStore = io.github.vrcmteam.vrcm.storage.NoOpFriendActivityCacheStore,
+            meetupCardConfigDao = MeetupCardConfigDao(MapSettings()),
+            meetupCardAssetStore = MeetupCardAssetStore(
+                FakeFileSystem(),
+                "/meetup-assets".toPath(),
+            ),
+            favoriteListCacheStore = favoriteListCacheStore,
+        )
+        val authService = AuthService(
+            authApi = AuthApi(client),
+            accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also {
+                it.saveAccountInfo(account)
+            },
+            cookiesStorage = PersistentCookiesStorage(EmptyLogger()),
+            accountCacheManager = accountCacheManager,
+        )
+        val friendService = FriendService(
+            friendsApi = FriendsApi(client),
+            authService = authService,
+            json = json,
+            friendListCacheStore = friendListCacheStore,
+            accountCacheManager = accountCacheManager,
+            logger = EmptyLogger(),
+        )
+        val model = FriendListPagerModel(
+            usersApi = UsersApi(client),
+            friendService = friendService,
+            authService = authService,
+            favoriteService = FavoriteService(
+                favoriteApi = FavoriteApi(client),
+                favoriteLocalDao = FavoriteLocalDao(MapSettings()),
+            ),
+            worldsApi = WorldsApi(client),
+            avatarsApi = AvatarsApi(client),
+            favoriteListCacheStore = favoriteListCacheStore,
+            accountCacheManager = accountCacheManager,
+        )
+
+        try {
+            awaitUntil {
+                friendService.initialRefreshCompleted.value && !model.directoryRefreshing.value
+            }
+            emitFriendUntilObserved(
+                friendService,
+                session,
+                userId = "usr_alice",
+                event = activeFriendEvent(json, "usr_alice", "Alice"),
+            )
+            emitFriendUntilObserved(
+                friendService,
+                session,
+                userId = "usr_bob",
+                event = activeFriendEvent(json, "usr_bob", "Bob"),
+            )
+            awaitFriendIds(model, setOf("usr_alice", "usr_bob"))
+
+            model.setFriendDirectorySearchText("Alice")
+            awaitFriendIds(model, setOf("usr_alice"))
+
+            emitFriendUntilObserved(
+                friendService,
+                session,
+                userId = "usr_charlie",
+                event = activeFriendEvent(json, "usr_charlie", "Charlie"),
+            )
+            awaitUntil { model.friendTotal.value == 3 }
+
+            model.setFriendDirectorySearchText("")
+            val expectedIds = setOf("usr_alice", "usr_bob", "usr_charlie")
+            awaitFriendIds(model, expectedIds)
+
+            assertEquals(
+                expectedIds,
+                model.friendDirectoryFriends.value.mapTo(mutableSetOf()) { it.id },
+            )
+        } finally {
+            ViewModelStore().apply {
+                put("friend-list-pager", model)
+                clear()
+            }
+            friendService.dispose()
+            SharedFlowCentre.emitLogout()
+            client.close()
+        }
+    }
+
+    private suspend fun emitFriendUntilObserved(
+        friendService: FriendService,
+        session: AuthenticatedAccount,
+        userId: String,
+        event: WebSocketEvent,
+    ) {
+        withTimeout(3_000) {
+            while (userId !in friendService.friendState.value) {
+                SharedFlowCentre.emitWebSocket(AccountWebSocketEvent(session.token, event))
+                yield()
+            }
+        }
+    }
+
+    private suspend fun awaitFriendIds(model: FriendListPagerModel, expectedIds: Set<String>) {
+        awaitUntil {
+            model.friendDirectoryFriends.value.mapTo(mutableSetOf()) { it.id } == expectedIds
+        }
+    }
+
+    private suspend fun awaitUntil(predicate: () -> Boolean) {
+        withTimeout(3_000) {
+            while (!predicate()) yield()
+        }
+    }
+
+    private fun testClient(json: Json) = HttpClient(MockEngine) {
+        engine {
+            addHandler { request ->
+                when (request.url.encodedPath) {
+                    "/auth/user/favoritelimits" -> jsonResponse(favoriteLimitsJson())
+                    "/auth/user/friends", "/favorites", "/favorite/groups" -> jsonResponse("[]")
+                    "/auth/user" -> respond("unavailable", HttpStatusCode.InternalServerError)
+                    else -> error("Unexpected request: ${request.url}")
+                }
+            }
+        }
+        install(ContentNegotiation) { json(json) }
+    }
+
+    private fun activeFriendEvent(json: Json, userId: String, displayName: String) = WebSocketEvent(
+        type = FriendEvents.FriendActive.typeName,
+        content = json.encodeToString(
+            FriendActiveContent(
+                userId = userId,
+                user = UserContent(
+                    allowAvatarCopying = true,
+                    bio = null,
+                    bioLinks = emptyList(),
+                    currentAvatarImageUrl = "",
+                    currentAvatarTags = emptyList(),
+                    currentAvatarThumbnailImageUrl = "",
+                    dateJoined = "",
+                    developerType = "none",
+                    displayName = displayName,
+                    friendKey = "",
+                    id = userId,
+                    isFriend = true,
+                    lastActivity = "",
+                    lastLogin = "",
+                    lastPlatform = "web",
+                    profilePicOverride = "",
+                    state = "active",
+                    status = UserStatus.Active,
+                    statusDescription = "",
+                    tags = emptyList(),
+                    userIcon = "",
+                    pronouns = null,
+                ),
+            )
+        ),
+    )
+}
+
+private fun MockRequestHandleScope.jsonResponse(content: String) = respond(
+    content = content,
+    status = HttpStatusCode.OK,
+    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+)
+
+private fun favoriteLimitsJson() = """
+    {
+      "maxFavoriteGroups":{"avatar":1,"friend":1,"world":1},
+      "maxFavoritesPerGroup":{"avatar":100,"friend":100,"world":100},
+      "defaultMaxFavoriteGroups":1,
+      "defaultMaxFavoritesPerGroup":100
+    }
+""".trimIndent()

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
@@ -60,7 +60,8 @@ class FriendListPagerModelTest : MainDispatcherTest() {
         SharedFlowCentre.emitAuthenticated(account)
         val session = assertNotNull(SharedFlowCentre.currentSession.value)
         val json = Json { ignoreUnknownKeys = true }
-        val client = testClient(json)
+        var nonFriendProfileRequests = 0
+        val client = testClient(json) { nonFriendProfileRequests++ }
         val friendListCacheStore = InMemoryFriendListCacheStore()
         val favoriteListCacheStore = InMemoryFavoriteListCacheStore()
         val accountCacheManager = AccountCacheManager(
@@ -141,6 +142,15 @@ class FriendListPagerModelTest : MainDispatcherTest() {
                 expectedIds,
                 model.friendDirectoryFriends.value.mapTo(mutableSetOf()) { it.id },
             )
+
+            val remoteGroup = model.friendFavoriteGroupsFlow.value.keys.single {
+                it.ownerId != "local"
+            }
+            model.updateFriendGroupOptions(FriendGroupOptions(remoteGroup))
+            model.setSearchText("No matching friend")
+            awaitUntil { model.friendList.value.isEmpty() }
+
+            assertEquals(0, nonFriendProfileRequests)
         } finally {
             ViewModelStore().apply {
                 put("friend-list-pager", model)
@@ -178,12 +188,25 @@ class FriendListPagerModelTest : MainDispatcherTest() {
         }
     }
 
-    private fun testClient(json: Json) = HttpClient(MockEngine) {
+    private fun testClient(
+        json: Json,
+        onNonFriendProfileRequest: () -> Unit,
+    ) = HttpClient(MockEngine) {
         engine {
             addHandler { request ->
                 when (request.url.encodedPath) {
                     "/auth/user/favoritelimits" -> jsonResponse(favoriteLimitsJson())
-                    "/auth/user/friends", "/favorites", "/favorite/groups" -> jsonResponse("[]")
+                    "/auth/user/friends" -> jsonResponse("[]")
+                    "/favorites" -> jsonResponse(
+                        if (request.url.parameters["offset"] == "0") friendFavoritesJson() else "[]"
+                    )
+                    "/favorite/groups" -> jsonResponse(
+                        if (request.url.parameters["offset"] == "0") friendFavoriteGroupsJson() else "[]"
+                    )
+                    "/users/usr_non_friend" -> {
+                        onNonFriendProfileRequest()
+                        jsonResponse(nonFriendUserJson())
+                    }
                     "/auth/user" -> respond("unavailable", HttpStatusCode.InternalServerError)
                     else -> error("Unexpected request: ${request.url}")
                 }
@@ -238,5 +261,36 @@ private fun favoriteLimitsJson() = """
       "maxFavoritesPerGroup":{"avatar":100,"friend":100,"world":100},
       "defaultMaxFavoriteGroups":1,
       "defaultMaxFavoritesPerGroup":100
+    }
+""".trimIndent()
+
+private fun friendFavoritesJson() = """
+    [{
+      "favoriteId":"usr_non_friend","id":"fvrt_non_friend",
+      "tags":["group_0"],"type":"friend"
+    }]
+""".trimIndent()
+
+private fun friendFavoriteGroupsJson() = """
+    [{
+      "id":"grp_friend","ownerId":"usr_directory_owner","type":"friend",
+      "visibility":"private","displayName":"Friends","name":"group_0",
+      "ownerDisplayName":"directory-owner","tags":[]
+    }]
+""".trimIndent()
+
+private fun nonFriendUserJson() = """
+    {
+      "ageVerificationStatus":"verified","allowAvatarCopying":true,
+      "bio":"","bioLinks":[],"currentAvatarImageUrl":"",
+      "currentAvatarTags":[],"currentAvatarThumbnailImageUrl":"",
+      "date_joined":"","developerType":"none","displayName":"Former Friend",
+      "friendKey":"","friendRequestStatus":"null","id":"usr_non_friend",
+      "instanceId":"","isFriend":false,"last_activity":"","last_login":"",
+      "last_platform":"web","location":"offline","note":"",
+      "profilePicOverride":"","state":"offline","status":"offline",
+      "statusDescription":"","tags":[],"travelingToInstance":null,
+      "travelingToLocation":null,"travelingToWorld":null,"userIcon":"",
+      "worldId":"","pronouns":null
     }
 """.trimIndent()

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
@@ -15,6 +15,7 @@ import io.github.vrcmteam.vrcm.network.api.users.UsersApi
 import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
 import io.github.vrcmteam.vrcm.network.websocket.data.WebSocketEvent
 import io.github.vrcmteam.vrcm.network.websocket.data.content.FriendActiveContent
+import io.github.vrcmteam.vrcm.network.websocket.data.content.FriendOfflineContent
 import io.github.vrcmteam.vrcm.network.websocket.data.content.UserContent
 import io.github.vrcmteam.vrcm.network.websocket.data.type.FriendEvents
 import io.github.vrcmteam.vrcm.service.AuthService
@@ -40,7 +41,13 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
 import kotlinx.serialization.encodeToString
@@ -91,14 +98,15 @@ class FriendListPagerModelTest : MainDispatcherTest() {
             accountCacheManager = accountCacheManager,
             logger = EmptyLogger(),
         )
+        val favoriteService = FavoriteService(
+            favoriteApi = FavoriteApi(client),
+            favoriteLocalDao = FavoriteLocalDao(MapSettings()),
+        )
         val model = FriendListPagerModel(
             usersApi = UsersApi(client),
             friendService = friendService,
             authService = authService,
-            favoriteService = FavoriteService(
-                favoriteApi = FavoriteApi(client),
-                favoriteLocalDao = FavoriteLocalDao(MapSettings()),
-            ),
+            favoriteService = favoriteService,
             worldsApi = WorldsApi(client),
             avatarsApi = AvatarsApi(client),
             favoriteListCacheStore = favoriteListCacheStore,
@@ -157,6 +165,124 @@ class FriendListPagerModelTest : MainDispatcherTest() {
                 clear()
             }
             friendService.dispose()
+            favoriteService.dispose()
+            SharedFlowCentre.emitLogout()
+            client.close()
+        }
+    }
+
+    @Test
+    fun lateOfflineProfileFromPreviousAccountCannotReplaceCurrentFriendSnapshot() = runBlocking {
+        SharedFlowCentre.emitLogout()
+        val accountA = AccountDto(userId = "usr_directory_owner_a", username = "directory-owner-a")
+        val accountB = AccountDto(userId = "usr_directory_owner_b", username = "directory-owner-b")
+        SharedFlowCentre.emitAuthenticated(accountA)
+        val sessionA = assertNotNull(SharedFlowCentre.currentSession.value)
+        val json = Json { ignoreUnknownKeys = true }
+        val accountAProfileStarted = CompletableDeferred<Unit>()
+        val releaseAccountAProfile = CompletableDeferred<Unit>()
+        val accountAProfileJob = CompletableDeferred<Job>()
+        val client = accountSwitchClient(
+            json = json,
+            accountAProfileStarted = accountAProfileStarted,
+            releaseAccountAProfile = releaseAccountAProfile,
+            accountAProfileJob = accountAProfileJob,
+        )
+        val friendListCacheStore = InMemoryFriendListCacheStore()
+        val favoriteListCacheStore = InMemoryFavoriteListCacheStore()
+        val accountCacheManager = AccountCacheManager(
+            friendListCacheStore = friendListCacheStore,
+            userProfileCacheStore = InMemoryUserProfileCacheStore(),
+            friendActivityStore = io.github.vrcmteam.vrcm.storage.NoOpFriendActivityCacheStore,
+            meetupCardConfigDao = MeetupCardConfigDao(MapSettings()),
+            meetupCardAssetStore = MeetupCardAssetStore(
+                FakeFileSystem(),
+                "/meetup-assets".toPath(),
+            ),
+            favoriteListCacheStore = favoriteListCacheStore,
+        )
+        val authService = AuthService(
+            authApi = AuthApi(client),
+            accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also {
+                it.saveAccountInfo(accountA)
+            },
+            cookiesStorage = PersistentCookiesStorage(EmptyLogger()),
+            accountCacheManager = accountCacheManager,
+        )
+        val friendService = FriendService(
+            friendsApi = FriendsApi(client),
+            authService = authService,
+            json = json,
+            friendListCacheStore = friendListCacheStore,
+            accountCacheManager = accountCacheManager,
+            logger = EmptyLogger(),
+        )
+        val favoriteService = FavoriteService(
+            favoriteApi = FavoriteApi(client),
+            favoriteLocalDao = FavoriteLocalDao(MapSettings()),
+        )
+        val model = FriendListPagerModel(
+            usersApi = UsersApi(client),
+            friendService = friendService,
+            authService = authService,
+            favoriteService = favoriteService,
+            worldsApi = WorldsApi(client),
+            avatarsApi = AvatarsApi(client),
+            favoriteListCacheStore = favoriteListCacheStore,
+            accountCacheManager = accountCacheManager,
+        )
+
+        try {
+            awaitUntil {
+                friendService.initialRefreshCompleted.value && !model.directoryRefreshing.value
+            }
+            emitFriendUntilObserved(
+                friendService,
+                sessionA,
+                userId = "usr_account_a_friend",
+                event = activeFriendEvent(json, "usr_account_a_friend", "Account A Friend"),
+            )
+            awaitFriendIds(model, setOf("usr_account_a_friend"))
+
+            SharedFlowCentre.emitWebSocket(
+                AccountWebSocketEvent(
+                    sessionA.token,
+                    offlineFriendEvent(json, "usr_account_a_friend"),
+                )
+            )
+            withTimeout(3_000) { accountAProfileStarted.await() }
+            val oldProfileJob = withTimeout(3_000) { accountAProfileJob.await() }
+
+            SharedFlowCentre.emitAuthenticated(accountB)
+            val sessionB = assertNotNull(SharedFlowCentre.currentSession.value)
+            awaitUntil {
+                friendService.friendState.value.isEmpty() &&
+                    model.friendDirectoryFriends.value.isEmpty()
+            }
+            emitFriendUntilObserved(
+                friendService,
+                sessionB,
+                userId = "usr_account_b_friend",
+                event = activeFriendEvent(json, "usr_account_b_friend", "Account B Friend"),
+            )
+            awaitFriendIds(model, setOf("usr_account_b_friend"))
+
+            releaseAccountAProfile.complete(Unit)
+            withTimeout(3_000) { oldProfileJob.join() }
+
+            assertEquals(
+                listOf("usr_account_b_friend"),
+                model.friendDirectoryFriends.value.map { it.id },
+            )
+            assertEquals("", model.friendDirectoryFriends.value.single().statusDescription)
+        } finally {
+            releaseAccountAProfile.complete(Unit)
+            ViewModelStore().apply {
+                put("friend-list-pager", model)
+                clear()
+            }
+            friendService.dispose()
+            favoriteService.dispose()
             SharedFlowCentre.emitLogout()
             client.close()
         }
@@ -247,6 +373,36 @@ class FriendListPagerModelTest : MainDispatcherTest() {
             )
         ),
     )
+
+    private fun offlineFriendEvent(json: Json, userId: String) = WebSocketEvent(
+        type = FriendEvents.FriendOffline.typeName,
+        content = json.encodeToString(FriendOfflineContent(userId = userId)),
+    )
+}
+
+private fun accountSwitchClient(
+    json: Json,
+    accountAProfileStarted: CompletableDeferred<Unit>,
+    releaseAccountAProfile: CompletableDeferred<Unit>,
+    accountAProfileJob: CompletableDeferred<Job>,
+) = HttpClient(MockEngine) {
+    engine {
+        addHandler { request ->
+            when (request.url.encodedPath) {
+                "/auth/user/favoritelimits" -> jsonResponse(favoriteLimitsJson())
+                "/auth/user/friends", "/favorites", "/favorite/groups" -> jsonResponse("[]")
+                "/users/usr_account_a_friend" -> {
+                    accountAProfileJob.complete(currentCoroutineContext().job)
+                    accountAProfileStarted.complete(Unit)
+                    withContext(NonCancellable) { releaseAccountAProfile.await() }
+                    jsonResponse(accountAProfileJson())
+                }
+                "/auth/user" -> respond("unavailable", HttpStatusCode.InternalServerError)
+                else -> error("Unexpected request: ${request.url}")
+            }
+        }
+    }
+    install(ContentNegotiation) { json(json) }
 }
 
 private fun MockRequestHandleScope.jsonResponse(content: String) = respond(
@@ -290,6 +446,22 @@ private fun nonFriendUserJson() = """
       "last_platform":"web","location":"offline","note":"",
       "profilePicOverride":"","state":"offline","status":"offline",
       "statusDescription":"","tags":[],"travelingToInstance":null,
+      "travelingToLocation":null,"travelingToWorld":null,"userIcon":"",
+      "worldId":"","pronouns":null
+    }
+""".trimIndent()
+
+private fun accountAProfileJson() = """
+    {
+      "ageVerificationStatus":"verified","allowAvatarCopying":true,
+      "bio":"","bioLinks":[],"currentAvatarImageUrl":"",
+      "currentAvatarTags":[],"currentAvatarThumbnailImageUrl":"",
+      "date_joined":"","developerType":"none","displayName":"Account A Friend",
+      "friendKey":"","friendRequestStatus":"null","id":"usr_account_a_friend",
+      "instanceId":"","isFriend":true,"last_activity":"","last_login":"",
+      "last_platform":"web","location":"offline","note":"",
+      "profilePicOverride":"","state":"offline","status":"offline",
+      "statusDescription":"Account A private status","tags":[],"travelingToInstance":null,
       "travelingToLocation":null,"travelingToWorld":null,"userIcon":"",
       "worldId":"","pronouns":null
     }

--- a/composeApp/src/commonTest/kotlin/service/FavoriteServiceSessionTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/FavoriteServiceSessionTest.kt
@@ -33,13 +33,15 @@ class FavoriteServiceSessionTest {
             favoritesRequestCount++
             error("Unexpected favorites request: $requestPath")
         }
+        val service = favoriteService(client)
         try {
-            val result = favoriteService(client).loadFavoriteByGroup(FavoriteType.World)
+            val result = service.loadFavoriteByGroup(FavoriteType.World)
 
             assertTrue(result.isFailure)
             assertEquals("No authenticated session", result.exceptionOrNull()?.message)
             assertEquals(0, favoritesRequestCount)
         } finally {
+            service.dispose()
             client.close()
             SharedFlowCentre.emitLogout()
         }
@@ -71,8 +73,8 @@ class FavoriteServiceSessionTest {
                 else -> error("Unexpected favorites request: $requestPath")
             }
         }
+        val service = favoriteService(client)
         try {
-            val service = favoriteService(client)
             val oldLoad = async(start = CoroutineStart.UNDISPATCHED) {
                 service.loadFavoriteByGroup(FavoriteType.World)
             }
@@ -97,6 +99,7 @@ class FavoriteServiceSessionTest {
                     .map { it.id },
             )
         } finally {
+            service.dispose()
             client.close()
             SharedFlowCentre.emitLogout()
         }
@@ -124,14 +127,15 @@ class FavoriteServiceSessionTest {
                 else -> error("Unexpected favorites request: $requestPath")
             }
         }
+        val service = favoriteService(client)
         try {
-            val service = favoriteService(client)
             assertTrue(service.loadFavoriteByGroup(FavoriteType.World).isSuccess)
             val previous = service.favoritesByGroup(FavoriteType.World).value
 
             assertTrue(service.loadFavoriteByGroup(FavoriteType.World).isFailure)
             assertEquals(previous, service.favoritesByGroup(FavoriteType.World).value)
         } finally {
+            service.dispose()
             client.close()
             SharedFlowCentre.emitLogout()
         }


### PR DESCRIPTION
## 概要

- 使用账户绑定的 `_friendSnapshot` 保存未经过搜索或分组筛选的好友原始快照。
- 将搜索、好友收藏组与状态排序统一改为 `combine` 派生，`friendList` 和 `friendDirectoryFriends` 共享同一个 `StateFlow`。
- 离线状态描述只补全当前好友快照，避免筛选结果反向污染数据源，也避免请求不会展示的非好友资料。

## 代码逻辑图

```mermaid
flowchart LR
    A["FriendService.friendState"] --> B["离线资料补全"]
    B --> C["账户好友原始快照"]
    C --> D["组合搜索词与好友组"]
    D --> E["排序后的好友目录 StateFlow"]
    F["FavoriteService"] --> G["serviceScope (SupervisorJob)"]
    G --> H["currentSession.collect"]
    G --> I["loadFavoriteLimits"]
    J["dispose()"] -->|cancel| G
```

## 实现假设清单

- `FriendService.friendState` 是当前账户好友目录的权威来源。
- 好友收藏组中不在当前好友集合里的用户不应出现在好友目录。
- 账户 token 与 generation 校验足以丢弃切换账户后的迟到补全结果。

## 本轮评审修复

- 使用可取消的服务级 `SupervisorJob` 作用域承载 `FavoriteService` 的会话收集和收藏限制加载，并在直接构造服务的测试结束时调用 `dispose()`，避免遗留后台协程。
- 增加账户切换并发回归场景：账户 A 的离线资料请求挂起后切换到账户 B，发布 B 的好友快照，再放行 A 的迟到响应，验证目录只保留 B 的好友及状态。

## 测试结果

- `FriendListPagerModelTest` 覆盖连续筛选、原始快照恢复、账户切换和非好友零请求。
- `./gradlew :composeApp:desktopTest :composeApp:compileKotlinDesktop` 通过。
- `git diff --check upstream/newui..HEAD` 通过。
- 本轮定向运行 `FriendListPagerModelTest` 与 `FavoriteServiceSessionTest`，结果为 `BUILD SUCCESSFUL`。
- 本轮完整 `desktopTest` 共执行 782 项，业务测试通过；唯一失败为无图形会话下既有的 `DesktopWindowTitleBarLocaleTest` `HeadlessException`。虚拟显示重跑受本机 AWT/Skia 原生库缺失阻断。
- `check-gate.sh fix-review 101` 通过，Android `assembleDebug` 为 `BUILD SUCCESSFUL`，质量门禁结果为 `quality gate: pass`。

## 剩余风险

- 未执行 Android/iOS 真机视觉回归；改动集中在共享状态派生、服务协程生命周期与回归测试。
- 当前 Linux 环境无法完成依赖桌面图形栈的全量 UI 测试；本轮相关非 UI 测试均已通过。
