### PR TITLE
fix(profile): 合并并缓存用户资料补全请求

### DIFF
--- a/composeApp/src/commonMain/kotlin/di/modules/ServiceModule.kt
+++ b/composeApp/src/commonMain/kotlin/di/modules/ServiceModule.kt
@@ -26,6 +26,7 @@ import org.koin.dsl.module
 val serviceModule: Module = module {
     singleOf(::VersionService)
     singleOf(::AuthService) bind WebSocketSessionRecovery::class
+    single { UserProfileEnrichmentService(get()) }
     singleOf(::FavoriteService)
     singleOf(::FriendService)
     singleOf(::FriendActivityService)

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
@@ -16,7 +16,6 @@ import io.github.vrcmteam.vrcm.network.api.friends.date.FriendData
 import io.github.vrcmteam.vrcm.network.api.avatars.AvatarsApi
 import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
 import io.github.vrcmteam.vrcm.network.api.files.resolveOriginalImageUrl
-import io.github.vrcmteam.vrcm.network.api.users.UsersApi
 import io.github.vrcmteam.vrcm.network.api.users.data.UserData
 import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
 import io.github.vrcmteam.vrcm.network.api.worlds.data.FavoritedWorld
@@ -28,6 +27,7 @@ import io.github.vrcmteam.vrcm.presentation.screens.user.data.UserProfileVo
 import io.github.vrcmteam.vrcm.service.AuthService
 import io.github.vrcmteam.vrcm.service.FavoriteService
 import io.github.vrcmteam.vrcm.service.FriendService
+import io.github.vrcmteam.vrcm.service.UserProfileEnrichmentService
 import io.github.vrcmteam.vrcm.storage.AccountCacheManager
 import io.github.vrcmteam.vrcm.storage.AccountCacheWriteToken
 import io.github.vrcmteam.vrcm.storage.FavoriteListCacheStore
@@ -36,9 +36,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -65,7 +62,7 @@ data class AvatarGroupOptions(
 )
 
 class FriendListPagerModel(
-    private val usersApi: UsersApi,
+    private val userProfileEnrichmentService: UserProfileEnrichmentService,
     private val friendService: FriendService,
     private val authService: AuthService,
     private val favoriteService: FavoriteService,
@@ -581,10 +578,13 @@ class FriendListPagerModel(
         generation: Long,
     ): List<FriendData> {
 
-        val unFriendData = favoriteIds?.filterNot { friendService.friendMap.contains(it) }?.map {
-            withContext(Dispatchers.IO) { usersApi.fetchUser(it) }
-                .toFriendData()
-        } ?: emptyList()
+        val unFriendIds = favoriteIds
+            ?.filterNot { friendService.friendMap.contains(it) }
+            .orEmpty()
+        val unFriendProfiles = userProfileEnrichmentService.fetchProfiles(sessionToken, unFriendIds)
+        val unFriendData = unFriendIds.mapNotNull { userId ->
+            unFriendProfiles[userId]?.toFriendData()
+        }
 
         // 先按名称过滤
         val nameFilteredList = (friendService.friendMap.values + unFriendData).let { friends ->
@@ -616,22 +616,13 @@ class FriendListPagerModel(
         if (candidates.isEmpty()) return friends
 
         val missing = candidates.filterNot { offlineStatusDescriptions.containsKey(it.id) }
-        missing.chunked(8).forEach { batch ->
-            val fetched = coroutineScope {
-                batch.map { friend ->
-                    async {
-                        friend.id to runCatching {
-                            withContext(Dispatchers.IO) {
-                                usersApi.fetchUser(friend.id).statusDescription.trim()
-                            }
-                        }.getOrDefault("")
-                    }
-                }.awaitAll()
-            }
-            if (acceptsAccount(sessionToken, generation)) {
-                fetched.forEach { (id, description) ->
-                    offlineStatusDescriptions[id] = description
-                }
+        val profiles = userProfileEnrichmentService.fetchProfiles(
+            sessionToken = sessionToken,
+            userIds = missing.map { it.id },
+        )
+        if (acceptsAccount(sessionToken, generation)) {
+            profiles.forEach { (id, user) ->
+                offlineStatusDescriptions[id] = user.statusDescription.trim()
             }
         }
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/notification/NotificationCenterModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/notification/NotificationCenterModel.kt
@@ -28,6 +28,7 @@ import io.github.vrcmteam.vrcm.service.AuthService
 import io.github.vrcmteam.vrcm.service.BoopResult
 import io.github.vrcmteam.vrcm.service.BoopService
 import io.github.vrcmteam.vrcm.service.FriendService
+import io.github.vrcmteam.vrcm.service.UserProfileEnrichmentService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -45,6 +46,7 @@ import org.koin.core.logger.Logger
 class NotificationCenterModel(
     private val authService: AuthService,
     private val usersApi: UsersApi,
+    private val userProfileEnrichmentService: UserProfileEnrichmentService,
     private val notificationApi: NotificationApi,
     private val friendService: FriendService,
     private val logger: Logger,
@@ -123,7 +125,7 @@ class NotificationCenterModel(
         hasRefreshError = false
         try {
             val (friendRequestsResult, notificationsResult) = supervisorScope {
-                async { loadFriendRequests() } to async { loadNotifications() }
+                async { loadFriendRequests(token) } to async { loadNotifications() }
             }.let { (friendRequests, notifications) ->
                 friendRequests.await() to notifications.await()
             }
@@ -147,16 +149,22 @@ class NotificationCenterModel(
         }
     }
 
-    private suspend fun loadFriendRequests(): Result<List<NotificationItemData>> =
+    private suspend fun loadFriendRequests(
+        token: AccountSessionToken,
+    ): Result<List<NotificationItemData>> =
         authService.reTryAuthCatching {
             notificationApi.fetchNotificationsV2(NotificationType.FriendRequest.value)
         }.mapCatching { data ->
+            val usersById = userProfileEnrichmentService.fetchProfiles(
+                sessionToken = token,
+                userIds = data.map { it.senderUserId },
+            )
             data.map { notification ->
-                val user = usersApi.fetchUser(notification.senderUserId)
+                val user = usersById[notification.senderUserId]
                 NotificationItemData(
                     n = notification,
-                    imageUrl = user.profileImageUrl,
-                    title = user.displayName,
+                    imageUrl = user?.profileImageUrl.orEmpty(),
+                    title = user?.displayName ?: notification.senderUserId,
                     actions = listOf(
                         NotificationItemData.ActionData(data = "", type = "Hide"),
                         NotificationItemData.ActionData(data = "", type = "Accept"),

--- a/composeApp/src/commonMain/kotlin/service/UserProfileEnrichmentService.kt
+++ b/composeApp/src/commonMain/kotlin/service/UserProfileEnrichmentService.kt
@@ -1,0 +1,231 @@
+package io.github.vrcmteam.vrcm.service
+
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
+import io.github.vrcmteam.vrcm.network.api.users.UsersApi
+import io.github.vrcmteam.vrcm.network.api.users.data.UserData
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+/**
+ * Resolves user profiles through an account-bound cache with shared request deduplication.
+ * Ordinary profile failures are omitted from batch results and briefly cooled down.
+ */
+@OptIn(ExperimentalTime::class)
+class UserProfileEnrichmentService internal constructor(
+    private val fetchUser: suspend (String) -> UserData,
+    private val currentSessionToken: () -> AccountSessionToken?,
+    private val requestScope: CoroutineScope,
+    sessionTokens: Flow<AccountSessionToken?> = emptyFlow(),
+    maxConcurrentRequests: Int = DEFAULT_MAX_CONCURRENT_REQUESTS,
+    private val failureCooldownMillis: Long = DEFAULT_FAILURE_COOLDOWN_MILLIS,
+    private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+) {
+    constructor(usersApi: UsersApi) : this(
+        fetchUser = usersApi::fetchUser,
+        currentSessionToken = { SharedFlowCentre.currentSession.value?.token },
+        requestScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+        sessionTokens = SharedFlowCentre.currentSession
+            .map { session -> session?.token }
+            .distinctUntilChanged(),
+    )
+
+    private sealed interface CachedProfile {
+        data class Found(val user: UserData) : CachedProfile
+        data class Failed(val retryAtMillis: Long) : CachedProfile
+    }
+
+    private sealed interface ProfileLookup {
+        data class Cached(val user: UserData?) : ProfileLookup
+        data class Pending(val request: Deferred<UserData?>) : ProfileLookup
+        data object StaleSession : ProfileLookup
+    }
+
+    private sealed interface FetchOutcome {
+        data class Found(val user: UserData) : FetchOutcome
+        data object Failed : FetchOutcome
+    }
+
+    private data class InFlightRequest(
+        val id: Long,
+        val deferred: Deferred<UserData?>,
+    )
+
+    private val cacheMutex = Mutex()
+    private val requestSemaphore = Semaphore(maxConcurrentRequests)
+    private val cachedProfiles = mutableMapOf<String, CachedProfile>()
+    private val inFlightRequests = mutableMapOf<String, InFlightRequest>()
+    private var activeSessionToken: AccountSessionToken? = null
+    private var nextRequestId = 0L
+
+    init {
+        require(maxConcurrentRequests > 0)
+        require(failureCooldownMillis >= 0)
+        requestScope.launch {
+            sessionTokens.collect(::activateSession)
+        }
+    }
+
+    /** Returns every profile resolved for the supplied session; individual failures are omitted. */
+    suspend fun fetchProfiles(
+        sessionToken: AccountSessionToken,
+        userIds: Iterable<String>,
+    ): Map<String, UserData> = coroutineScope {
+        userIds.asSequence()
+            .map(String::trim)
+            .filter(String::isNotEmpty)
+            .distinct()
+            .map { userId ->
+                async { userId to fetchProfile(sessionToken, userId) }
+            }
+            .toList()
+            .awaitAll()
+            .mapNotNull { (userId, user) -> user?.let { userId to it } }
+            .toMap()
+    }
+
+    private suspend fun fetchProfile(
+        sessionToken: AccountSessionToken,
+        userId: String,
+    ): UserData? {
+        if (!isCurrentSession(sessionToken)) return null
+
+        var staleRequests = emptyList<Deferred<UserData?>>()
+        val lookup = cacheMutex.withLock {
+            if (!isCurrentSession(sessionToken)) return@withLock ProfileLookup.StaleSession
+            if (activeSessionToken != sessionToken) {
+                staleRequests = inFlightRequests.values.map(InFlightRequest::deferred)
+                inFlightRequests.clear()
+                cachedProfiles.clear()
+                activeSessionToken = sessionToken
+            }
+
+            when (val cached = cachedProfiles[userId]) {
+                is CachedProfile.Found -> ProfileLookup.Cached(cached.user)
+                is CachedProfile.Failed -> {
+                    if (nowMillis() < cached.retryAtMillis) {
+                        ProfileLookup.Cached(null)
+                    } else {
+                        cachedProfiles.remove(userId)
+                        pendingLookup(sessionToken, userId)
+                    }
+                }
+
+                null -> pendingLookup(sessionToken, userId)
+            }
+        }
+        staleRequests.forEach { request ->
+            request.cancel(CancellationException("User profile session changed"))
+        }
+
+        return when (lookup) {
+            is ProfileLookup.Cached -> lookup.user
+            is ProfileLookup.Pending -> lookup.request.await()
+            ProfileLookup.StaleSession -> null
+        }.takeIf { isCurrentSession(sessionToken) }
+    }
+
+    private fun pendingLookup(
+        sessionToken: AccountSessionToken,
+        userId: String,
+    ): ProfileLookup {
+        inFlightRequests[userId]?.let { return ProfileLookup.Pending(it.deferred) }
+
+        val requestId = ++nextRequestId
+        val request = requestScope.async(start = CoroutineStart.LAZY) {
+            executeFetch(sessionToken, userId, requestId)
+        }
+        inFlightRequests[userId] = InFlightRequest(requestId, request)
+        request.start()
+        return ProfileLookup.Pending(request)
+    }
+
+    private suspend fun executeFetch(
+        sessionToken: AccountSessionToken,
+        userId: String,
+        requestId: Long,
+    ): UserData? {
+        val outcome = try {
+            FetchOutcome.Found(
+                requestSemaphore.withPermit {
+                    if (!isCurrentSession(sessionToken)) {
+                        throw CancellationException("User profile session changed")
+                    }
+                    fetchUser(userId)
+                },
+            )
+        } catch (cancelled: CancellationException) {
+            discardRequest(userId, requestId)
+            throw cancelled
+        } catch (_: Exception) {
+            FetchOutcome.Failed
+        }
+
+        cacheMutex.withLock {
+            val currentRequest = inFlightRequests[userId]
+            if (currentRequest?.id == requestId) {
+                inFlightRequests.remove(userId)
+                if (activeSessionToken == sessionToken && isCurrentSession(sessionToken)) {
+                    cachedProfiles[userId] = when (outcome) {
+                        is FetchOutcome.Found -> CachedProfile.Found(outcome.user)
+                        FetchOutcome.Failed -> CachedProfile.Failed(
+                            retryAtMillis = nowMillis() + failureCooldownMillis,
+                        )
+                    }
+                }
+            }
+        }
+        return (outcome as? FetchOutcome.Found)?.user
+    }
+
+    private suspend fun activateSession(sessionToken: AccountSessionToken?) {
+        val staleRequests = cacheMutex.withLock {
+            if (currentSessionToken() != sessionToken) return
+            if (activeSessionToken == sessionToken) return
+            activeSessionToken = sessionToken
+            cachedProfiles.clear()
+            inFlightRequests.values.map(InFlightRequest::deferred).also {
+                inFlightRequests.clear()
+            }
+        }
+        staleRequests.forEach { request ->
+            request.cancel(CancellationException("User profile session changed"))
+        }
+    }
+
+    private suspend fun discardRequest(userId: String, requestId: Long) {
+        cacheMutex.withLock {
+            if (inFlightRequests[userId]?.id == requestId) {
+                inFlightRequests.remove(userId)
+            }
+        }
+    }
+
+    private fun isCurrentSession(sessionToken: AccountSessionToken): Boolean =
+        currentSessionToken() == sessionToken
+
+    private companion object {
+        const val DEFAULT_MAX_CONCURRENT_REQUESTS = 4
+        const val DEFAULT_FAILURE_COOLDOWN_MILLIS = 30_000L
+    }
+}

--- a/composeApp/src/commonMain/kotlin/service/UserProfileEnrichmentService.kt
+++ b/composeApp/src/commonMain/kotlin/service/UserProfileEnrichmentService.kt
@@ -42,9 +42,17 @@ class UserProfileEnrichmentService internal constructor(
     private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) {
     constructor(usersApi: UsersApi) : this(
+        usersApi = usersApi,
+        requestScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    )
+
+    internal constructor(
+        usersApi: UsersApi,
+        requestScope: CoroutineScope,
+    ) : this(
         fetchUser = usersApi::fetchUser,
         currentSessionToken = { SharedFlowCentre.currentSession.value?.token },
-        requestScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+        requestScope = requestScope,
         sessionTokens = SharedFlowCentre.currentSession
             .map { session -> session?.token }
             .distinctUntilChanged(),

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerFeatureActivationTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerFeatureActivationTest.kt
@@ -37,7 +37,11 @@ import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
@@ -145,6 +149,7 @@ private class FeatureActivationFixture(
     val friendListsBeforeFeatures: Int,
     private val friendService: FriendService,
     private val favoriteService: FavoriteService,
+    private val profileScope: CoroutineScope,
     private val client: HttpClient,
 ) {
     suspend fun awaitFavoritesRefresh() {
@@ -180,6 +185,7 @@ private class FeatureActivationFixture(
         }
         friendService.dispose()
         favoriteService.dispose()
+        profileScope.cancel()
         SharedFlowCentre.emitLogout()
         client.close()
     }
@@ -227,8 +233,9 @@ private suspend fun createFixture(
         favoriteApi = FavoriteApi(client),
         favoriteLocalDao = FavoriteLocalDao(MapSettings()),
     )
+    val profileScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     val model = FriendListPagerModel(
-        userProfileEnrichmentService = UserProfileEnrichmentService(UsersApi(client)),
+        userProfileEnrichmentService = UserProfileEnrichmentService(UsersApi(client), profileScope),
         friendService = friendService,
         authService = authService,
         favoriteService = favoriteService,
@@ -243,6 +250,7 @@ private suspend fun createFixture(
         friendListsBeforeFeatures = friendListsBeforeFeatures,
         friendService = friendService,
         favoriteService = favoriteService,
+        profileScope = profileScope,
         client = client,
     )
 }

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
@@ -43,8 +43,12 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
@@ -103,8 +107,9 @@ class FriendListPagerModelTest : MainDispatcherTest() {
             favoriteApi = FavoriteApi(client),
             favoriteLocalDao = FavoriteLocalDao(MapSettings()),
         )
+        val profileScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val model = FriendListPagerModel(
-            userProfileEnrichmentService = UserProfileEnrichmentService(UsersApi(client)),
+            userProfileEnrichmentService = UserProfileEnrichmentService(UsersApi(client), profileScope),
             friendService = friendService,
             authService = authService,
             favoriteService = favoriteService,
@@ -162,6 +167,7 @@ class FriendListPagerModelTest : MainDispatcherTest() {
 
             assertEquals(0, nonFriendProfileRequests)
         } finally {
+            profileScope.cancel()
             ViewModelStore().apply {
                 put("friend-list-pager", model)
                 clear()
@@ -223,8 +229,9 @@ class FriendListPagerModelTest : MainDispatcherTest() {
             favoriteApi = FavoriteApi(client),
             favoriteLocalDao = FavoriteLocalDao(MapSettings()),
         )
+        val profileScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val model = FriendListPagerModel(
-            userProfileEnrichmentService = UserProfileEnrichmentService(UsersApi(client)),
+            userProfileEnrichmentService = UserProfileEnrichmentService(UsersApi(client), profileScope),
             friendService = friendService,
             authService = authService,
             favoriteService = favoriteService,
@@ -278,6 +285,7 @@ class FriendListPagerModelTest : MainDispatcherTest() {
             )
             assertEquals("", model.friendDirectoryFriends.value.single().statusDescription)
         } finally {
+            profileScope.cancel()
             releaseAccountAProfile.complete(Unit)
             ViewModelStore().apply {
                 put("friend-list-pager", model)

--- a/composeApp/src/commonTest/kotlin/service/UserProfileEnrichmentServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/UserProfileEnrichmentServiceTest.kt
@@ -1,0 +1,168 @@
+package io.github.vrcmteam.vrcm.service
+
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+import io.github.vrcmteam.vrcm.network.api.attributes.AgeVerificationStatus
+import io.github.vrcmteam.vrcm.network.api.attributes.FriendRequestStatus
+import io.github.vrcmteam.vrcm.network.api.attributes.UserState
+import io.github.vrcmteam.vrcm.network.api.attributes.UserStatus
+import io.github.vrcmteam.vrcm.network.api.users.data.UserData
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UserProfileEnrichmentServiceTest {
+    @Test
+    fun concurrentDuplicateRequestsShareOneFetchAndReuseAccountCache() = runTest {
+        val token = AccountSessionToken("usr_account", 1)
+        val fetchStarted = CompletableDeferred<Unit>()
+        val releaseFetch = CompletableDeferred<Unit>()
+        var fetchCount = 0
+        val service = service(token) { userId ->
+            fetchCount++
+            fetchStarted.complete(Unit)
+            releaseFetch.await()
+            user(userId)
+        }
+
+        val requests = List(6) {
+            async { service.fetchProfiles(token, listOf("usr_target")) }
+        }
+        fetchStarted.await()
+        releaseFetch.complete(Unit)
+        val results = requests.awaitAll()
+        val cached = service.fetchProfiles(token, listOf("usr_target"))
+
+        assertEquals(1, fetchCount)
+        assertEquals(List(6) { setOf("usr_target") }, results.map { it.keys })
+        assertEquals("Target usr_target", cached.getValue("usr_target").displayName)
+    }
+
+    @Test
+    fun oneFailedProfileDoesNotDiscardSuccessfulProfilesOrImmediatelyRetry() = runTest {
+        val token = AccountSessionToken("usr_account", 1)
+        val requestCounts = mutableMapOf<String, Int>()
+        val service = service(token) { userId ->
+            requestCounts[userId] = requestCounts.getOrElse(userId) { 0 } + 1
+            if (userId == "usr_failed") error("profile unavailable")
+            user(userId)
+        }
+
+        val first = service.fetchProfiles(token, listOf("usr_ok", "usr_failed"))
+        val second = service.fetchProfiles(token, listOf("usr_ok", "usr_failed"))
+
+        assertEquals(setOf("usr_ok"), first.keys)
+        assertEquals(first, second)
+        assertEquals(mapOf("usr_ok" to 1, "usr_failed" to 1), requestCounts)
+    }
+
+    @Test
+    fun profileFetchesRespectConfiguredConcurrencyLimit() = runTest {
+        val token = AccountSessionToken("usr_account", 1)
+        val twoRequestsStarted = CompletableDeferred<Unit>()
+        val releaseFetches = CompletableDeferred<Unit>()
+        var activeRequests = 0
+        var maximumActiveRequests = 0
+        val service = service(token, maxConcurrentRequests = 2) { userId ->
+            activeRequests++
+            maximumActiveRequests = maxOf(maximumActiveRequests, activeRequests)
+            if (activeRequests == 2) twoRequestsStarted.complete(Unit)
+            releaseFetches.await()
+            activeRequests--
+            user(userId)
+        }
+
+        val request = async {
+            service.fetchProfiles(token, List(6) { "usr_$it" })
+        }
+        twoRequestsStarted.await()
+
+        assertEquals(2, maximumActiveRequests)
+        releaseFetches.complete(Unit)
+        assertEquals(6, request.await().size)
+        assertEquals(2, maximumActiveRequests)
+    }
+
+    @Test
+    fun switchingAccountInvalidatesCachedProfiles() = runTest {
+        val accountA = AccountSessionToken("usr_account_a", 1)
+        val accountB = AccountSessionToken("usr_account_b", 2)
+        val currentToken = MutableStateFlow<AccountSessionToken?>(accountA)
+        var fetchCount = 0
+        val service = UserProfileEnrichmentService(
+            fetchUser = { userId ->
+                fetchCount++
+                user(userId, displayName = "${currentToken.value?.userId}:$fetchCount")
+            },
+            currentSessionToken = { currentToken.value },
+            requestScope = backgroundScope,
+            sessionTokens = currentToken,
+        )
+
+        val accountAProfile = service.fetchProfiles(accountA, listOf("usr_target"))
+        currentToken.value = accountB
+        runCurrent()
+        val staleAccountResult = service.fetchProfiles(accountA, listOf("usr_target"))
+        val accountBProfile = service.fetchProfiles(accountB, listOf("usr_target"))
+
+        assertEquals("usr_account_a:1", accountAProfile.getValue("usr_target").displayName)
+        assertFalse(staleAccountResult.containsKey("usr_target"))
+        assertEquals("usr_account_b:2", accountBProfile.getValue("usr_target").displayName)
+        assertEquals(2, fetchCount)
+    }
+
+    private fun kotlinx.coroutines.test.TestScope.service(
+        token: AccountSessionToken,
+        maxConcurrentRequests: Int = 4,
+        fetchUser: suspend (String) -> UserData,
+    ) = UserProfileEnrichmentService(
+        fetchUser = fetchUser,
+        currentSessionToken = { token },
+        requestScope = backgroundScope,
+        maxConcurrentRequests = maxConcurrentRequests,
+    )
+
+    private fun user(
+        id: String,
+        displayName: String = "Target $id",
+    ) = UserData(
+        ageVerificationStatus = AgeVerificationStatus.Verified,
+        allowAvatarCopying = true,
+        bio = "",
+        bioLinks = emptyList(),
+        currentAvatarImageUrl = "",
+        currentAvatarTags = emptyList(),
+        currentAvatarThumbnailImageUrl = "",
+        dateJoined = "2020-01-01",
+        developerType = "none",
+        displayName = displayName,
+        friendKey = "",
+        friendRequestStatus = FriendRequestStatus.Null,
+        id = id,
+        instanceId = "",
+        isFriend = false,
+        lastActivity = "",
+        lastLogin = "",
+        lastPlatform = "standalonewindows",
+        location = "offline",
+        note = "",
+        profilePicOverride = "",
+        state = UserState.Offline,
+        status = UserStatus.Offline,
+        statusDescription = "",
+        tags = emptyList(),
+        travelingToInstance = null,
+        travelingToLocation = null,
+        travelingToWorld = null,
+        userIcon = "",
+        worldId = "",
+        pronouns = null,
+    )
+}


### PR DESCRIPTION
## 概要

- 新增账户绑定的 `UserProfileEnrichmentService`，在好友目录与通知中心之间共享用户资料补全结果。
- 对同一用户的并发请求执行 single-flight，限制最多 4 个远端请求并发，并对失败结果设置 30 秒冷却。
- 会话切换时取消旧请求并清空缓存，消费者只接收仍属于当前账户的结果。

## 代码流程

```mermaid
flowchart LR
    Session["SharedFlowCentre.currentSession"] -->|token 变化| Activate["UserProfileEnrichmentService.activateSession"]
    Activate --> Reset["清空 cachedProfiles/inFlightRequests\n更新 activeSessionToken"]
    Reset --> CancelOld["取消在途 Deferred"]

    FriendState["FriendService.friendState"] --> Friend["FriendListPagerModel.updateFriendSnapshot"]
    Friend -->|enrichOfflineStatusDescriptions| FetchProfiles["fetchProfiles(sessionToken, userIds)"]
    Friend --> Snapshot["写入账户绑定的 _friendSnapshot"]
    Snapshot --> Filter["搜索与收藏组过滤\n不触发远端资料请求"]
    Notice["NotificationCenterModel"] -->|loadFriendRequests(token)| FetchProfiles
    FetchProfiles --> Normalize["去空白并去重"]
    Normalize --> FetchProfile["fetchProfile(sessionToken, userId)"]
    FetchProfile --> Current{"isCurrentSession?"}
    Current -->|否| Stale["返回 null：stale 会话"]
    Current -->|是| SessionMatch{"activeSessionToken == sessionToken?"}
    SessionMatch -->|否| Reset
    SessionMatch -->|是| Lookup{"cachedProfiles / inFlightRequests"}
    Reset --> Lookup
    Lookup -->|Found| Found["返回缓存 UserData"]
    Lookup -->|Failed 且 retryAt 未到| Cooldown["30 秒冷却内省略该用户"]
    Lookup -->|缺失或 Failed 已过期| Pending["pendingLookup"]
    Pending --> Shared{"同一用户已有在途请求?"}
    Shared -->|是| Await["等待现有 Deferred"]
    Shared -->|否| Gate["requestSemaphore\n最多 4 个并发"]
    Gate --> API["UsersApi.fetchUser"]
    API -->|成功| StoreFound["移除 inFlight；缓存 Found"]
    API -->|普通异常| StoreFailed["移除 inFlight；缓存 Failed\nretryAt = now + 30 秒"]
    API -->|CancellationException| Discard["discardRequest；传播取消"]
    Found --> SessionCheck["takeIf isCurrentSession"]
    Cooldown --> SessionCheck
    Await --> SessionCheck
    StoreFound --> SessionCheck
    StoreFailed --> SessionCheck
    SessionCheck -->|仍是当前会话| Batch["awaitAll；mapNotNull 汇总结果"]
    SessionCheck -->|已过期| Stale
    CancelOld -->|Deferred 取消| Discard
```

## 实现假设

- 用户资料在单个账户会话内可以复用，会话变化后必须全部失效。
- 批量补全允许个别用户失败并从结果中省略，不应让整批 UI 数据失败。
- 30 秒失败冷却可以抑制短时故障下的请求风暴，同时保留后续恢复能力。

## 测试结果

- `UserProfileEnrichmentServiceTest` 覆盖 single-flight、并发上限、缓存、失败冷却、取消和账户切换。
- `./gradlew :composeApp:desktopTest :composeApp:compileKotlinDesktop` 通过。
- `git diff --check upstream/newui..HEAD` 通过。

## 剩余风险

- 成功缓存会增长到当前会话查询过的用户数量，并在账户切换时整体释放。
- 通知串行化及好友目录相关 PR 会触及相同调用方；若先合并，需要在最新 `newui` 上重放本分支。

## 实现假设清单

- 本轮没有新增未经验证的实现假设；上述缓存、single-flight、并发上限、失败冷却和会话切换约束保持不变。

## 最新基线同步

- `81a3d56` 已同步 `newui@1bd61fd`，共享资料补全接入账户绑定的好友快照；搜索和收藏组筛选继续只消费快照，不为非好友收藏发起资料请求。
- `UserProfileEnrichmentServiceTest`、`FriendListPagerModelTest`、`FriendListPagerFeatureActivationTest` 和 `NotificationCenterStateStoreTest` 定向测试通过。
- 完整 `desktopTest` 共执行 800 项；仅 `DesktopWindowTitleBarLocaleTest.windowControlLabelsUseTheLatestLanguage` 在 Linux 无图形环境因 `HeadlessException` 失败，其余 799 项通过。
- `check-gate.sh fix-review 105` 执行 `assembleDebug` 成功，结果为 `quality gate: pass`。

## 测试作用域收尾

- `5684ed0` 为好友目录三个测试 fixture 注入显式可取消的 `SupervisorJob` scope，并在 `finally/close()` 中取消；生产构造器仍保留独立 IO scope，测试结束不会遗留 `currentSession` 收集器。
