### PR TITLE
fix(search): 改进搜索列表可访问性

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/compoments/GenericSearchList.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/GenericSearchList.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
-import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshotFlow
@@ -23,6 +22,7 @@ import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.presentation.extensions.animateScrollToFirst
 import io.github.vrcmteam.vrcm.presentation.extensions.getInsetPadding
 import io.github.vrcmteam.vrcm.presentation.extensions.simpleClickable
+import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
 import kotlinx.coroutines.flow.distinctUntilChanged
 
@@ -101,7 +101,7 @@ fun GenericSearchList(
                     headerContent()
 
                     // 标签栏
-                    TabRow(
+                    PrimaryTabRow(
                         selectedTabIndex = selectedTabIndex,
                         modifier = Modifier
                             .fillMaxWidth(),
@@ -115,7 +115,7 @@ fun GenericSearchList(
                         indicator = {
                             TabRowDefaults.PrimaryIndicator(
                                 modifier = Modifier
-                                    .tabIndicatorOffset(it[selectedTabIndex]),
+                                    .tabIndicatorOffset(selectedTabIndex),
                                 width = 32.dp,
                                 shape = RoundedCornerShape(4.dp)
                             )
@@ -184,7 +184,7 @@ fun <T> SearchResultItem(
     ListItem(
         modifier = modifier
             .fillMaxWidth()
-            .height(68.dp)
+            .heightIn(min = 68.dp)
             .padding(horizontal = 6.dp)
             .clip(MaterialTheme.shapes.large)
             .clickable { onClick(item) },
@@ -232,7 +232,11 @@ fun AdvancedOptionsPanel(
             }
             Icon(
                 imageVector = if (expanded) AppIcons.ExpandLess else AppIcons.ExpandMore,
-                contentDescription = if (expanded) "收起" else "展开"
+                contentDescription = if (expanded) {
+                    strings.notificationCollapse
+                } else {
+                    strings.notificationExpand
+                }
             )
         }
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/notification/NotificationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/notification/NotificationScreen.kt
@@ -41,12 +41,12 @@ import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
 import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
 import io.github.vrcmteam.vrcm.service.isGroupNotificationType
-import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.Serializable
 import org.koin.compose.koinInject
 import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 @Serializable
 data class NotificationScreen(val targetNotificationId: String? = null) : AppDetailRoute {


### PR DESCRIPTION
## 概要

- 将搜索页签迁移到 `PrimaryTabRow` 的新指示器 API，移除已弃用的 TabRow 偏移调用。
- 搜索结果项由固定高度改为最小高度，允许大字体和多行内容自然增高。
- 高级选项展开/收起语义改用现有多语言文案，并将通知时间迁移到 `kotlin.time.Instant`。

## 代码流程

```mermaid
flowchart LR
    A["搜索与页签状态"] --> B["PrimaryTabRow"]
    A --> C["可增长的结果行"]
    D["当前语言"] --> E["展开或收起语义"]
    B --> F["可访问的搜索列表"]
    C --> F
    E --> F
```

## 实现假设清单

- 现有 `notificationExpand` 与 `notificationCollapse` 文案适用于通用高级选项语义。
- 调用方始终提供有效的 `selectedTabIndex`。
- 结果行只需要 68 dp 最小高度，不应继续限制内容最大高度。

## 测试结果

- `./gradlew :composeApp:desktopTest :composeApp:compileKotlinDesktop` 通过。
- `git diff --check upstream/newui..HEAD` 通过。
- 按仓库测试规范，纯视觉与框架 API 调整未新增 Compose UI 测试。

## 剩余风险

- 尚未在所有平台、窄窗口和系统大字体组合下进行截图级视觉验证。
