### PR TITLE
fix(activity): 合并世界名称并发解析请求

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/screens/activity/FriendActivityTimelineModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/activity/FriendActivityTimelineModel.kt
@@ -146,13 +146,12 @@ class FriendActivityTimelineModel internal constructor(
                 _state.value = FriendActivityTimelineState.Loading
                 var emittedContent = false
                 try {
-                    source.observeHead(token, filter.eventTypes, pageSize + 1).collect { page ->
-                        if (!isCurrent(currentGeneration, token, filter)) return@collect
-                        if (oldestCursor != null) return@collect
+                    source.observeHead(token, filter.eventTypes, pageSize + 1).first { page ->
+                        if (!isCurrent(currentGeneration, token, filter)) return@first false
                         emittedContent = true
                         if (page.isEmpty()) {
                             _state.value = FriendActivityTimelineState.Content(emptyList(), hasMore = false)
-                            return@collect
+                            return@first false
                         }
 
                         val loaded = page.take(pageSize)
@@ -163,6 +162,7 @@ class FriendActivityTimelineModel internal constructor(
                             hasMore = hasMore,
                         )
                         observeLoadedSnapshot(currentGeneration, token, filter)
+                        true
                     }
                 } catch (error: CancellationException) {
                     throw error

--- a/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendActivityService.kt
@@ -394,15 +394,14 @@ class FriendActivityService internal constructor(
     }
 
     private fun resolveWorldName(ownerUserId: String, worldId: String) {
-        serviceScope.launch {
-            try {
-                worldNameResolver.resolve(ownerUserId, worldId)
-            } catch (error: CancellationException) {
-                throw error
-            } catch (error: Throwable) {
+        worldNameResolver.request(
+            scope = serviceScope,
+            ownerUserId = ownerUserId,
+            worldId = worldId,
+            onFailure = { error ->
                 logger.error("Friend activity world lookup failed for $worldId: ${error.message}")
-            }
-        }
+            },
+        )
     }
 
     private companion object {

--- a/composeApp/src/commonMain/kotlin/service/FriendActivityWorldNameResolver.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendActivityWorldNameResolver.kt
@@ -1,46 +1,142 @@
 package io.github.vrcmteam.vrcm.service
 
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 
 internal class FriendActivityWorldNameResolver(
     private val readCachedName: suspend (ownerUserId: String, worldId: String) -> String?,
     private val fetchWorldName: suspend (worldId: String) -> String,
     private val cacheWorldName: suspend (ownerUserId: String, worldId: String, worldName: String) -> Unit,
     private val nowMillis: () -> Long,
+    maxConcurrentFetches: Int = DEFAULT_MAX_CONCURRENT_FETCHES,
 ) {
     private data class WorldKey(
         val ownerUserId: String,
         val worldId: String,
     )
 
-    private val mutex = Mutex()
+    private data class ResolutionFlight(
+        val startedAtMillis: Long,
+        val completion: CompletableDeferred<Unit> = CompletableDeferred(),
+    )
+
+    private data class ResolutionClaim(
+        val flight: ResolutionFlight,
+        val ownsFlight: Boolean,
+    )
+
+    private val lock = SynchronizedObject()
+    private val fetchSemaphore = Semaphore(maxConcurrentFetches)
+    private val inFlightByWorld = mutableMapOf<WorldKey, ResolutionFlight>()
     private val retryAtMillisByWorld = mutableMapOf<WorldKey, Long>()
+
+    init {
+        require(maxConcurrentFetches > 0) { "maxConcurrentFetches must be positive" }
+    }
 
     suspend fun resolve(ownerUserId: String, worldId: String) {
         val key = WorldKey(ownerUserId, worldId)
-        mutex.lock()
-        try {
-            val now = nowMillis()
-            if (now < (retryAtMillisByWorld[key] ?: Long.MIN_VALUE)) return
+        val claim = claimResolution(key) ?: return
+        if (!claim.ownsFlight) {
+            claim.flight.completion.await()
+            return
+        }
+        resolveClaimed(key, claim.flight)
+    }
 
+    fun request(
+        scope: CoroutineScope,
+        ownerUserId: String,
+        worldId: String,
+        onFailure: (Throwable) -> Unit,
+    ) {
+        val key = WorldKey(ownerUserId, worldId)
+        val claim = claimResolution(key) ?: return
+        if (!claim.ownsFlight) return
+
+        val job = scope.launch(start = CoroutineStart.LAZY) {
             try {
-                val worldName = readCachedName(ownerUserId, worldId)
-                    ?: fetchWorldName(worldId).also { require(it.isNotBlank()) }
-                cacheWorldName(ownerUserId, worldId, worldName)
-                retryAtMillisByWorld.remove(key)
+                resolveClaimed(key, claim.flight)
             } catch (error: CancellationException) {
                 throw error
             } catch (error: Throwable) {
-                retryAtMillisByWorld[key] = now + FAILURE_COOLDOWN_MILLIS
-                throw error
+                onFailure(error)
             }
+        }
+        job.invokeOnCompletion { error ->
+            if (error != null) completeResolution(key, claim.flight, error)
+        }
+        job.start()
+    }
+
+    private fun claimResolution(key: WorldKey): ResolutionClaim? = synchronized(lock) {
+        inFlightByWorld[key]?.let { current ->
+            return@synchronized ResolutionClaim(current, ownsFlight = false)
+        }
+        val now = nowMillis()
+        if (now < (retryAtMillisByWorld[key] ?: Long.MIN_VALUE)) return@synchronized null
+
+        val flight = ResolutionFlight(startedAtMillis = now)
+        inFlightByWorld[key] = flight
+        ResolutionClaim(flight, ownsFlight = true)
+    }
+
+    private suspend fun resolveClaimed(key: WorldKey, flight: ResolutionFlight) {
+        var failure: Throwable? = null
+        try {
+            val worldName = readCachedName(key.ownerUserId, key.worldId)
+                ?: fetchSemaphore.withPermit {
+                    fetchWorldName(key.worldId).also { require(it.isNotBlank()) }
+                }
+            cacheWorldName(key.ownerUserId, key.worldId, worldName)
+        } catch (error: CancellationException) {
+            failure = error
+            throw error
+        } catch (error: Throwable) {
+            failure = error
+            throw error
         } finally {
-            mutex.unlock()
+            completeResolution(key, flight, failure)
+        }
+    }
+
+    private fun completeResolution(
+        key: WorldKey,
+        flight: ResolutionFlight,
+        failure: Throwable?,
+    ) {
+        val shouldComplete = synchronized(lock) {
+            if (inFlightByWorld[key] !== flight) return@synchronized false
+
+            when (failure) {
+                null -> retryAtMillisByWorld.remove(key)
+                is CancellationException -> Unit
+                else -> retryAtMillisByWorld[key] =
+                    flight.startedAtMillis + FAILURE_COOLDOWN_MILLIS
+            }
+            true
+        }
+        if (!shouldComplete) return
+
+        if (failure == null) {
+            flight.completion.complete(Unit)
+        } else {
+            flight.completion.completeExceptionally(failure)
+        }
+        synchronized(lock) {
+            if (inFlightByWorld[key] === flight) inFlightByWorld.remove(key)
         }
     }
 
     private companion object {
         const val FAILURE_COOLDOWN_MILLIS = 60_000L
+        const val DEFAULT_MAX_CONCURRENT_FETCHES = 4
     }
 }

--- a/composeApp/src/commonTest/kotlin/presentation/screens/activity/FriendActivityTimelineModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/activity/FriendActivityTimelineModelTest.kt
@@ -73,6 +73,25 @@ class FriendActivityTimelineModelTest : MainDispatcherTest() {
     }
 
     @Test
+    fun loadedSnapshotReplacesTheInitialHeadCollector() = runTest {
+        val source = FakeTimelineSource(listOf(event(3), event(2), event(1)))
+        val model = FriendActivityTimelineModel(source, pageSize = 2)
+        advanceUntilIdle()
+        assertEquals(1, source.headEmissionCount)
+
+        repeat(5) { index ->
+            source.database.value = listOf(event(4L + index)) + source.database.value
+            advanceUntilIdle()
+        }
+
+        assertEquals(1, source.headEmissionCount)
+        assertEquals(
+            8L,
+            assertIs<FriendActivityTimelineState.Content>(model.state.value).events.first().id,
+        )
+    }
+
+    @Test
     fun emptyAppendCompletionKeepsHeadEventsReceivedWhileLoading() = runTest {
         val source = FakeTimelineSource(listOf(event(4), event(3), event(2)))
         val appendStarted = CompletableDeferred<Unit>()
@@ -224,6 +243,7 @@ class FriendActivityTimelineModelTest : MainDispatcherTest() {
         val appendResponses = ArrayDeque<Flow<List<FriendActivityEvent>>>()
         val requestedCursors = mutableListOf<FriendActivityTimelineCursor>()
         val requestedTokens = mutableListOf<AccountSessionToken>()
+        var headEmissionCount = 0
 
         override fun observeHead(
             token: AccountSessionToken,
@@ -233,7 +253,7 @@ class FriendActivityTimelineModelTest : MainDispatcherTest() {
             requestedTokens += token
             val accountDatabase = accountDatabases.getValue(token)
             val overridden = filteredHeads[types]
-            return if (overridden != null) {
+            val source = if (overridden != null) {
                 overridden.onEach { page ->
                     accountDatabase.value = if (types.isEmpty()) {
                         page
@@ -247,6 +267,7 @@ class FriendActivityTimelineModelTest : MainDispatcherTest() {
                     events.filter { types.isEmpty() || it.type in types }.take(limit)
                 }
             }
+            return source.onEach { headEmissionCount++ }
         }
 
         override fun observeBefore(

--- a/composeApp/src/commonTest/kotlin/service/FriendActivityWorldNameResolverTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/FriendActivityWorldNameResolverTest.kt
@@ -1,47 +1,134 @@
 package io.github.vrcmteam.vrcm.service
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class FriendActivityWorldNameResolverTest {
     @Test
-    fun concurrentResolutionFetchesWorldOnlyOnce() = runTest {
-        var cachedName: String? = null
+    fun concurrentResolutionForTheSameKeySharesOneRequest() = runTest {
         var fetchCount = 0
+        val fetchStarted = CompletableDeferred<Unit>()
+        val releaseFetch = CompletableDeferred<Unit>()
+        val cacheWrites = mutableListOf<Triple<String, String, String>>()
         val resolver = FriendActivityWorldNameResolver(
-            readCachedName = { _, _ -> cachedName },
+            readCachedName = { _, _ -> null },
             fetchWorldName = {
                 fetchCount += 1
+                fetchStarted.complete(Unit)
+                releaseFetch.await()
                 "The Black Cat"
             },
-            cacheWorldName = { _, _, worldName -> cachedName = worldName },
+            cacheWorldName = { ownerUserId, worldId, worldName ->
+                cacheWrites += Triple(ownerUserId, worldId, worldName)
+            },
             nowMillis = { 1_000L },
         )
 
-        listOf(
-            async { resolver.resolve("usr_owner", "wrld_world") },
-            async { resolver.resolve("usr_owner", "wrld_world") },
-        ).awaitAll()
+        val resolutions = List(20) {
+            async { resolver.resolve("usr_owner", "wrld_world") }
+        }
+        fetchStarted.await()
+        runCurrent()
+        assertEquals(1, fetchCount)
+
+        releaseFetch.complete(Unit)
+        resolutions.awaitAll()
 
         assertEquals(1, fetchCount)
-        assertEquals("The Black Cat", cachedName)
+        assertEquals(
+            listOf(Triple("usr_owner", "wrld_world", "The Black Cat")),
+            cacheWrites,
+        )
+    }
+
+    @Test
+    fun differentOwnerWorldKeysFetchConcurrently() = runTest {
+        val releaseFetches = CompletableDeferred<Unit>()
+        val startedWorlds = mutableListOf<String>()
+        val cacheWrites = mutableListOf<Pair<String, String>>()
+        val resolver = FriendActivityWorldNameResolver(
+            readCachedName = { _, _ -> null },
+            fetchWorldName = { worldId ->
+                startedWorlds += worldId
+                releaseFetches.await()
+                "World name"
+            },
+            cacheWorldName = { ownerUserId, worldId, _ ->
+                cacheWrites += ownerUserId to worldId
+            },
+            nowMillis = { 1_000L },
+        )
+        val resolutions = listOf(
+            async { resolver.resolve("usr_owner_a", "wrld_shared") },
+            async { resolver.resolve("usr_owner_b", "wrld_shared") },
+        )
+
+        runCurrent()
+        try {
+            assertEquals(listOf("wrld_shared", "wrld_shared"), startedWorlds)
+        } finally {
+            releaseFetches.complete(Unit)
+        }
+        resolutions.awaitAll()
+
+        assertEquals(
+            setOf("usr_owner_a" to "wrld_shared", "usr_owner_b" to "wrld_shared"),
+            cacheWrites.toSet(),
+        )
+    }
+
+    @Test
+    fun differentWorldFetchesUseSmallBoundedConcurrency() = runTest {
+        val releaseFetches = CompletableDeferred<Unit>()
+        val startedWorlds = mutableListOf<String>()
+        val resolver = FriendActivityWorldNameResolver(
+            readCachedName = { _, _ -> null },
+            fetchWorldName = { worldId ->
+                startedWorlds += worldId
+                releaseFetches.await()
+                "World $worldId"
+            },
+            cacheWorldName = { _, _, _ -> },
+            nowMillis = { 1_000L },
+        )
+        val resolutions = (1..5).map { index ->
+            async { resolver.resolve("usr_owner", "wrld_$index") }
+        }
+
+        runCurrent()
+        try {
+            assertEquals(4, startedWorlds.size)
+        } finally {
+            releaseFetches.complete(Unit)
+        }
+        resolutions.awaitAll()
+
+        assertEquals(5, startedWorlds.size)
     }
 
     @Test
     fun failedResolutionWaitsForCooldownBeforeRetrying() = runTest {
         var nowMillis = 1_000L
         var fetchCount = 0
+        var cachedName: String? = null
         val resolver = FriendActivityWorldNameResolver(
-            readCachedName = { _, _ -> null },
+            readCachedName = { _, _ -> cachedName },
             fetchWorldName = {
                 fetchCount += 1
-                error("Network unavailable")
+                if (fetchCount == 1) error("Network unavailable")
+                "Retry succeeded"
             },
-            cacheWorldName = { _, _, _ -> error("Must not cache failures") },
+            cacheWorldName = { _, _, worldName -> cachedName = worldName },
             nowMillis = { nowMillis },
         )
 
@@ -52,9 +139,40 @@ class FriendActivityWorldNameResolverTest {
         assertEquals(1, fetchCount)
 
         nowMillis += 60_000L
-        assertFailsWith<IllegalStateException> {
+        resolver.resolve("usr_owner", "wrld_world")
+        assertEquals(2, fetchCount)
+        assertEquals("Retry succeeded", cachedName)
+    }
+
+    @Test
+    fun cancellationPropagatesWithoutStartingFailureCooldown() = runTest {
+        var fetchCount = 0
+        val firstFetchStarted = CompletableDeferred<Unit>()
+        val blockedFetch = CompletableDeferred<String>()
+        val resolver = FriendActivityWorldNameResolver(
+            readCachedName = { _, _ -> null },
+            fetchWorldName = {
+                fetchCount += 1
+                if (fetchCount == 1) {
+                    firstFetchStarted.complete(Unit)
+                    blockedFetch.await()
+                } else {
+                    "Retry after cancellation"
+                }
+            },
+            cacheWorldName = { _, _, _ -> },
+            nowMillis = { 1_000L },
+        )
+
+        val cancelledResolution = async {
             resolver.resolve("usr_owner", "wrld_world")
         }
+        firstFetchStarted.await()
+        cancelledResolution.cancelAndJoin()
+        assertTrue(cancelledResolution.isCancelled)
+
+        resolver.resolve("usr_owner", "wrld_world")
+
         assertEquals(2, fetchCount)
     }
 }


### PR DESCRIPTION
## 概要

- 按 `(ownerUserId, worldId)` 合并世界名称解析，同一世界的重复观察只保留一个在途任务。
- 将远端世界名称请求并发限制为 4，并保留失败 60 秒冷却；取消不会进入失败冷却。
- 时间线头部读取在拿到首个有效页面后结束，避免额外保留一条重复 Room 观察链。

## 代码流程

```mermaid
flowchart LR
    A["动态事件缺少世界名"] --> B["按账户与世界声明解析"]
    B --> C{"已有在途任务"}
    C -->|是| D["复用或跳过重复任务"]
    C -->|否| E["最多 4 个并发请求"]
    E --> F["缓存读取或远端查询"]
    F --> G["写回 Room"]
    G --> H["Room Flow 刷新时间线"]
```

## 实现假设

- 世界名称解析必须按账户隔离，因为本地缓存写入带有 `ownerUserId`。
- 世界名称在短时间内稳定，解析成功后由 Room 记录承担后续缓存。
- 普通失败等待 60 秒重试可避免持续请求；协程取消应允许下一次立即重新声明。

## 测试结果

- `FriendActivityWorldNameResolverTest` 覆盖 single-flight、并发上限、缓存、失败冷却和取消。
- `FriendActivityTimelineModelTest` 覆盖头部观察释放与账户切换。
- `./gradlew :composeApp:desktopTest :composeApp:compileKotlinDesktop` 通过。
- `git diff --check upstream/newui..HEAD` 通过。

## 剩余风险

- 世界 API 持续失败时，名称最多每 60 秒重试一次。
- Room 查询索引优化 PR 也会修改时间线与 Service 文件；后合并的分支可能需要重放冲突。

## 实现假设清单

- 本轮仅补充 PR 正文结构，未修改代码或用户可见行为；上述原有实现假设保持有效。
- 当前没有新增未经验证的实现假设。
