### PR TITLE
fix(favorites): 隔离好友目录刷新激活边界

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPager.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPager.kt
@@ -65,7 +65,7 @@ fun FriendsDirectoryContent(
     val refreshFailed by model.directoryRefreshFailed.collectAsState()
     val listState = rememberLazyListState()
 
-    LaunchedEffect(model) { model.refreshFriendDirectory() }
+    LaunchedEffect(model) { model.activateFriendDirectory() }
     LaunchedEffect(listState) {
         SharedFlowCentre.toPagerTop.collect {
             runCatching { listState.animateScrollToFirst() }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
@@ -157,7 +157,7 @@ class FriendListPagerModel(
     private var friendFilterJob: Job? = null
     private val offlineStatusDescriptions = mutableMapOf<String, String>()
 
-    private val _directoryRefreshing = MutableStateFlow(true)
+    private val _directoryRefreshing = MutableStateFlow(false)
     val directoryRefreshing = _directoryRefreshing.asStateFlow()
     private val _directoryRefreshFailed = MutableStateFlow(false)
     val directoryRefreshFailed = _directoryRefreshFailed.asStateFlow()
@@ -165,6 +165,7 @@ class FriendListPagerModel(
     private val refreshJobsByTab = mutableMapOf<Int, Job>()
     private var activeSessionToken: AccountSessionToken? = null
     private var accountGeneration = 0L
+    private var friendDirectoryActivated = false
     private var favoritesPageActivated = false
     private var favoriteLocale: LocaleStrings? = null
 
@@ -237,9 +238,9 @@ class FriendListPagerModel(
         }
         _refreshErrors.value = emptyMap()
         _refreshingTabs.value = emptySet()
-        _directoryRefreshing.value = sessionToken != null
+        _directoryRefreshing.value = sessionToken != null && friendDirectoryActivated
         _directoryRefreshFailed.value = false
-        if (sessionToken != null) refreshFriendDirectory()
+        if (sessionToken != null && friendDirectoryActivated) refreshFriendDirectory()
         if (sessionToken != null && favoritesPageActivated) refreshFavoritesTabs()
     }
 
@@ -251,6 +252,12 @@ class FriendListPagerModel(
     fun activateFavoritesPage() {
         favoritesPageActivated = true
         if (activeSessionToken != null) refreshFavoritesTabs()
+    }
+
+    /** Marks the friend directory as active and refreshes its friend-only data. */
+    fun activateFriendDirectory() {
+        friendDirectoryActivated = true
+        refreshFriendDirectory()
     }
 
     private fun refreshFavoritesTabs() {
@@ -387,13 +394,14 @@ class FriendListPagerModel(
 
     /** Refreshes only the friend snapshot and VRChat friend favorite groups. */
     fun refreshFriendDirectory() {
+        if (!friendDirectoryActivated) return
         if (directoryRefreshJob?.isActive == true) return
         val sessionToken = activeSessionToken ?: return
         val generation = accountGeneration
+        _directoryRefreshing.value = true
+        _directoryRefreshFailed.value = false
         directoryRefreshJob = viewModelScope.launch(Dispatchers.IO) {
             if (!acceptsAccount(sessionToken, generation)) return@launch
-            _directoryRefreshing.value = true
-            _directoryRefreshFailed.value = false
             var failed = false
             try {
                 if (favoriteService.loadFavoriteByGroup(Friend).isFailure) failed = true

--- a/composeApp/src/commonMain/kotlin/service/FavoriteService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FavoriteService.kt
@@ -41,6 +41,7 @@ class FavoriteService(
     private val favoriteLocalDao: FavoriteLocalDao,
 ) {
 
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val favoritesByGroupCache = FavoriteGroupCache()
     private var favoritesOwnerUserId: String? = SharedFlowCentre.currentSession.value?.token?.userId
     private var favoritesOwnerToken: io.github.vrcmteam.vrcm.core.shared.AccountSessionToken? =
@@ -52,7 +53,7 @@ class FavoriteService(
     private var _favoriteLimits: FavoriteLimits? = null
 
     init {
-        CoroutineScope(Dispatchers.Default).launch {
+        serviceScope.launch {
             SharedFlowCentre.currentSession.collect { session ->
                 val nextUserId = session?.token?.userId
                 cacheMutex.withLock {
@@ -76,7 +77,7 @@ class FavoriteService(
 
 
     init {
-        CoroutineScope(Job()).launch(Dispatchers.IO) {
+        serviceScope.launch(Dispatchers.IO) {
             loadFavoriteLimits()
         }
     }
@@ -259,4 +260,7 @@ class FavoriteService(
     fun getFavoriteByFavoriteId(favoriteType: FavoriteType, favoriteId: String): FavoriteData? =
         favoritesByGroup(favoriteType).value.values.flatten().firstOrNull { it.favoriteId == favoriteId }
 
+    internal fun dispose() {
+        serviceScope.cancel()
+    }
 }

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerFeatureActivationTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerFeatureActivationTest.kt
@@ -123,6 +123,7 @@ private class FeatureActivationFixture(
     val requests: FeatureRequestRecorder,
     val friendListsBeforeFeatures: Int,
     private val friendService: FriendService,
+    private val favoriteService: FavoriteService,
     private val client: HttpClient,
 ) {
     suspend fun awaitFavoritesRefresh() {
@@ -148,6 +149,7 @@ private class FeatureActivationFixture(
             clear()
         }
         friendService.dispose()
+        favoriteService.dispose()
         SharedFlowCentre.emitLogout()
         client.close()
     }
@@ -208,6 +210,7 @@ private suspend fun createFixture(): FeatureActivationFixture {
         requests = requests,
         friendListsBeforeFeatures = friendListsBeforeFeatures,
         friendService = friendService,
+        favoriteService = favoriteService,
         client = client,
     )
 }

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerFeatureActivationTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerFeatureActivationTest.kt
@@ -35,6 +35,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -116,6 +117,25 @@ class FriendListPagerFeatureActivationTest : MainDispatcherTest() {
             fixture.close()
         }
     }
+
+    @Test
+    fun repeatedDirectoryActivationKeepsSingleRefreshInFlight() = runBlocking {
+        val fixture = createFixture(blockFirstFriendFavoriteGroupRequest = true)
+        try {
+            fixture.model.activateFriendDirectory()
+            fixture.awaitFriendFavoriteGroupRequest()
+            val friendListsBeforeDirectoryRefresh = fixture.requests.friendLists
+
+            fixture.model.activateFriendDirectory()
+            fixture.releaseFriendFavoriteGroupRequest()
+            fixture.awaitFriendDirectoryRefresh()
+
+            assertEquals(1, fixture.requests.favoriteGroups(FavoriteType.Friend))
+            assertTrue(fixture.requests.friendLists > friendListsBeforeDirectoryRefresh)
+        } finally {
+            fixture.close()
+        }
+    }
 }
 
 private class FeatureActivationFixture(
@@ -143,7 +163,16 @@ private class FeatureActivationFixture(
         }
     }
 
+    suspend fun awaitFriendFavoriteGroupRequest() {
+        requests.awaitFriendFavoriteGroupRequest()
+    }
+
+    fun releaseFriendFavoriteGroupRequest() {
+        requests.releaseFriendFavoriteGroupRequest()
+    }
+
     suspend fun close() {
+        requests.releaseFriendFavoriteGroupRequest()
         ViewModelStore().apply {
             put("feature-activation", model)
             clear()
@@ -155,11 +184,13 @@ private class FeatureActivationFixture(
     }
 }
 
-private suspend fun createFixture(): FeatureActivationFixture {
+private suspend fun createFixture(
+    blockFirstFriendFavoriteGroupRequest: Boolean = false,
+): FeatureActivationFixture {
     SharedFlowCentre.emitLogout()
     val account = AccountDto(userId = "usr_a", username = "a")
     SharedFlowCentre.emitAuthenticated(account)
-    val requests = FeatureRequestRecorder()
+    val requests = FeatureRequestRecorder(blockFirstFriendFavoriteGroupRequest)
     val json = Json { ignoreUnknownKeys = true }
     val client = featureActivationClient(requests, json)
     val accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also {
@@ -215,24 +246,42 @@ private suspend fun createFixture(): FeatureActivationFixture {
     )
 }
 
-private class FeatureRequestRecorder {
+private class FeatureRequestRecorder(
+    private val blockFirstFriendFavoriteGroupRequest: Boolean,
+) {
     private val friendFavoriteGroups = atomic(0)
     private val worldFavoriteGroups = atomic(0)
     private val avatarFavoriteGroups = atomic(0)
     private val friendListRequests = atomic(0)
     private val worldListRequests = atomic(0)
     private val avatarListRequests = atomic(0)
+    private val firstFriendFavoriteGroupRequestStarted = CompletableDeferred<Unit>()
+    private val releaseFirstFriendFavoriteGroupRequest = CompletableDeferred<Unit>()
 
     val friendLists: Int get() = friendListRequests.value
     val worldLists: Int get() = worldListRequests.value
     val avatarLists: Int get() = avatarListRequests.value
 
-    fun recordFavoriteGroup(type: FavoriteType) {
+    suspend fun recordFavoriteGroup(type: FavoriteType) {
         when (type) {
-            FavoriteType.Friend -> friendFavoriteGroups.incrementAndGet()
+            FavoriteType.Friend -> {
+                val requestNumber = friendFavoriteGroups.incrementAndGet()
+                if (blockFirstFriendFavoriteGroupRequest && requestNumber == 1) {
+                    firstFriendFavoriteGroupRequestStarted.complete(Unit)
+                    releaseFirstFriendFavoriteGroupRequest.await()
+                }
+            }
             FavoriteType.World -> worldFavoriteGroups.incrementAndGet()
             FavoriteType.Avatar -> avatarFavoriteGroups.incrementAndGet()
         }
+    }
+
+    suspend fun awaitFriendFavoriteGroupRequest() {
+        withTimeout(3_000) { firstFriendFavoriteGroupRequestStarted.await() }
+    }
+
+    fun releaseFriendFavoriteGroupRequest() {
+        releaseFirstFriendFavoriteGroupRequest.complete(Unit)
     }
 
     fun recordFriendList() {

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerFeatureActivationTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerFeatureActivationTest.kt
@@ -1,0 +1,308 @@
+package io.github.vrcmteam.vrcm.presentation.screens.home.pager
+
+import androidx.lifecycle.ViewModelStore
+import com.russhwolf.settings.MapSettings
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
+import io.github.vrcmteam.vrcm.di.supports.PersistentCookiesStorage
+import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
+import io.github.vrcmteam.vrcm.network.api.auth.AuthApi
+import io.github.vrcmteam.vrcm.network.api.avatars.AvatarsApi
+import io.github.vrcmteam.vrcm.network.api.favorite.FavoriteApi
+import io.github.vrcmteam.vrcm.network.api.friends.FriendsApi
+import io.github.vrcmteam.vrcm.network.api.users.UsersApi
+import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
+import io.github.vrcmteam.vrcm.service.AuthService
+import io.github.vrcmteam.vrcm.service.FavoriteService
+import io.github.vrcmteam.vrcm.service.FriendService
+import io.github.vrcmteam.vrcm.service.data.AccountDto
+import io.github.vrcmteam.vrcm.storage.AccountCacheManager
+import io.github.vrcmteam.vrcm.storage.AccountDao
+import io.github.vrcmteam.vrcm.storage.FavoriteLocalDao
+import io.github.vrcmteam.vrcm.storage.InMemoryFavoriteListCacheStore
+import io.github.vrcmteam.vrcm.storage.InMemoryFriendListCacheStore
+import io.github.vrcmteam.vrcm.storage.InMemorySecureStorage
+import io.github.vrcmteam.vrcm.storage.InMemoryUserProfileCacheStore
+import io.github.vrcmteam.vrcm.storage.NoOpFriendActivityCacheStore
+import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardAssetStore
+import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardConfigDao
+import io.github.vrcmteam.vrcm.testing.MainDispatcherTest
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import kotlinx.serialization.json.Json
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.koin.core.logger.EmptyLogger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FriendListPagerFeatureActivationTest : MainDispatcherTest() {
+    @Test
+    fun favoritesDoNotRefreshFriendsUntilDirectoryIsActivated() = runBlocking {
+        val fixture = createFixture()
+        try {
+            fixture.model.activateFavoritesPage()
+            fixture.awaitFavoritesRefresh()
+
+            assertEquals(0, fixture.requests.favoriteGroups(FavoriteType.Friend))
+            assertEquals(fixture.friendListsBeforeFeatures, fixture.requests.friendLists)
+
+            fixture.model.activateFriendDirectory()
+            fixture.awaitFriendDirectoryRefresh()
+
+            assertEquals(1, fixture.requests.favoriteGroups(FavoriteType.Friend))
+            assertTrue(fixture.requests.friendLists > fixture.friendListsBeforeFeatures)
+        } finally {
+            fixture.close()
+        }
+    }
+
+    @Test
+    fun accountSwitchRestartsOnlyActivatedFeatures() = runBlocking {
+        val fixture = createFixture()
+        try {
+            fixture.model.activateFavoritesPage()
+            fixture.awaitFavoritesRefresh()
+            val worldGroupsBeforeSwitch = fixture.requests.favoriteGroups(FavoriteType.World)
+            val avatarGroupsBeforeSwitch = fixture.requests.favoriteGroups(FavoriteType.Avatar)
+            val worldsBeforeSwitch = fixture.requests.worldLists
+            val avatarsBeforeSwitch = fixture.requests.avatarLists
+
+            SharedFlowCentre.emitAuthenticated(AccountDto(userId = "usr_b", username = "b"))
+            awaitUntil {
+                fixture.requests.favoriteGroups(FavoriteType.World) > worldGroupsBeforeSwitch &&
+                    fixture.requests.favoriteGroups(FavoriteType.Avatar) > avatarGroupsBeforeSwitch &&
+                    fixture.requests.worldLists > worldsBeforeSwitch &&
+                    fixture.requests.avatarLists > avatarsBeforeSwitch &&
+                    1 !in fixture.model.refreshingTabs.value &&
+                    2 !in fixture.model.refreshingTabs.value &&
+                    !fixture.model.directoryRefreshing.value
+            }
+
+            assertEquals(0, fixture.requests.favoriteGroups(FavoriteType.Friend))
+
+            fixture.model.activateFriendDirectory()
+            fixture.awaitFriendDirectoryRefresh()
+            val friendGroupsBeforeSecondSwitch = fixture.requests.favoriteGroups(FavoriteType.Friend)
+            val worldGroupsBeforeSecondSwitch = fixture.requests.favoriteGroups(FavoriteType.World)
+            val avatarGroupsBeforeSecondSwitch = fixture.requests.favoriteGroups(FavoriteType.Avatar)
+            val worldsBeforeSecondSwitch = fixture.requests.worldLists
+            val avatarsBeforeSecondSwitch = fixture.requests.avatarLists
+
+            SharedFlowCentre.emitAuthenticated(AccountDto(userId = "usr_c", username = "c"))
+            awaitUntil {
+                fixture.requests.favoriteGroups(FavoriteType.Friend) > friendGroupsBeforeSecondSwitch &&
+                    fixture.requests.favoriteGroups(FavoriteType.World) > worldGroupsBeforeSecondSwitch &&
+                    fixture.requests.favoriteGroups(FavoriteType.Avatar) > avatarGroupsBeforeSecondSwitch &&
+                    fixture.requests.worldLists > worldsBeforeSecondSwitch &&
+                    fixture.requests.avatarLists > avatarsBeforeSecondSwitch &&
+                    1 !in fixture.model.refreshingTabs.value &&
+                    2 !in fixture.model.refreshingTabs.value &&
+                    !fixture.model.directoryRefreshing.value
+            }
+        } finally {
+            fixture.close()
+        }
+    }
+}
+
+private class FeatureActivationFixture(
+    val model: FriendListPagerModel,
+    val requests: FeatureRequestRecorder,
+    val friendListsBeforeFeatures: Int,
+    private val friendService: FriendService,
+    private val client: HttpClient,
+) {
+    suspend fun awaitFavoritesRefresh() {
+        awaitUntil {
+            requests.favoriteGroups(FavoriteType.World) > 0 &&
+                requests.favoriteGroups(FavoriteType.Avatar) > 0 &&
+                1 !in model.refreshingTabs.value &&
+                2 !in model.refreshingTabs.value &&
+                !model.directoryRefreshing.value
+        }
+    }
+
+    suspend fun awaitFriendDirectoryRefresh() {
+        awaitUntil {
+            requests.favoriteGroups(FavoriteType.Friend) > 0 &&
+                !model.directoryRefreshing.value
+        }
+    }
+
+    suspend fun close() {
+        ViewModelStore().apply {
+            put("feature-activation", model)
+            clear()
+        }
+        friendService.dispose()
+        SharedFlowCentre.emitLogout()
+        client.close()
+    }
+}
+
+private suspend fun createFixture(): FeatureActivationFixture {
+    SharedFlowCentre.emitLogout()
+    val account = AccountDto(userId = "usr_a", username = "a")
+    SharedFlowCentre.emitAuthenticated(account)
+    val requests = FeatureRequestRecorder()
+    val json = Json { ignoreUnknownKeys = true }
+    val client = featureActivationClient(requests, json)
+    val accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also {
+        it.saveAccountInfo(account)
+    }
+    val friendListCacheStore = InMemoryFriendListCacheStore()
+    val favoriteListCacheStore = InMemoryFavoriteListCacheStore()
+    val accountCacheManager = AccountCacheManager(
+        friendListCacheStore = friendListCacheStore,
+        userProfileCacheStore = InMemoryUserProfileCacheStore(),
+        friendActivityStore = NoOpFriendActivityCacheStore,
+        meetupCardConfigDao = MeetupCardConfigDao(MapSettings()),
+        meetupCardAssetStore = MeetupCardAssetStore(FakeFileSystem(), "/assets".toPath()),
+        favoriteListCacheStore = favoriteListCacheStore,
+    )
+    val authService = AuthService(
+        authApi = AuthApi(client),
+        accountDao = accountDao,
+        cookiesStorage = PersistentCookiesStorage(EmptyLogger()),
+        accountCacheManager = accountCacheManager,
+    )
+    val friendService = FriendService(
+        friendsApi = FriendsApi(client),
+        authService = authService,
+        json = json,
+        friendListCacheStore = friendListCacheStore,
+        accountCacheManager = accountCacheManager,
+        logger = EmptyLogger(),
+    )
+    awaitUntil { friendService.initialRefreshCompleted.value }
+    val friendListsBeforeFeatures = requests.friendLists
+    val favoriteService = FavoriteService(
+        favoriteApi = FavoriteApi(client),
+        favoriteLocalDao = FavoriteLocalDao(MapSettings()),
+    )
+    val model = FriendListPagerModel(
+        usersApi = UsersApi(client),
+        friendService = friendService,
+        authService = authService,
+        favoriteService = favoriteService,
+        worldsApi = WorldsApi(client),
+        avatarsApi = AvatarsApi(client),
+        favoriteListCacheStore = favoriteListCacheStore,
+        accountCacheManager = accountCacheManager,
+    )
+    return FeatureActivationFixture(
+        model = model,
+        requests = requests,
+        friendListsBeforeFeatures = friendListsBeforeFeatures,
+        friendService = friendService,
+        client = client,
+    )
+}
+
+private class FeatureRequestRecorder {
+    private val friendFavoriteGroups = atomic(0)
+    private val worldFavoriteGroups = atomic(0)
+    private val avatarFavoriteGroups = atomic(0)
+    private val friendListRequests = atomic(0)
+    private val worldListRequests = atomic(0)
+    private val avatarListRequests = atomic(0)
+
+    val friendLists: Int get() = friendListRequests.value
+    val worldLists: Int get() = worldListRequests.value
+    val avatarLists: Int get() = avatarListRequests.value
+
+    fun recordFavoriteGroup(type: FavoriteType) {
+        when (type) {
+            FavoriteType.Friend -> friendFavoriteGroups.incrementAndGet()
+            FavoriteType.World -> worldFavoriteGroups.incrementAndGet()
+            FavoriteType.Avatar -> avatarFavoriteGroups.incrementAndGet()
+        }
+    }
+
+    fun recordFriendList() {
+        friendListRequests.incrementAndGet()
+    }
+
+    fun recordWorldList() {
+        worldListRequests.incrementAndGet()
+    }
+
+    fun recordAvatarList() {
+        avatarListRequests.incrementAndGet()
+    }
+
+    fun favoriteGroups(type: FavoriteType): Int = when (type) {
+        FavoriteType.Friend -> friendFavoriteGroups.value
+        FavoriteType.World -> worldFavoriteGroups.value
+        FavoriteType.Avatar -> avatarFavoriteGroups.value
+    }
+}
+
+private fun featureActivationClient(
+    requests: FeatureRequestRecorder,
+    json: Json,
+) = HttpClient(MockEngine) {
+    engine {
+        addHandler { request ->
+            when (request.url.encodedPath) {
+                "/auth/user/friends" -> {
+                    requests.recordFriendList()
+                    jsonResponse("[]")
+                }
+                "/favorite/groups" -> {
+                    requests.recordFavoriteGroup(
+                        FavoriteType.entries.single { it.value == request.url.parameters["type"] },
+                    )
+                    jsonResponse("[]")
+                }
+                "/favorites" -> jsonResponse("[]")
+                "/worlds/favorites" -> {
+                    requests.recordWorldList()
+                    jsonResponse("[]")
+                }
+                "/avatars/favorites" -> {
+                    requests.recordAvatarList()
+                    jsonResponse("[]")
+                }
+                "/auth/user/favoritelimits" -> jsonResponse(FAVORITE_LIMITS_JSON)
+                "/auth/user" -> respond("unavailable", HttpStatusCode.InternalServerError)
+                else -> error("Unexpected request: ${request.url}")
+            }
+        }
+    }
+    install(ContentNegotiation) { json(json) }
+}
+
+private fun io.ktor.client.engine.mock.MockRequestHandleScope.jsonResponse(content: String) = respond(
+    content = content,
+    status = HttpStatusCode.OK,
+    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+)
+
+private suspend fun awaitUntil(predicate: () -> Boolean) {
+    withTimeout(3_000) {
+        while (!predicate()) yield()
+    }
+}
+
+private const val FAVORITE_LIMITS_JSON = """
+    {
+      "maxFavoriteGroups":{"avatar":4,"friend":3,"world":4},
+      "maxFavoritesPerGroup":{"avatar":100,"friend":100,"world":100},
+      "defaultMaxFavoriteGroups":4,
+      "defaultMaxFavoritesPerGroup":100
+    }
+"""

--- a/composeApp/src/commonTest/kotlin/service/FavoriteServiceSessionTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/FavoriteServiceSessionTest.kt
@@ -33,13 +33,15 @@ class FavoriteServiceSessionTest {
             favoritesRequestCount++
             error("Unexpected favorites request: $requestPath")
         }
+        val service = favoriteService(client)
         try {
-            val result = favoriteService(client).loadFavoriteByGroup(FavoriteType.World)
+            val result = service.loadFavoriteByGroup(FavoriteType.World)
 
             assertTrue(result.isFailure)
             assertEquals("No authenticated session", result.exceptionOrNull()?.message)
             assertEquals(0, favoritesRequestCount)
         } finally {
+            service.dispose()
             client.close()
             SharedFlowCentre.emitLogout()
         }
@@ -71,8 +73,8 @@ class FavoriteServiceSessionTest {
                 else -> error("Unexpected favorites request: $requestPath")
             }
         }
+        val service = favoriteService(client)
         try {
-            val service = favoriteService(client)
             val oldLoad = async(start = CoroutineStart.UNDISPATCHED) {
                 service.loadFavoriteByGroup(FavoriteType.World)
             }
@@ -97,6 +99,7 @@ class FavoriteServiceSessionTest {
                     .map { it.id },
             )
         } finally {
+            service.dispose()
             client.close()
             SharedFlowCentre.emitLogout()
         }
@@ -124,14 +127,15 @@ class FavoriteServiceSessionTest {
                 else -> error("Unexpected favorites request: $requestPath")
             }
         }
+        val service = favoriteService(client)
         try {
-            val service = favoriteService(client)
             assertTrue(service.loadFavoriteByGroup(FavoriteType.World).isSuccess)
             val previous = service.favoritesByGroup(FavoriteType.World).value
 
             assertTrue(service.loadFavoriteByGroup(FavoriteType.World).isFailure)
             assertEquals(previous, service.favoritesByGroup(FavoriteType.World).value)
         } finally {
+            service.dispose()
             client.close()
             SharedFlowCentre.emitLogout()
         }


### PR DESCRIPTION
## 概要

- 好友目录未进入组合树前不再自动发起好友与好友收藏组刷新。
- 新增幂等的 `activateFriendDirectory()`，把目录刷新绑定到页面首次激活；账户切换只恢复已经激活功能的数据。
- 收藏页激活继续只刷新世界和模型页签，避免共享 ViewModel 装配时触发无关请求。

## 代码流程

```mermaid
flowchart TD
    A["账户会话变化"] --> B{"功能是否已激活"}
    B -->|好友目录已激活| C["刷新好友与好友组"]
    B -->|收藏页已激活| D["刷新世界与模型"]
    B -->|均未激活| E["保持静默"]
    F["好友目录进入组合树"] --> G["activateFriendDirectory"]
    G --> C
```

## 实现假设

- `FriendsDirectoryContent` 进入组合树代表好友目录功能已被用户激活。
- 激活函数允许重复调用，但同一时间只保留一个目录刷新任务。
- 页面级激活状态应在当前 ViewModel 生命周期内保留，并在账户切换后按需重新加载。

## 实现假设清单

- 本节仅按评审前置检查要求同步上一节的现有假设，不新增或改写任何需求。
- 激活边界：`FriendsDirectoryContent` 进入组合树即视为好友目录已激活。
- 并发边界：激活可重复调用，同时只保留一个目录刷新任务。
- 生命周期边界：激活状态在当前 ViewModel 生命周期内保留，账户切换后只按需重新加载已激活功能。

## 代码逻辑图

```mermaid
flowchart TD
    A["FavoriteService 构造"] --> B["serviceScope: SupervisorJob + Dispatchers.Default"]
    B --> C["收集 SharedFlowCentre.currentSession"]
    B --> D["在 Dispatchers.IO 加载收藏限制"]
    E["FeatureActivationFixture.close"] --> F["清理 FriendListPagerModel"]
    F --> G["FriendService.dispose"]
    G --> H["FavoriteService.dispose"]
    H --> I["取消 serviceScope 及其子协程"]
```

## 测试结果

- `FriendListPagerFeatureActivationTest` 覆盖未激活静默、目录激活、收藏页激活、重复激活和账户切换。
- `./gradlew :composeApp:desktopTest :composeApp:compileKotlinDesktop` 通过。
- `git diff --check upstream/newui..HEAD` 通过。

## 剩余风险

- 未执行完整导航 UI 自动化；组合生命周期边界通过 ViewModel 行为测试保护。
- 其他好友目录优化 PR 也会修改 `FriendListPagerModel`，后合并的分支可能需要重放冲突。
