### PR TITLE
perf(activity): 优化动态时间线查询与索引

### DIFF
--- a/composeApp/schemas/io.github.vrcmteam.vrcm.storage.VrcmDatabase/5.json
+++ b/composeApp/schemas/io.github.vrcmteam.vrcm.storage.VrcmDatabase/5.json
@@ -1,0 +1,451 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "bd029ff2b4e074cf9ce6afa61352a83b",
+    "entities": [
+      {
+        "tableName": "friend_activity_generations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ownerUserId` TEXT NOT NULL, `generation` INTEGER NOT NULL, PRIMARY KEY(`ownerUserId`))",
+        "fields": [
+          {
+            "fieldPath": "ownerUserId",
+            "columnName": "ownerUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generation",
+            "columnName": "generation",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "ownerUserId"
+          ]
+        }
+      },
+      {
+        "tableName": "friend_activity_summaries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ownerUserId` TEXT NOT NULL, `friendUserId` TEXT NOT NULL, `displayName` TEXT NOT NULL, `profileImageUrl` TEXT NOT NULL, `lastSeenTogetherAtMillis` INTEGER, `meetingCount` INTEGER NOT NULL, `togetherDurationMillis` INTEGER NOT NULL, `lastOnlineAtMillis` INTEGER, `lastOfflineAtMillis` INTEGER, `lastActivityAtMillis` INTEGER, PRIMARY KEY(`ownerUserId`, `friendUserId`), FOREIGN KEY(`ownerUserId`) REFERENCES `friend_activity_generations`(`ownerUserId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "ownerUserId",
+            "columnName": "ownerUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "friendUserId",
+            "columnName": "friendUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileImageUrl",
+            "columnName": "profileImageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenTogetherAtMillis",
+            "columnName": "lastSeenTogetherAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "meetingCount",
+            "columnName": "meetingCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "togetherDurationMillis",
+            "columnName": "togetherDurationMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOnlineAtMillis",
+            "columnName": "lastOnlineAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastOfflineAtMillis",
+            "columnName": "lastOfflineAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastActivityAtMillis",
+            "columnName": "lastActivityAtMillis",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "ownerUserId",
+            "friendUserId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_friend_activity_summaries_ownerUserId",
+            "unique": false,
+            "columnNames": [
+              "ownerUserId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_friend_activity_summaries_ownerUserId` ON `${TABLE_NAME}` (`ownerUserId`)"
+          },
+          {
+            "name": "index_friend_activity_summaries_ownerUserId_lastSeenTogetherAtMillis",
+            "unique": false,
+            "columnNames": [
+              "ownerUserId",
+              "lastSeenTogetherAtMillis"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_friend_activity_summaries_ownerUserId_lastSeenTogetherAtMillis` ON `${TABLE_NAME}` (`ownerUserId`, `lastSeenTogetherAtMillis`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "friend_activity_generations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "ownerUserId"
+            ],
+            "referencedColumns": [
+              "ownerUserId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "friend_activity_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerUserId` TEXT NOT NULL, `friendUserId` TEXT NOT NULL, `displayName` TEXT NOT NULL, `profileImageUrl` TEXT NOT NULL, `type` TEXT NOT NULL, `occurredAtMillis` INTEGER NOT NULL, `previousValue` TEXT, `currentValue` TEXT, `worldId` TEXT, `worldName` TEXT, `accessType` TEXT, FOREIGN KEY(`ownerUserId`) REFERENCES `friend_activity_generations`(`ownerUserId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerUserId",
+            "columnName": "ownerUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "friendUserId",
+            "columnName": "friendUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileImageUrl",
+            "columnName": "profileImageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAtMillis",
+            "columnName": "occurredAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "previousValue",
+            "columnName": "previousValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "currentValue",
+            "columnName": "currentValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "worldId",
+            "columnName": "worldId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "worldName",
+            "columnName": "worldName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accessType",
+            "columnName": "accessType",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_friend_activity_events_ownerUserId_occurredAtMillis_id",
+            "unique": false,
+            "columnNames": [
+              "ownerUserId",
+              "occurredAtMillis",
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_friend_activity_events_ownerUserId_occurredAtMillis_id` ON `${TABLE_NAME}` (`ownerUserId`, `occurredAtMillis`, `id`)"
+          },
+          {
+            "name": "index_friend_activity_events_ownerUserId_type_occurredAtMillis_id",
+            "unique": false,
+            "columnNames": [
+              "ownerUserId",
+              "type",
+              "occurredAtMillis",
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_friend_activity_events_ownerUserId_type_occurredAtMillis_id` ON `${TABLE_NAME}` (`ownerUserId`, `type`, `occurredAtMillis`, `id`)"
+          },
+          {
+            "name": "index_friend_activity_events_ownerUserId_friendUserId_occurredAtMillis",
+            "unique": false,
+            "columnNames": [
+              "ownerUserId",
+              "friendUserId",
+              "occurredAtMillis"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_friend_activity_events_ownerUserId_friendUserId_occurredAtMillis` ON `${TABLE_NAME}` (`ownerUserId`, `friendUserId`, `occurredAtMillis`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "friend_activity_generations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "ownerUserId"
+            ],
+            "referencedColumns": [
+              "ownerUserId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "friend_activity_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerUserId` TEXT NOT NULL, `friendUserId` TEXT NOT NULL, `displayName` TEXT NOT NULL, `profileImageUrl` TEXT NOT NULL, `startedAtMillis` INTEGER NOT NULL, `endedAtMillis` INTEGER, `durationMillis` INTEGER NOT NULL, `worldId` TEXT NOT NULL, `worldName` TEXT, `accessType` TEXT NOT NULL, `announced` INTEGER NOT NULL, FOREIGN KEY(`ownerUserId`) REFERENCES `friend_activity_generations`(`ownerUserId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerUserId",
+            "columnName": "ownerUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "friendUserId",
+            "columnName": "friendUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileImageUrl",
+            "columnName": "profileImageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAtMillis",
+            "columnName": "startedAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAtMillis",
+            "columnName": "endedAtMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationMillis",
+            "columnName": "durationMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "worldId",
+            "columnName": "worldId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "worldName",
+            "columnName": "worldName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accessType",
+            "columnName": "accessType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "announced",
+            "columnName": "announced",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_friend_activity_sessions_ownerUserId",
+            "unique": false,
+            "columnNames": [
+              "ownerUserId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_friend_activity_sessions_ownerUserId` ON `${TABLE_NAME}` (`ownerUserId`)"
+          },
+          {
+            "name": "index_friend_activity_sessions_ownerUserId_friendUserId_startedAtMillis",
+            "unique": false,
+            "columnNames": [
+              "ownerUserId",
+              "friendUserId",
+              "startedAtMillis"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_friend_activity_sessions_ownerUserId_friendUserId_startedAtMillis` ON `${TABLE_NAME}` (`ownerUserId`, `friendUserId`, `startedAtMillis`)"
+          },
+          {
+            "name": "index_friend_activity_sessions_ownerUserId_endedAtMillis",
+            "unique": false,
+            "columnNames": [
+              "ownerUserId",
+              "endedAtMillis"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_friend_activity_sessions_ownerUserId_endedAtMillis` ON `${TABLE_NAME}` (`ownerUserId`, `endedAtMillis`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "friend_activity_generations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "ownerUserId"
+            ],
+            "referencedColumns": [
+              "ownerUserId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cached_blobs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`scope` TEXT NOT NULL, `cacheKey` TEXT NOT NULL, `groupKey` TEXT NOT NULL, `payload` TEXT NOT NULL, `updatedAtMillis` INTEGER NOT NULL, PRIMARY KEY(`scope`, `cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupKey",
+            "columnName": "groupKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtMillis",
+            "columnName": "updatedAtMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "scope",
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_blobs_scope_groupKey_updatedAtMillis",
+            "unique": false,
+            "columnNames": [
+              "scope",
+              "groupKey",
+              "updatedAtMillis"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_blobs_scope_groupKey_updatedAtMillis` ON `${TABLE_NAME}` (`scope`, `groupKey`, `updatedAtMillis`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bd029ff2b4e074cf9ce6afa61352a83b')"
+    ]
+  }
+}

--- a/composeApp/src/commonMain/kotlin/presentation/screens/activity/FriendActivityTimelineModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/activity/FriendActivityTimelineModel.kt
@@ -65,6 +65,7 @@ internal interface FriendActivityTimelineSource {
         token: AccountSessionToken,
         types: Set<FriendActivityEventType>,
         cursor: FriendActivityTimelineCursor,
+        limit: Int,
     ): Flow<List<FriendActivityEvent>>
 }
 
@@ -98,11 +99,13 @@ private class ServiceFriendActivityTimelineSource(
         token: AccountSessionToken,
         types: Set<FriendActivityEventType>,
         cursor: FriendActivityTimelineCursor,
+        limit: Int,
     ) = service.observeAllEventsThrough(
         token = token,
         types = types,
         oldestOccurredAtMillis = cursor.occurredAtMillis,
         oldestId = cursor.id,
+        limit = limit,
     )
 }
 
@@ -122,7 +125,9 @@ class FriendActivityTimelineModel internal constructor(
     private var generation = 0L
     private var activeToken: AccountSessionToken? = null
     private var oldestCursor: FriendActivityTimelineCursor? = null
+    private var loadedRowCount = 0
     private var hasMore = false
+    private var snapshotRevision = 0L
     private var snapshotJob: Job? = null
     private var loadMoreJob: Job? = null
 
@@ -135,7 +140,9 @@ class FriendActivityTimelineModel internal constructor(
                 val currentGeneration = ++generation
                 activeToken = token
                 oldestCursor = null
+                loadedRowCount = 0
                 hasMore = false
+                snapshotRevision++
                 snapshotJob?.cancel()
                 loadMoreJob?.cancel()
                 if (token == null) {
@@ -156,6 +163,7 @@ class FriendActivityTimelineModel internal constructor(
                         }
 
                         val loaded = page.take(pageSize)
+                        loadedRowCount = loaded.size
                         oldestCursor = loaded.last().toCursor()
                         hasMore = page.size > pageSize
                         _state.value = FriendActivityTimelineState.Content(
@@ -202,15 +210,17 @@ class FriendActivityTimelineModel internal constructor(
                 ).first()
                 if (!isCurrent(currentGeneration, token, currentFilter)) return@launch
                 val loaded = page.take(pageSize)
-                hasMore = page.size > pageSize
                 if (loaded.isEmpty()) {
                     val latest = _state.value as? FriendActivityTimelineState.Content ?: return@launch
+                    if (cursor == oldestCursor) hasMore = false
                     _state.value = latest.copy(
-                        hasMore = false,
+                        hasMore = hasMore,
                         isLoadingMore = false,
                         loadMoreError = false,
                     )
                 } else {
+                    hasMore = page.size > pageSize
+                    loadedRowCount += loaded.size
                     oldestCursor = loaded.last().toCursor()
                     observeLoadedSnapshot(
                         currentGeneration,
@@ -244,18 +254,32 @@ class FriendActivityTimelineModel internal constructor(
         completesLoadMore: Boolean = false,
     ) {
         val cursor = oldestCursor ?: return
+        val visibleRowLimit = loadedRowCount
+        if (visibleRowLimit <= 0) return
+        val currentSnapshotRevision = ++snapshotRevision
         snapshotJob?.cancel()
         snapshotJob = viewModelScope.launch {
             var firstSnapshot = true
             try {
-                source.observeThrough(token, filter.eventTypes, cursor).collect { snapshot ->
-                    if (!isCurrent(currentGeneration, token, filter) || cursor != oldestCursor) {
+                // The extra raw row detects a head insertion that displaced the loaded tail before deduplication.
+                source.observeThrough(
+                    token = token,
+                    types = filter.eventTypes,
+                    cursor = cursor,
+                    limit = visibleRowLimit + 1,
+                ).collect { snapshot ->
+                    if (!isCurrent(currentGeneration, token, filter) ||
+                        currentSnapshotRevision != snapshotRevision
+                    ) {
                         return@collect
                     }
+                    val visibleRows = snapshot.take(visibleRowLimit)
                     val current = _state.value as? FriendActivityTimelineState.Content
                     if (snapshot.isEmpty()) hasMore = false
+                    if (snapshot.size > visibleRowLimit) hasMore = true
+                    oldestCursor = visibleRows.lastOrNull()?.toCursor()
                     _state.value = FriendActivityTimelineState.Content(
-                        events = snapshot.normalizeActivityEvents(),
+                        events = visibleRows.normalizeActivityEvents(),
                         hasMore = hasMore,
                         isLoadingMore = if (completesLoadMore && firstSnapshot) false else {
                             current?.isLoadingMore == true

--- a/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
@@ -342,12 +342,14 @@ class FriendActivityService internal constructor(
         types: Set<FriendActivityEventType> = emptySet(),
         oldestOccurredAtMillis: Long,
         oldestId: Long,
+        limit: Int,
     ): Flow<List<FriendActivityEvent>> =
         store.observeAllEventsThrough(
             ownerUserId = token.userId,
             types = types,
             oldestOccurredAtMillis = oldestOccurredAtMillis,
             oldestId = oldestId,
+            limit = limit,
         ).onEach { events ->
             if (SharedFlowCentre.isCurrentSession(token)) {
                 events.asSequence()

--- a/composeApp/src/commonMain/kotlin/storage/FriendActivityDao.kt
+++ b/composeApp/src/commonMain/kotlin/storage/FriendActivityDao.kt
@@ -126,12 +126,13 @@ internal interface FriendActivityDao {
             "WHERE ownerUserId = :ownerUserId AND " +
             "(occurredAtMillis > :oldestOccurredAtMillis OR " +
             "(occurredAtMillis = :oldestOccurredAtMillis AND id >= :oldestId)) " +
-            "ORDER BY occurredAtMillis DESC, id DESC"
+            "ORDER BY occurredAtMillis DESC, id DESC LIMIT :limit"
     )
     fun observeAllEventsThrough(
         ownerUserId: String,
         oldestOccurredAtMillis: Long,
         oldestId: Long,
+        limit: Int,
     ): Flow<List<FriendActivityEventEntity>>
 
     @Query(
@@ -139,13 +140,14 @@ internal interface FriendActivityDao {
             "WHERE ownerUserId = :ownerUserId AND type IN (:types) AND " +
             "(occurredAtMillis > :oldestOccurredAtMillis OR " +
             "(occurredAtMillis = :oldestOccurredAtMillis AND id >= :oldestId)) " +
-            "ORDER BY occurredAtMillis DESC, id DESC"
+            "ORDER BY occurredAtMillis DESC, id DESC LIMIT :limit"
     )
     fun observeAllEventsByTypesThrough(
         ownerUserId: String,
         types: List<String>,
         oldestOccurredAtMillis: Long,
         oldestId: Long,
+        limit: Int,
     ): Flow<List<FriendActivityEventEntity>>
 
     @Query(

--- a/composeApp/src/commonMain/kotlin/storage/FriendActivityEntities.kt
+++ b/composeApp/src/commonMain/kotlin/storage/FriendActivityEntities.kt
@@ -48,7 +48,8 @@ internal data class FriendActivitySummaryEntity(
         )
     ],
     indices = [
-        Index("ownerUserId"),
+        Index(value = ["ownerUserId", "occurredAtMillis", "id"]),
+        Index(value = ["ownerUserId", "type", "occurredAtMillis", "id"]),
         Index(value = ["ownerUserId", "friendUserId", "occurredAtMillis"]),
     ],
 )

--- a/composeApp/src/commonMain/kotlin/storage/RoomFriendActivityStore.kt
+++ b/composeApp/src/commonMain/kotlin/storage/RoomFriendActivityStore.kt
@@ -106,14 +106,21 @@ internal class RoomFriendActivityStore(
         types: Set<FriendActivityEventType> = emptySet(),
         oldestOccurredAtMillis: Long,
         oldestId: Long,
+        limit: Int,
     ): Flow<List<FriendActivityEventEntity>> = if (types.isEmpty()) {
-        dao.observeAllEventsThrough(ownerUserId, oldestOccurredAtMillis, oldestId)
+        dao.observeAllEventsThrough(
+            ownerUserId = ownerUserId,
+            oldestOccurredAtMillis = oldestOccurredAtMillis,
+            oldestId = oldestId,
+            limit = limit.coerceAtLeast(0),
+        )
     } else {
         dao.observeAllEventsByTypesThrough(
             ownerUserId = ownerUserId,
             types = types.map(FriendActivityEventType::name),
             oldestOccurredAtMillis = oldestOccurredAtMillis,
             oldestId = oldestId,
+            limit = limit.coerceAtLeast(0),
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/storage/VrcmDatabase.kt
+++ b/composeApp/src/commonMain/kotlin/storage/VrcmDatabase.kt
@@ -16,12 +16,13 @@ import androidx.room.RoomDatabaseConstructor
         FriendActivitySessionEntity::class,
         CachedBlobEntity::class,
     ],
-    version = 4,
+    version = 5,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
         // 3 引入过 user_profile_caches 专表，4 统一到 cached_blobs，专表删除。
         AutoMigration(from = 3, to = 4, spec = DropUserProfileCacheTable::class),
+        AutoMigration(from = 4, to = 5),
     ],
     exportSchema = true,
 )

--- a/composeApp/src/commonTest/kotlin/presentation/screens/activity/FriendActivityTimelineModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/activity/FriendActivityTimelineModelTest.kt
@@ -25,11 +25,12 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalCoroutinesApi::class)
 class FriendActivityTimelineModelTest : MainDispatcherTest() {
     @Test
-    fun newHeadEventsDoNotMoveTheAppendCursorOrDuplicateLoadedEvents() = runTest {
+    fun newHeadEventsKeepLoadedWindowBoundedAndMoveAppendCursorWithoutGaps() = runTest {
         val source = FakeTimelineSource(
             initialHead = listOf(event(5), event(4), event(3), event(2)),
         )
         source.appendResponses += flowOf(listOf(event(2), event(1)))
+        source.appendResponses += flowOf(listOf(event(1)))
         val model = FriendActivityTimelineModel(source, pageSize = 3)
         advanceUntilIdle()
 
@@ -43,9 +44,22 @@ class FriendActivityTimelineModelTest : MainDispatcherTest() {
         advanceUntilIdle()
 
         val loaded = assertIs<FriendActivityTimelineState.Content>(model.state.value)
-        assertEquals(listOf(6L, 5L, 4L, 3L, 2L, 1L), loaded.events.map(FriendActivityEvent::id))
-        assertFalse(loaded.hasMore)
-        assertEquals(FriendActivityTimelineCursor(3_000L, 3L), source.requestedCursors.single())
+        assertEquals(listOf(6L, 5L, 4L, 3L, 2L), loaded.events.map(FriendActivityEvent::id))
+        assertTrue(loaded.hasMore)
+
+        model.loadMore()
+        advanceUntilIdle()
+
+        val completed = assertIs<FriendActivityTimelineState.Content>(model.state.value)
+        assertEquals(listOf(6L, 5L, 4L, 3L, 2L, 1L), completed.events.map(FriendActivityEvent::id))
+        assertFalse(completed.hasMore)
+        assertEquals(
+            listOf(
+                FriendActivityTimelineCursor(3_000L, 3L),
+                FriendActivityTimelineCursor(2_000L, 2L),
+            ),
+            source.requestedCursors,
+        )
     }
 
     @Test
@@ -73,7 +87,7 @@ class FriendActivityTimelineModelTest : MainDispatcherTest() {
     }
 
     @Test
-    fun emptyAppendCompletionKeepsHeadEventsReceivedWhileLoading() = runTest {
+    fun emptyAppendFromStaleCursorKeepsTheDisplacedBoundaryLoadable() = runTest {
         val source = FakeTimelineSource(listOf(event(4), event(3), event(2)))
         val appendStarted = CompletableDeferred<Unit>()
         val releaseAppend = CompletableDeferred<Unit>()
@@ -82,6 +96,7 @@ class FriendActivityTimelineModelTest : MainDispatcherTest() {
             releaseAppend.await()
             emit(emptyList())
         }
+        source.appendResponses += flowOf(listOf(event(3), event(2)))
         val model = FriendActivityTimelineModel(source, pageSize = 2)
         advanceUntilIdle()
 
@@ -93,10 +108,17 @@ class FriendActivityTimelineModelTest : MainDispatcherTest() {
         advanceUntilIdle()
 
         val completed = assertIs<FriendActivityTimelineState.Content>(model.state.value)
-        assertEquals(listOf(5L, 4L, 3L), completed.events.map(FriendActivityEvent::id))
-        assertFalse(completed.hasMore)
+        assertEquals(listOf(5L, 4L), completed.events.map(FriendActivityEvent::id))
+        assertTrue(completed.hasMore)
         assertFalse(completed.isLoadingMore)
         assertFalse(completed.loadMoreError)
+
+        model.loadMore()
+        advanceUntilIdle()
+
+        val reloaded = assertIs<FriendActivityTimelineState.Content>(model.state.value)
+        assertEquals(listOf(5L, 4L, 3L, 2L), reloaded.events.map(FriendActivityEvent::id))
+        assertFalse(reloaded.hasMore)
     }
 
     @Test
@@ -124,7 +146,7 @@ class FriendActivityTimelineModelTest : MainDispatcherTest() {
             initialHead = listOf(event(4), event(3), event(2)),
         )
         source.appendResponses += flow { throw IllegalStateException("read failed") }
-        source.appendResponses += flowOf(listOf(event(1)))
+        source.appendResponses += flowOf(listOf(event(2), event(1)))
         val model = FriendActivityTimelineModel(source, pageSize = 2)
         advanceUntilIdle()
 
@@ -267,6 +289,7 @@ class FriendActivityTimelineModelTest : MainDispatcherTest() {
             token: AccountSessionToken,
             types: Set<FriendActivityEventType>,
             cursor: FriendActivityTimelineCursor,
+            limit: Int,
         ): Flow<List<FriendActivityEvent>> {
             requestedTokens += token
             return accountDatabases.getValue(token).map { events ->
@@ -274,7 +297,7 @@ class FriendActivityTimelineModelTest : MainDispatcherTest() {
                     (types.isEmpty() || event.type in types) &&
                         (event.occurredAtMillis > cursor.occurredAtMillis ||
                             (event.occurredAtMillis == cursor.occurredAtMillis && event.id >= cursor.id))
-                }
+                }.take(limit)
             }
         }
     }

--- a/composeApp/src/desktopTest/kotlin/storage/FriendActivityRoomStoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/storage/FriendActivityRoomStoreTest.kt
@@ -44,6 +44,122 @@ import kotlin.test.assertTrue
 
 class FriendActivityRoomStoreTest {
     @Test
+    fun filteredKeysetTimelineStaysCompleteAcrossDeepSameTimestampPagesAndHeadUpdates() = runTest {
+        withStore { store ->
+            val token = store.activateAccount("usr_owner")
+            val friend = observation()
+            val eventCount = 240
+            val pageSize = 17
+            val filterTypes = setOf(FriendActivityEventType.Online, FriendActivityEventType.Offline)
+            store.record(
+                token = token,
+                observations = listOf(friend),
+                batch = FriendActivityBatch(
+                    events = (1L..eventCount.toLong()).map { sequence ->
+                        FriendActivityEventDraft(
+                            userId = friend.userId,
+                            displayName = friend.displayName,
+                            profileImageUrl = friend.profileImageUrl,
+                            type = when ((sequence % 3L).toInt()) {
+                                0 -> FriendActivityEventType.Online
+                                1 -> FriendActivityEventType.Offline
+                                else -> FriendActivityEventType.LocationChanged
+                            },
+                            occurredAtMillis = sequence / 13L * 1_000L,
+                        )
+                    },
+                ),
+                nowMillis = 20_000L,
+            )
+
+            val expected = store.observeAllEvents(
+                ownerUserId = "usr_owner",
+                types = filterTypes,
+                limit = eventCount,
+            ).first()
+            val paged = mutableListOf<FriendActivityEventEntity>()
+            var cursor: FriendActivityEventEntity? = null
+            while (true) {
+                val page = cursor?.let { currentCursor ->
+                    store.observeAllEventsBefore(
+                        ownerUserId = "usr_owner",
+                        types = filterTypes,
+                        beforeOccurredAtMillis = currentCursor.occurredAtMillis,
+                        beforeId = currentCursor.id,
+                        limit = pageSize,
+                    ).first()
+                } ?: store.observeAllEvents(
+                    ownerUserId = "usr_owner",
+                    types = filterTypes,
+                    limit = pageSize,
+                ).first()
+                if (page.isEmpty()) break
+                paged += page
+                assertTrue(paged.size <= expected.size)
+                cursor = page.last()
+            }
+
+            assertEquals(expected.map { it.id }, paged.map { it.id })
+            assertEquals(paged.size, paged.map { it.id }.distinct().size)
+            assertTrue(paged.chunked(pageSize).zipWithNext().any { (newerPage, olderPage) ->
+                newerPage.last().occurredAtMillis == olderPage.first().occurredAtMillis
+            })
+
+            val loadedCount = pageSize * 6
+            val loaded = expected.take(loadedCount)
+            val oldest = loaded.last()
+            val snapshots = mutableListOf<List<FriendActivityEventEntity>>()
+            val initialSnapshotReceived = CompletableDeferred<Unit>()
+            val observationJob = launch {
+                store.observeAllEventsThrough(
+                    ownerUserId = "usr_owner",
+                    types = filterTypes,
+                    oldestOccurredAtMillis = oldest.occurredAtMillis,
+                    oldestId = oldest.id,
+                    limit = loadedCount,
+                ).onEach { initialSnapshotReceived.complete(Unit) }
+                    .take(2)
+                    .toList(snapshots)
+            }
+            initialSnapshotReceived.await()
+
+            store.record(
+                token = token,
+                observations = listOf(friend),
+                batch = FriendActivityBatch(
+                    events = listOf(
+                        FriendActivityEventDraft(
+                            userId = friend.userId,
+                            displayName = friend.displayName,
+                            profileImageUrl = friend.profileImageUrl,
+                            type = FriendActivityEventType.LocationChanged,
+                            occurredAtMillis = 99_000L,
+                        ),
+                        FriendActivityEventDraft(
+                            userId = friend.userId,
+                            displayName = friend.displayName,
+                            profileImageUrl = friend.profileImageUrl,
+                            type = FriendActivityEventType.Online,
+                            occurredAtMillis = 100_000L,
+                        ),
+                    ),
+                ),
+                nowMillis = 100_000L,
+            )
+            observationJob.join()
+
+            assertEquals(loaded.map { it.id }, snapshots.first().map { it.id })
+            assertEquals(loadedCount, snapshots.last().size)
+            assertEquals(100_000L, snapshots.last().first().occurredAtMillis)
+            assertTrue(snapshots.last().all { it.type in filterTypes.map(FriendActivityEventType::name) })
+            assertEquals(
+                snapshots.first().take(loadedCount - 1).map { it.id },
+                snapshots.last().drop(1).map { it.id },
+            )
+        }
+    }
+
+    @Test
     fun globalTimelineIsAccountScopedStablySortedAndFilterable() = runTest {
         withStore { store ->
             val ownerA = store.activateAccount("usr_owner_a")
@@ -169,6 +285,7 @@ class FriendActivityRoomStoreTest {
                     ownerUserId = "usr_owner_a",
                     oldestOccurredAtMillis = pageCursor.occurredAtMillis,
                     oldestId = pageCursor.id,
+                    limit = 3,
                 ).onEach { firstRangeObserved.complete(Unit) }
                     .take(2)
                     .toList(loadedRangeSnapshots)

--- a/composeApp/src/desktopTest/kotlin/storage/VrcmDatabaseMigrationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/storage/VrcmDatabaseMigrationTest.kt
@@ -1,0 +1,164 @@
+package io.github.vrcmteam.vrcm.storage
+
+import androidx.room.Room
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import androidx.sqlite.execSQL
+import io.github.vrcmteam.vrcm.service.FriendActivityEventType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import java.nio.file.Files
+import kotlin.io.path.absolutePathString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class VrcmDatabaseMigrationTest {
+    @Test
+    fun migrationFrom4To5PreservesEventsAndReplacesTimelineIndexes() = runTest {
+        val directory = Files.createTempDirectory("vrcm-migration-")
+        val databaseFile = directory.resolve("vrcm.db")
+        val expectedEvent = FriendActivityEventEntity(
+            id = 7L,
+            ownerUserId = "usr_owner",
+            friendUserId = "usr_friend",
+            displayName = "Friend",
+            profileImageUrl = "https://example.com/friend.png",
+            type = FriendActivityEventType.Online.name,
+            occurredAtMillis = 1_234_567L,
+            previousValue = "offline",
+            currentValue = "online",
+            worldId = "wrld_test",
+            worldName = "Test World",
+            accessType = "Public",
+        )
+
+        try {
+            createVersion4Database(databaseFile.absolutePathString(), expectedEvent)
+
+            val database = Room.databaseBuilder<VrcmDatabase>(name = databaseFile.absolutePathString())
+                .setDriver(BundledSQLiteDriver())
+                .setQueryCoroutineContext(Dispatchers.IO)
+                .build()
+            try {
+                assertEquals(
+                    listOf(expectedEvent),
+                    database.friendActivityDao().observeAllEvents(
+                        ownerUserId = expectedEvent.ownerUserId,
+                        limit = 10,
+                        offset = 0,
+                    ).first(),
+                )
+            } finally {
+                database.close()
+            }
+
+            BundledSQLiteDriver().open(databaseFile.absolutePathString()).use { connection ->
+                assertEquals(5L, connection.queryLong("PRAGMA user_version"))
+                assertEquals(
+                    mapOf(
+                        "index_friend_activity_events_ownerUserId_friendUserId_occurredAtMillis" to
+                            listOf("ownerUserId", "friendUserId", "occurredAtMillis"),
+                        "index_friend_activity_events_ownerUserId_occurredAtMillis_id" to
+                            listOf("ownerUserId", "occurredAtMillis", "id"),
+                        "index_friend_activity_events_ownerUserId_type_occurredAtMillis_id" to
+                            listOf("ownerUserId", "type", "occurredAtMillis", "id"),
+                    ),
+                    connection.friendActivityEventIndexes(),
+                )
+            }
+        } finally {
+            directory.toFile().deleteRecursively()
+        }
+    }
+
+    private fun createVersion4Database(
+        databasePath: String,
+        event: FriendActivityEventEntity,
+    ) {
+        BundledSQLiteDriver().open(databasePath).use { connection ->
+            connection.execSQL("PRAGMA foreign_keys = ON")
+            VERSION_4_SCHEMA.forEach(connection::execSQL)
+            connection.prepare(
+                "INSERT INTO friend_activity_generations (ownerUserId, generation) VALUES (?, ?)"
+            ).use { statement ->
+                statement.bindText(1, event.ownerUserId)
+                statement.bindLong(2, 3L)
+                statement.step()
+            }
+            connection.prepare(
+                "INSERT INTO friend_activity_events " +
+                    "(id, ownerUserId, friendUserId, displayName, profileImageUrl, type, occurredAtMillis, " +
+                    "previousValue, currentValue, worldId, worldName, accessType) " +
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            ).use { statement ->
+                statement.bindLong(1, event.id)
+                statement.bindText(2, event.ownerUserId)
+                statement.bindText(3, event.friendUserId)
+                statement.bindText(4, event.displayName)
+                statement.bindText(5, event.profileImageUrl)
+                statement.bindText(6, event.type)
+                statement.bindLong(7, event.occurredAtMillis)
+                statement.bindText(8, checkNotNull(event.previousValue))
+                statement.bindText(9, checkNotNull(event.currentValue))
+                statement.bindText(10, checkNotNull(event.worldId))
+                statement.bindText(11, checkNotNull(event.worldName))
+                statement.bindText(12, checkNotNull(event.accessType))
+                statement.step()
+            }
+            connection.execSQL(
+                "CREATE TABLE IF NOT EXISTS room_master_table " +
+                    "(id INTEGER PRIMARY KEY, identity_hash TEXT)"
+            )
+            connection.execSQL(
+                "INSERT OR REPLACE INTO room_master_table (id, identity_hash) " +
+                    "VALUES (42, '$VERSION_4_IDENTITY_HASH')"
+            )
+            connection.execSQL("PRAGMA user_version = 4")
+        }
+    }
+
+    private fun SQLiteConnection.queryLong(sql: String): Long = prepare(sql).use { statement ->
+        check(statement.step()) { "Query returned no rows: $sql" }
+        statement.getLong(0)
+    }
+
+    private fun SQLiteConnection.friendActivityEventIndexes(): Map<String, List<String>> {
+        val indexNames = prepare(
+            "SELECT name FROM sqlite_master " +
+                "WHERE type = 'index' AND tbl_name = 'friend_activity_events' " +
+                "AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        ).use { statement ->
+            buildList {
+                while (statement.step()) add(statement.getText(0))
+            }
+        }
+        return indexNames.associateWith { indexName ->
+            prepare("PRAGMA index_info(`$indexName`)").use { statement ->
+                buildList {
+                    while (statement.step()) add(statement.getText(2))
+                }
+            }
+        }
+    }
+
+    private companion object {
+        const val VERSION_4_IDENTITY_HASH = "a834f82f640fe40d4170f619f62ce48c"
+
+        val VERSION_4_SCHEMA = listOf(
+            """CREATE TABLE IF NOT EXISTS `friend_activity_generations` (`ownerUserId` TEXT NOT NULL, `generation` INTEGER NOT NULL, PRIMARY KEY(`ownerUserId`))""",
+            """CREATE TABLE IF NOT EXISTS `friend_activity_summaries` (`ownerUserId` TEXT NOT NULL, `friendUserId` TEXT NOT NULL, `displayName` TEXT NOT NULL, `profileImageUrl` TEXT NOT NULL, `lastSeenTogetherAtMillis` INTEGER, `meetingCount` INTEGER NOT NULL, `togetherDurationMillis` INTEGER NOT NULL, `lastOnlineAtMillis` INTEGER, `lastOfflineAtMillis` INTEGER, `lastActivityAtMillis` INTEGER, PRIMARY KEY(`ownerUserId`, `friendUserId`), FOREIGN KEY(`ownerUserId`) REFERENCES `friend_activity_generations`(`ownerUserId`) ON UPDATE NO ACTION ON DELETE CASCADE )""",
+            """CREATE INDEX IF NOT EXISTS `index_friend_activity_summaries_ownerUserId` ON `friend_activity_summaries` (`ownerUserId`)""",
+            """CREATE INDEX IF NOT EXISTS `index_friend_activity_summaries_ownerUserId_lastSeenTogetherAtMillis` ON `friend_activity_summaries` (`ownerUserId`, `lastSeenTogetherAtMillis`)""",
+            """CREATE TABLE IF NOT EXISTS `friend_activity_events` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerUserId` TEXT NOT NULL, `friendUserId` TEXT NOT NULL, `displayName` TEXT NOT NULL, `profileImageUrl` TEXT NOT NULL, `type` TEXT NOT NULL, `occurredAtMillis` INTEGER NOT NULL, `previousValue` TEXT, `currentValue` TEXT, `worldId` TEXT, `worldName` TEXT, `accessType` TEXT, FOREIGN KEY(`ownerUserId`) REFERENCES `friend_activity_generations`(`ownerUserId`) ON UPDATE NO ACTION ON DELETE CASCADE )""",
+            """CREATE INDEX IF NOT EXISTS `index_friend_activity_events_ownerUserId` ON `friend_activity_events` (`ownerUserId`)""",
+            """CREATE INDEX IF NOT EXISTS `index_friend_activity_events_ownerUserId_friendUserId_occurredAtMillis` ON `friend_activity_events` (`ownerUserId`, `friendUserId`, `occurredAtMillis`)""",
+            """CREATE TABLE IF NOT EXISTS `friend_activity_sessions` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerUserId` TEXT NOT NULL, `friendUserId` TEXT NOT NULL, `displayName` TEXT NOT NULL, `profileImageUrl` TEXT NOT NULL, `startedAtMillis` INTEGER NOT NULL, `endedAtMillis` INTEGER, `durationMillis` INTEGER NOT NULL, `worldId` TEXT NOT NULL, `worldName` TEXT, `accessType` TEXT NOT NULL, `announced` INTEGER NOT NULL, FOREIGN KEY(`ownerUserId`) REFERENCES `friend_activity_generations`(`ownerUserId`) ON UPDATE NO ACTION ON DELETE CASCADE )""",
+            """CREATE INDEX IF NOT EXISTS `index_friend_activity_sessions_ownerUserId` ON `friend_activity_sessions` (`ownerUserId`)""",
+            """CREATE INDEX IF NOT EXISTS `index_friend_activity_sessions_ownerUserId_friendUserId_startedAtMillis` ON `friend_activity_sessions` (`ownerUserId`, `friendUserId`, `startedAtMillis`)""",
+            """CREATE INDEX IF NOT EXISTS `index_friend_activity_sessions_ownerUserId_endedAtMillis` ON `friend_activity_sessions` (`ownerUserId`, `endedAtMillis`)""",
+            """CREATE TABLE IF NOT EXISTS `cached_blobs` (`scope` TEXT NOT NULL, `cacheKey` TEXT NOT NULL, `groupKey` TEXT NOT NULL, `payload` TEXT NOT NULL, `updatedAtMillis` INTEGER NOT NULL, PRIMARY KEY(`scope`, `cacheKey`))""",
+            """CREATE INDEX IF NOT EXISTS `index_cached_blobs_scope_groupKey_updatedAtMillis` ON `cached_blobs` (`scope`, `groupKey`, `updatedAtMillis`)""",
+        )
+    }
+}


### PR DESCRIPTION
## 概要

- 为好友动态表增加 `(ownerUserId, occurredAtMillis, id)` 和 `(ownerUserId, type, occurredAtMillis, id)` 复合索引，并加入 Room 4 -> 5 自动迁移及 KSP 生成 schema。
- 将已加载区间查询限制在可见行数，继续使用 `(occurredAtMillis, id)` keyset 游标，避免时间线增长后反复读取整个历史区间。
- 保留头部实时更新与深分页语义，并覆盖大量同时间戳记录、筛选分页和头部插入场景。

## 代码流程

```mermaid
flowchart TD
    A["sessionToken / selectFilter / retry"] --> B["combine.collectLatest：generation++<br/>清空游标与计数，snapshotRevision++<br/>取消 snapshotJob 与 loadMoreJob"]
    B --> C{"token 是否为空"}
    C -- "是" --> D["Content(emptyList, hasMore=false)"]
    C -- "否" --> E["Loading"]

    subgraph HEAD["首次加载与实时头部"]
        E --> F["observeHead(pageSize + 1)"]
        F --> G{"generation / token / filter<br/>是否仍为当前值"}
        G -- "否" --> STALE["拒绝旧回执"]
        G -- "是，空页" --> D
        G -- "是，有数据" --> H["取 pageSize 行<br/>设置 loadedRowCount、oldestCursor、hasMore"]
        H --> I["Content(events, hasMore,<br/>isLoadingMore=false, loadMoreError=false)"]
        F -- "首次内容前失败" --> J["Error"]
        J -- "retry" --> A
    end

    subgraph SNAPSHOT["已加载区间快照"]
        H --> K["snapshotRevision++，取消旧 snapshotJob<br/>observeThrough(oldestCursor, loadedRowCount + 1)"]
        K --> L{"generation / token / filter<br/>及 snapshotRevision 是否仍有效"}
        L -- "否" --> STALE
        L -- "是" --> M["只保留 loadedRowCount 行<br/>头部插入挤出尾行后推进 oldestCursor<br/>额外一行用于更新 hasMore"]
        M --> N["Content(events, hasMore,<br/>按首个分页快照结束 isLoadingMore，保留 loadMoreError)"]
    end

    subgraph PAGE["深分页与重试"]
        I --> O{"loadMore：hasMore=true<br/>且未加载、无分页错误"}
        N --> O
        O -- "否" --> P["保持当前 Content"]
        O -- "是" --> Q["Content(isLoadingMore=true, loadMoreError=false)"]
        Q --> R["observeBefore(oldestCursor, pageSize + 1).first()"]
        R --> S{"generation / token / filter<br/>是否仍为当前值"}
        S -- "否" --> STALE
        S -- "是，空页" --> T["Content(hasMore=false,<br/>isLoadingMore=false, loadMoreError=false)"]
        S -- "是，有数据" --> U["增加 loadedRowCount<br/>推进 oldestCursor"]
        U --> K
        R -- "失败" --> V["Content(isLoadingMore=false,<br/>loadMoreError=true)"]
        K -- "完成分页所需的首个快照失败" --> V
        V -- "retryLoadMore：清除错误后重试" --> O
    end
```

## 实现假设清单

- `(occurredAtMillis, id)` 能为同一账户内的事件提供稳定全序。
- `ownerUserId` 是数据库查询与索引的账户隔离边界。
- Room 自动迁移 4 -> 5 只新增索引，不改变已有事件数据。

## 测试结果

- `FriendActivityTimelineModelTest` 覆盖分页窗口、头部插入、重试与账户切换。
- `FriendActivityRoomStoreTest` 覆盖深层同时间戳 keyset 分页、筛选和实时快照。
- `VrcmDatabaseMigrationTest` 使用 Desktop 文件数据库按 v4 schema 建库并写入事件，再由当前 `VrcmDatabase` 打开；验证事件字段不变、版本升至 5、旧单列索引移除且两个新复合索引存在。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests 'io.github.vrcmteam.vrcm.storage.VrcmDatabaseMigrationTest' --tests 'io.github.vrcmteam.vrcm.storage.FriendActivityRoomStoreTest' --tests 'io.github.vrcmteam.vrcm.presentation.screens.activity.FriendActivityTimelineModelTest'` 通过。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:compileKotlinDesktop` 通过。
- 完整 `desktopTest` 共执行 782 项，唯一失败为无图形会话下 `DesktopWindowTitleBarLocaleTest.windowControlLabelsUseTheLatestLanguage` 的既有 `HeadlessException`，与本次数据库迁移改动无关。
- `git diff --check` 通过。

## 剩余风险

- 自动迁移已由 Desktop v4 文件数据库升级测试覆盖，尚未在 Android/iOS 的真实历史数据库上执行升级验证。
- 世界名称并发优化 PR 也会修改动态时间线相关文件；若其先合并，本分支需要基于最新 `newui` 重放。
