### PR TITLE
perf(home): 延迟创建好友动态时间线

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -212,6 +213,7 @@ private fun HomeDestinationContent(
 ) {
     val stateHolder = rememberSaveableStateHolder()
     val scope = rememberCoroutineScope()
+    var activityActivated by rememberSaveable { mutableStateOf(false) }
     val pagerState = rememberPagerState(
         initialPage = model.selectedHomeTabIndex,
         pageCount = { HomeTab.entries.size },
@@ -220,7 +222,10 @@ private fun HomeDestinationContent(
     LaunchedEffect(pagerState, model) {
         snapshotFlow { pagerState.settledPage }
             .distinctUntilChanged()
-            .collect { page -> model.selectHomeTab(HomeTab.entries[page]) }
+            .collect { page ->
+                model.selectHomeTab(HomeTab.entries[page])
+                if (page == HomeTab.Activity.ordinal) activityActivated = true
+            }
     }
     HorizontalPager(
         state = pagerState,
@@ -243,10 +248,15 @@ private fun HomeDestinationContent(
                         )
                     }
                 }
-                HomeTab.Activity -> FriendActivityTimelineDestination(
-                    hasBottomNavigation = hasBottomNavigation,
-                    headerContent = tabRow,
-                )
+                HomeTab.Activity -> if (activityActivated) {
+                    FriendActivityTimelineDestination(
+                        hasBottomNavigation = hasBottomNavigation,
+                        headerContent = tabRow,
+                        isActive = { pagerState.settledPage == HomeTab.Activity.ordinal },
+                    )
+                } else {
+                    ActivityTimelinePreview(headerContent = tabRow)
+                }
             }
         }
     }
@@ -285,16 +295,20 @@ private fun HomeTabRow(
 private fun FriendActivityTimelineDestination(
     hasBottomNavigation: Boolean,
     headerContent: @Composable () -> Unit,
+    isActive: () -> Boolean,
 ) {
     val model: FriendActivityTimelineModel = koinViewModel()
     val state by model.state.collectAsState()
     val filter by model.filter.collectAsState()
     val listState = rememberLazyListState()
     val navigator = currentNavigator
+    val currentIsActive by rememberUpdatedState(isActive)
 
     LaunchedEffect(listState) {
         SharedFlowCentre.toPagerTop.collect {
-            runCatching { listState.animateScrollToItem(0) }
+            if (currentIsActive()) {
+                launch { runCatching { listState.animateScrollToItem(0) } }
+            }
         }
     }
 
@@ -328,6 +342,13 @@ private fun FriendActivityTimelineDestination(
             )
             .padding(bottom = if (hasBottomNavigation) 80.dp else 0.dp),
     )
+}
+
+@Composable
+private fun ActivityTimelinePreview(headerContent: @Composable () -> Unit) {
+    Box(Modifier.fillMaxSize()) {
+        headerContent()
+    }
 }
 
 @OptIn(ExperimentalSharedTransitionApi::class)

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
@@ -75,9 +75,6 @@ object HomeScreen : AppListRoute {
         val navigator = currentNavigator
         val model: HomeScreenModel = koinViewModel()
         val notificationModel = koinInject<NotificationCenterModel>()
-        val timelineModel: FriendActivityTimelineModel = koinViewModel()
-        val timelineState by timelineModel.state.collectAsState()
-        val timelineFilter by timelineModel.filter.collectAsState()
         val stateHolder = rememberSaveableStateHolder()
         val scope = rememberCoroutineScope()
         val drawerState = rememberDrawerState(DrawerValue.Closed)
@@ -184,9 +181,6 @@ object HomeScreen : AppListRoute {
                                 when (selectedDestination) {
                                     HomeDestination.Home -> HomeDestinationContent(
                                         model,
-                                        timelineModel,
-                                        timelineState,
-                                        timelineFilter,
                                         hasBottomNavigation = !useRail && showMainNavigation,
                                     )
                                     HomeDestination.Search -> SearchListPager.Content()
@@ -211,24 +205,11 @@ object HomeScreen : AppListRoute {
 @Composable
 private fun HomeDestinationContent(
     model: HomeScreenModel,
-    timelineModel: FriendActivityTimelineModel,
-    timelineState: FriendActivityTimelineState,
-    timelineFilter: FriendActivityTimelineFilter,
     hasBottomNavigation: Boolean,
 ) {
     val selectedTab = HomeTab.entries[model.selectedHomeTabIndex]
     val stateHolder = rememberSaveableStateHolder()
-    val timelineListState = rememberLazyListState()
-    val navigator = currentNavigator
     val scope = rememberCoroutineScope()
-
-    if (selectedTab == HomeTab.Activity) {
-        LaunchedEffect(timelineListState) {
-            SharedFlowCentre.toPagerTop.collect {
-                runCatching { timelineListState.animateScrollToItem(0) }
-            }
-        }
-    }
 
     Column(Modifier.fillMaxSize()) {
         PrimaryTabRow(selectedTabIndex = selectedTab.ordinal) {
@@ -257,39 +238,56 @@ private fun HomeDestinationContent(
                             FriendLocationPager.Content()
                         }
                     }
-                    HomeTab.Activity -> FriendActivityTimelineContent(
-                        state = timelineState,
-                        filter = timelineFilter,
-                        onFilterSelected = timelineModel::selectFilter,
-                        onLoadMore = timelineModel::loadMore,
-                        onRetry = timelineModel::retry,
-                        onRetryLoadMore = timelineModel::retryLoadMore,
-                        onUserClick = { event ->
-                            navigator push UserProfileScreen(
-                                UserProfileVo(
-                                    id = event.friendUserId,
-                                    displayName = event.displayName,
-                                    profileImageUrl = event.profileImageUrl,
-                                )
-                            )
-                        },
-                        onWorldClick = { event ->
-                            val worldId = event.navigableWorldId() ?: return@FriendActivityTimelineContent
-                            navigator push WorldProfileScreen(
-                                WorldProfileVo(worldId = worldId, worldName = event.worldName.orEmpty())
-                            )
-                        },
-                        listState = timelineListState,
-                        modifier = Modifier
-                            .windowInsetsPadding(
-                                WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom),
-                            )
-                            .padding(bottom = if (hasBottomNavigation) 80.dp else 0.dp),
-                    )
+                    HomeTab.Activity -> FriendActivityTimelineDestination(hasBottomNavigation)
                 }
             }
         }
     }
+}
+
+@Composable
+private fun FriendActivityTimelineDestination(hasBottomNavigation: Boolean) {
+    val model: FriendActivityTimelineModel = koinViewModel()
+    val state by model.state.collectAsState()
+    val filter by model.filter.collectAsState()
+    val listState = rememberLazyListState()
+    val navigator = currentNavigator
+
+    LaunchedEffect(listState) {
+        SharedFlowCentre.toPagerTop.collect {
+            runCatching { listState.animateScrollToItem(0) }
+        }
+    }
+
+    FriendActivityTimelineContent(
+        state = state,
+        filter = filter,
+        onFilterSelected = model::selectFilter,
+        onLoadMore = model::loadMore,
+        onRetry = model::retry,
+        onRetryLoadMore = model::retryLoadMore,
+        onUserClick = { event ->
+            navigator push UserProfileScreen(
+                UserProfileVo(
+                    id = event.friendUserId,
+                    displayName = event.displayName,
+                    profileImageUrl = event.profileImageUrl,
+                )
+            )
+        },
+        onWorldClick = { event ->
+            val worldId = event.navigableWorldId() ?: return@FriendActivityTimelineContent
+            navigator push WorldProfileScreen(
+                WorldProfileVo(worldId = worldId, worldName = event.worldName.orEmpty())
+            )
+        },
+        listState = listState,
+        modifier = Modifier
+            .windowInsetsPadding(
+                WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom),
+            )
+            .padding(bottom = if (hasBottomNavigation) 80.dp else 0.dp),
+    )
 }
 
 @OptIn(ExperimentalSharedTransitionApi::class)

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
@@ -112,6 +112,7 @@ class FriendListPagerModelTest : MainDispatcherTest() {
             favoriteListCacheStore = favoriteListCacheStore,
             accountCacheManager = accountCacheManager,
         )
+        model.activateFriendDirectory()
 
         try {
             awaitUntil {


### PR DESCRIPTION
## 概要

- 将 `FriendActivityTimelineModel`、状态收集和列表滚动监听移入动态页签专属 Composable。
- 首页停留在位置页签或其他主导航目的地时，不再提前创建时间线 ViewModel 或启动数据库观察。
- 保留原有筛选、分页、跳转、返回顶部和底部导航间距行为。

## 代码流程

```mermaid
flowchart LR
    A["首页选择页签"] --> B{"是否为动态"}
    B -->|否| C["不创建时间线模型"]
    B -->|是| D["组合动态目的地"]
    D --> E["获取 ViewModel 并收集状态"]
    E --> F["渲染时间线与交互"]
```

## 代码逻辑图

```mermaid
flowchart LR
    A["HomeDestinationContent"] --> B["rememberSaveable activityActivated=false"]
    B --> C["HorizontalPager + SaveableStateProvider"]
    C --> D{"Activity 页是否稳定 settled"}
    D -->|否| E["ActivityTimelinePreview（仅页签头）"]
    D -->|是| F["activityActivated=true"]
    F --> G["FriendActivityTimelineDestination"]
    G --> H["koinViewModel<FriendActivityTimelineModel>"]
    H --> I["collect state/filter"]
    I --> J["FriendActivityTimelineContent 与交互"]
    K["SharedFlowCentre.toPagerTop"] --> L{"settledPage == Activity"}
    L -->|是| M["子协程 animateScrollToItem(0)"]
    L -->|否| N["忽略回顶事件"]
```

## 实现假设

- `HorizontalPager` 会按需组合当前或过渡中的首页页签，`SaveableStateProvider` 按页签保存对应状态。
- 动态页首次稳定到 `settledPage == Activity` 后才取得时间线 ViewModel；初始页为动态时由首个 settled 快照触发该激活。
- 动态页离开再返回时，已激活状态和现有导航保存机制继续复用原 ViewModel 与列表状态。

## 测试结果

- `./gradlew :composeApp:desktopTest :composeApp:compileKotlinDesktop` 为首次送审记录；本轮合并后 `FriendActivityTimelineModelTest` 定向测试通过。
- `./gradlew :composeApp:testDebugUnitTest` 通过。
- 完整 Desktop 套件 792 项中仅 `DesktopWindowTitleBarLocaleTest` 因 Linux 无图形环境抛出 `HeadlessException`；`FriendListPagerModelTest` 已在本轮修正并通过。
- `check-gate.sh fix-review 104` 输出 `BUILD SUCCESSFUL` 与 `quality gate: pass`。

## 剩余风险

- 未在 Android/iOS/Desktop 窗口中手工切换页签验证滚动位置与首次加载视觉过程。
- Linux 无图形环境下的 `DesktopWindowTitleBarLocaleTest` 仍需在有图形会话的环境验证。

## 实现假设清单

- `HorizontalPager` 过渡预组合阶段只显示 `ActivityTimelinePreview`，不会创建时间线 ViewModel；稳定选中动态页后才持有 `FriendActivityTimelineDestination`。
- `koinViewModel()` 首次创建发生在稳定动态页激活之后，并由 Home NavEntry 的 ViewModelStore 管理生命周期。
- `SharedFlowCentre.toPagerTop` 由动态页收集，但只有 `settledPage == Activity` 时才启动滚动子协程；手势取消不会终止长期收集。
- `SaveableStateProvider` 为每个页签保存列表状态，动态页离开再返回时继续复用已激活的模型与滚动位置。
