### PR TITLE
fix(notification): 串行化通知中心状态更新

### DIFF
--- a/composeApp/src/commonMain/kotlin/di/modules/PresentationModule.kt
+++ b/composeApp/src/commonMain/kotlin/di/modules/PresentationModule.kt
@@ -62,6 +62,7 @@ import okio.FileSystem
 import org.koin.core.definition.Definition
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.onClose
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.module.dsl.viewModelOf
@@ -78,7 +79,9 @@ val presentationModule: Module = module {
     viewModelOf(::AuthScreenModel)
     viewModel { FriendActivityTimelineModel(get<FriendActivityService>()) }
     viewModelOf(::HomeScreenModel)
-    singleOf(::NotificationCenterModel)
+    singleOf(::NotificationCenterModel) {
+        onClose { it?.close() }
+    }
     viewModelOf(::UserProfileScreenModel)
     viewModelOf(::MutualFriendsScreenModel)
     viewModelOf(::FriendNetworkScreenModel)

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/data/NotificationItemData.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/data/NotificationItemData.kt
@@ -141,12 +141,19 @@ internal data class NotificationInboxState(
     val pipeline: List<NotificationItemData> = emptyList(),
     val legacy: List<NotificationItemData> = emptyList(),
     private val consumed: Set<NotificationIdentity> = emptySet(),
+    private val seenNotifications: Set<NotificationIdentity> = emptySet(),
 ) {
     fun replace(source: NotificationSource, items: List<NotificationItemData>): NotificationInboxState {
-        val visible = items.filterNot { it.identity in consumed }
+        // Seen is monotonic within a session, so a stale refresh cannot undo a read mutation.
+        val mergedSeen = seenNotifications + items.filter { it.seen }.map { it.identity }
+        val visible = items
+            .filterNot { it.identity in consumed }
+            .map { item ->
+                if (!item.seen && item.identity in mergedSeen) item.copy(seen = true) else item
+            }
         return when (source) {
-            NotificationSource.PIPELINE -> copy(pipeline = visible)
-            NotificationSource.LEGACY -> copy(legacy = visible)
+            NotificationSource.PIPELINE -> copy(pipeline = visible, seenNotifications = mergedSeen)
+            NotificationSource.LEGACY -> copy(legacy = visible, seenNotifications = mergedSeen)
         }
     }
 
@@ -164,17 +171,22 @@ internal data class NotificationInboxState(
         }
     }
 
-    fun markSeen(item: NotificationItemData): NotificationInboxState = when (item.source) {
-        NotificationSource.PIPELINE -> copy(
-            pipeline = pipeline.map { current ->
-                if (current.identity == item.identity) current.copy(seen = true) else current
-            },
-        )
-        NotificationSource.LEGACY -> copy(
-            legacy = legacy.map { current ->
-                if (current.identity == item.identity) current.copy(seen = true) else current
-            },
-        )
+    fun markSeen(item: NotificationItemData): NotificationInboxState {
+        val identity = item.identity
+        return when (item.source) {
+            NotificationSource.PIPELINE -> copy(
+                pipeline = pipeline.map { current ->
+                    if (current.identity == identity) current.copy(seen = true) else current
+                },
+                seenNotifications = seenNotifications + identity,
+            )
+            NotificationSource.LEGACY -> copy(
+                legacy = legacy.map { current ->
+                    if (current.identity == identity) current.copy(seen = true) else current
+                },
+                seenNotifications = seenNotifications + identity,
+            )
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/notification/NotificationCenterModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/notification/NotificationCenterModel.kt
@@ -1,8 +1,5 @@
 package io.github.vrcmteam.vrcm.presentation.screens.notification
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import io.github.vrcmteam.vrcm.core.shared.AccountWebSocketEvent
 import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
@@ -14,7 +11,6 @@ import io.github.vrcmteam.vrcm.presentation.compoments.ToastText
 import io.github.vrcmteam.vrcm.presentation.extensions.onApiFailure
 import io.github.vrcmteam.vrcm.presentation.screens.home.data.BoopNotificationResolver
 import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationInboxState
-import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationIdentity
 import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationItemData
 import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationReadTarget
 import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationResponseTarget
@@ -35,6 +31,7 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -49,32 +46,32 @@ class NotificationCenterModel(
     private val friendService: FriendService,
     private val logger: Logger,
     private val boopService: BoopService,
-) {
-    private val modelScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+) : AutoCloseable {
+    private val modelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val boopNotificationResolver = BoopNotificationResolver()
     private val refreshRequests = Channel<AccountSessionToken>(Channel.CONFLATED)
     private var refreshJob: Job? = null
-
-    private var inboxState by mutableStateOf(NotificationInboxState())
+    private val stateStore = NotificationCenterStateStore(
+        scope = modelScope,
+        initialState = NotificationCenterUiState(
+            sessionToken = SharedFlowCentre.currentSession.value?.token,
+        ),
+        reducerDispatcher = Dispatchers.Main.immediate,
+    )
+    private val state: NotificationCenterUiState
+        get() = stateStore.value
 
     val notifications: List<NotificationItemData>
-        get() = inboxState.pipeline
+        get() = state.inboxState.pipeline
 
     val friendRequestNotifications: List<NotificationItemData>
-        get() = inboxState.legacy
+        get() = state.inboxState.legacy
 
-    private var pendingNotificationActions by
-        mutableStateOf<Map<NotificationIdentity, NotificationItemData.ActionData>>(emptyMap())
+    val isRefreshing: Boolean
+        get() = state.isRefreshing
 
-    private var pendingReadNotifications by mutableStateOf<Set<NotificationIdentity>>(emptySet())
-
-    private var pendingDeleteNotifications by mutableStateOf<Set<NotificationIdentity>>(emptySet())
-
-    var isRefreshing by mutableStateOf(false)
-        private set
-
-    var hasRefreshError by mutableStateOf(false)
-        private set
+    val hasRefreshError: Boolean
+        get() = state.hasRefreshError
 
     val unreadCount: Int
         get() = (friendRequestNotifications + notifications).unreadCount
@@ -92,12 +89,7 @@ class NotificationCenterModel(
         modelScope.launch {
             SharedFlowCentre.currentSession.collectLatest { session ->
                 refreshJob?.cancel()
-                inboxState = NotificationInboxState()
-                pendingNotificationActions = emptyMap()
-                pendingReadNotifications = emptySet()
-                pendingDeleteNotifications = emptySet()
-                isRefreshing = false
-                hasRefreshError = false
+                reduceState { NotificationCenterUiState(sessionToken = session?.token) }
                 session?.token?.let(::queueNotificationRefresh)
             }
         }
@@ -119,8 +111,7 @@ class NotificationCenterModel(
 
     private suspend fun refreshAllNotification(token: AccountSessionToken) {
         if (!SharedFlowCentre.isCurrentSession(token)) return
-        isRefreshing = true
-        hasRefreshError = false
+        reduceForSession(token) { it.copy(isRefreshing = true, hasRefreshError = false) }
         try {
             val (friendRequestsResult, notificationsResult) = supervisorScope {
                 async { loadFriendRequests() } to async { loadNotifications() }
@@ -132,18 +123,40 @@ class NotificationCenterModel(
             friendRequestsResult
                 .onFailure { if (it is CancellationException) throw it }
                 .onNotificationFailure()
-                .onSuccess {
-                    inboxState = inboxState.replace(NotificationSource.LEGACY, it)
-                }
             notificationsResult
                 .onFailure { if (it is CancellationException) throw it }
                 .onNotificationFailure()
-                .onSuccess {
-                    inboxState = inboxState.replace(NotificationSource.PIPELINE, it)
-                }
-            hasRefreshError = friendRequestsResult.isFailure || notificationsResult.isFailure
+            reduceForSession(token) { current ->
+                val withFriendRequests = friendRequestsResult.getOrNull()?.let { notifications ->
+                    current.inboxState.replace(NotificationSource.LEGACY, notifications)
+                } ?: current.inboxState
+                val refreshedInbox = notificationsResult.getOrNull()?.let { notifications ->
+                    withFriendRequests.replace(NotificationSource.PIPELINE, notifications)
+                } ?: withFriendRequests
+                current.copy(
+                    inboxState = refreshedInbox,
+                    hasRefreshError = friendRequestsResult.isFailure || notificationsResult.isFailure,
+                )
+            }
         } finally {
-            if (SharedFlowCentre.isCurrentSession(token)) isRefreshing = false
+            if (SharedFlowCentre.isCurrentSession(token)) {
+                reduceForSession(token) { it.copy(isRefreshing = false) }
+            }
+        }
+    }
+
+    private fun reduceState(
+        reducer: (NotificationCenterUiState) -> NotificationCenterUiState,
+    ) {
+        stateStore.reduce(reducer)
+    }
+
+    private fun reduceForSession(
+        token: AccountSessionToken,
+        reducer: (NotificationCenterUiState) -> NotificationCenterUiState,
+    ) {
+        reduceState { current ->
+            if (current.sessionToken == token) reducer(current) else current
         }
     }
 
@@ -205,18 +218,19 @@ class NotificationCenterModel(
             deleteNotification(item)
             return
         }
-        pendingNotificationActions += item.identity to action
-        val token = SharedFlowCentre.currentSession.value?.token
-        if (token == null) {
-            finishNotificationAction(item)
-            return
+        val token = SharedFlowCentre.currentSession.value?.token ?: return
+        reduceForSession(token) { current ->
+            current.copy(
+                pendingNotificationActions =
+                    current.pendingNotificationActions + (item.identity to action),
+            )
         }
 
         when (responseTarget) {
             NotificationResponseTarget.BOOP_USER_API -> {
                 val senderId = item.senderId
                 if (senderId == null) {
-                    finishNotificationAction(item)
+                    finishNotificationAction(item, token)
                     return
                 }
                 boopUser(
@@ -245,7 +259,11 @@ class NotificationCenterModel(
     fun markNotificationAsRead(item: NotificationItemData) {
         if (item.seen || isNotificationPending(item)) return
         val token = SharedFlowCentre.currentSession.value?.token ?: return
-        pendingReadNotifications += item.identity
+        reduceForSession(token) { current ->
+            current.copy(
+                pendingReadNotifications = current.pendingReadNotifications + item.identity,
+            )
+        }
         modelScope.launch(Dispatchers.IO) {
             try {
                 val result = runNotificationMutation(token) {
@@ -259,13 +277,15 @@ class NotificationCenterModel(
                 result
                     .onNotificationFailure()
                     .onSuccess {
-                        if (SharedFlowCentre.isCurrentSession(token)) {
-                            inboxState = inboxState.markSeen(item)
+                        reduceForSession(token) { current ->
+                            current.copy(inboxState = current.inboxState.markSeen(item))
                         }
                     }
             } finally {
-                if (SharedFlowCentre.isCurrentSession(token)) {
-                    pendingReadNotifications -= item.identity
+                reduceForSession(token) { current ->
+                    current.copy(
+                        pendingReadNotifications = current.pendingReadNotifications - item.identity,
+                    )
                 }
             }
         }
@@ -274,31 +294,39 @@ class NotificationCenterModel(
     fun deleteNotification(item: NotificationItemData) {
         if (isNotificationPending(item)) return
         val token = SharedFlowCentre.currentSession.value?.token ?: return
-        pendingDeleteNotifications += item.identity
+        reduceForSession(token) { current ->
+            current.copy(
+                pendingDeleteNotifications = current.pendingDeleteNotifications + item.identity,
+            )
+        }
         modelScope.launch(Dispatchers.IO) {
             try {
                 val result = runNotificationMutation(token) {
                     deleteRemoteNotification(item)
                 } ?: return@launch
-                if (SharedFlowCentre.isCurrentSession(token)) {
-                    inboxState = inboxState.afterNotificationAction(item, result)
+                reduceForSession(token) { current ->
+                    current.copy(
+                        inboxState = current.inboxState.afterNotificationAction(item, result),
+                    )
                 }
                 result.onNotificationFailure()
             } finally {
-                if (SharedFlowCentre.isCurrentSession(token)) {
-                    pendingDeleteNotifications -= item.identity
+                reduceForSession(token) { current ->
+                    current.copy(
+                        pendingDeleteNotifications = current.pendingDeleteNotifications - item.identity,
+                    )
                 }
             }
         }
     }
 
     internal fun pendingAction(item: NotificationItemData): NotificationItemData.ActionData? =
-        pendingNotificationActions[item.identity]
+        state.pendingNotificationActions[item.identity]
 
     internal fun isNotificationPending(item: NotificationItemData): Boolean =
-        item.identity in pendingNotificationActions ||
-            item.identity in pendingReadNotifications ||
-            item.identity in pendingDeleteNotifications
+        item.identity in state.pendingNotificationActions ||
+            item.identity in state.pendingReadNotifications ||
+            item.identity in state.pendingDeleteNotifications
 
     private fun boopUser(
         item: NotificationItemData,
@@ -313,7 +341,9 @@ class NotificationCenterModel(
             try {
                 val result = boopService.send(userId, emojiId)
                 if (!SharedFlowCentre.isCurrentSession(token)) return@launch
-                inboxState = inboxState.afterBoopResult(item, result)
+                reduceForSession(token) { current ->
+                    current.copy(inboxState = current.inboxState.afterBoopResult(item, result))
+                }
                 when (result) {
                     BoopResult.Sent -> {
                         SharedFlowCentre.toastText.emit(ToastText.Success(successMessage))
@@ -327,7 +357,7 @@ class NotificationCenterModel(
                     BoopResult.InFlight, BoopResult.SessionChanged -> Unit
                 }
             } finally {
-                if (SharedFlowCentre.isCurrentSession(token)) finishNotificationAction(item)
+                finishNotificationAction(item, token)
             }
         }
     }
@@ -340,8 +370,10 @@ class NotificationCenterModel(
         modelScope.launch(Dispatchers.IO) {
             try {
                 val result = runNotificationMutation(token) { action() } ?: return@launch
-                if (SharedFlowCentre.isCurrentSession(token)) {
-                    inboxState = inboxState.afterNotificationAction(item, result)
+                reduceForSession(token) { current ->
+                    current.copy(
+                        inboxState = current.inboxState.afterNotificationAction(item, result),
+                    )
                 }
                 result
                     .onNotificationFailure()
@@ -351,7 +383,7 @@ class NotificationCenterModel(
                         }
                     }
             } finally {
-                if (SharedFlowCentre.isCurrentSession(token)) finishNotificationAction(item)
+                finishNotificationAction(item, token)
             }
         }
     }
@@ -371,8 +403,21 @@ class NotificationCenterModel(
         return response.result.takeIf { SharedFlowCentre.isCurrentSession(response.sessionToken) }
     }
 
-    private fun finishNotificationAction(item: NotificationItemData) {
-        pendingNotificationActions -= item.identity
+    private fun finishNotificationAction(
+        item: NotificationItemData,
+        token: AccountSessionToken,
+    ) {
+        reduceForSession(token) { current ->
+            current.copy(
+                pendingNotificationActions = current.pendingNotificationActions - item.identity,
+            )
+        }
+    }
+
+    override fun close() {
+        refreshRequests.close()
+        stateStore.close()
+        modelScope.cancel()
     }
 
     private inline fun <T> Result<T>.onNotificationFailure() =

--- a/composeApp/src/commonMain/kotlin/presentation/screens/notification/NotificationCenterModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/notification/NotificationCenterModel.kt
@@ -208,7 +208,6 @@ class NotificationCenterModel(
         boopAlreadySentMessage: String,
         boopDisabledMessage: String,
     ) {
-        if (isNotificationPending(item)) return
         val responseTarget = item.responseTarget(action)
         if (responseTarget == NotificationResponseTarget.NAVIGATION_LINK) return
         if (
@@ -218,117 +217,96 @@ class NotificationCenterModel(
             deleteNotification(item)
             return
         }
-        val token = SharedFlowCentre.currentSession.value?.token ?: return
-        reduceForSession(token) { current ->
-            current.copy(
-                pendingNotificationActions =
-                    current.pendingNotificationActions + (item.identity to action),
-            )
-        }
-
-        when (responseTarget) {
-            NotificationResponseTarget.BOOP_USER_API -> {
-                val senderId = item.senderId
-                if (senderId == null) {
-                    finishNotificationAction(item, token)
-                    return
+        launchReservedMutation(item, PendingNotificationMutation.Action(action)) { token ->
+            when (responseTarget) {
+                NotificationResponseTarget.BOOP_USER_API -> {
+                    val senderId = item.senderId ?: return@launchReservedMutation
+                    boopUser(
+                        item = item,
+                        token = token,
+                        userId = senderId,
+                        emojiId = boopEmojiId,
+                        successMessage = boopSuccessMessage,
+                        alreadySentMessage = boopAlreadySentMessage,
+                        disabledMessage = boopDisabledMessage,
+                    )
                 }
-                boopUser(
-                    item = item,
-                    token = token,
-                    userId = senderId,
-                    emojiId = boopEmojiId,
-                    successMessage = boopSuccessMessage,
-                    alreadySentMessage = boopAlreadySentMessage,
-                    disabledMessage = boopDisabledMessage,
-                )
-                return
+
+                NotificationResponseTarget.NOTIFICATION_API -> {
+                    if (item.type == NotificationType.FriendRequest.value) {
+                        notificationAction(item, token) { notificationApi.acceptFriendRequest(item.id) }
+                    } else {
+                        notificationAction(item, token) {
+                            notificationApi.responseNotification(item.id, action)
+                        }
+                    }
+                }
+
+                NotificationResponseTarget.NAVIGATION_LINK -> Unit
             }
-
-            NotificationResponseTarget.NOTIFICATION_API -> Unit
-            NotificationResponseTarget.NAVIGATION_LINK -> return
-        }
-
-        if (item.type == NotificationType.FriendRequest.value) {
-            notificationAction(item, token) { notificationApi.acceptFriendRequest(item.id) }
-        } else {
-            notificationAction(item, token) { notificationApi.responseNotification(item.id, action) }
         }
     }
 
     fun markNotificationAsRead(item: NotificationItemData) {
-        if (item.seen || isNotificationPending(item)) return
-        val token = SharedFlowCentre.currentSession.value?.token ?: return
-        reduceForSession(token) { current ->
-            current.copy(
-                pendingReadNotifications = current.pendingReadNotifications + item.identity,
-            )
-        }
-        modelScope.launch(Dispatchers.IO) {
-            try {
-                val result = runNotificationMutation(token) {
-                    when (item.readTarget) {
-                        NotificationReadTarget.PIPELINE_SEE ->
-                            notificationApi.markPipelineNotificationAsRead(item.id)
-                        NotificationReadTarget.LEGACY_SEE ->
-                            notificationApi.markLegacyNotificationAsRead(item.id)
-                    }
-                } ?: return@launch
-                result
-                    .onNotificationFailure()
-                    .onSuccess {
-                        reduceForSession(token) { current ->
-                            current.copy(inboxState = current.inboxState.markSeen(item))
-                        }
-                    }
-            } finally {
-                reduceForSession(token) { current ->
-                    current.copy(
-                        pendingReadNotifications = current.pendingReadNotifications - item.identity,
-                    )
+        if (item.seen) return
+        launchReservedMutation(item, PendingNotificationMutation.Read) { token ->
+            val result = runNotificationMutation(token) {
+                when (item.readTarget) {
+                    NotificationReadTarget.PIPELINE_SEE ->
+                        notificationApi.markPipelineNotificationAsRead(item.id)
+                    NotificationReadTarget.LEGACY_SEE ->
+                        notificationApi.markLegacyNotificationAsRead(item.id)
                 }
-            }
+            } ?: return@launchReservedMutation
+            result
+                .onNotificationFailure()
+                .onSuccess {
+                    reduceForSession(token) { current ->
+                        current.copy(inboxState = current.inboxState.markSeen(item))
+                    }
+                }
         }
     }
 
     fun deleteNotification(item: NotificationItemData) {
-        if (isNotificationPending(item)) return
-        val token = SharedFlowCentre.currentSession.value?.token ?: return
-        reduceForSession(token) { current ->
-            current.copy(
-                pendingDeleteNotifications = current.pendingDeleteNotifications + item.identity,
-            )
+        launchReservedMutation(item, PendingNotificationMutation.Delete) { token ->
+            val result = runNotificationMutation(token) {
+                deleteRemoteNotification(item)
+            } ?: return@launchReservedMutation
+            reduceForSession(token) { current ->
+                current.copy(
+                    inboxState = current.inboxState.afterNotificationAction(item, result),
+                )
+            }
+            result.onNotificationFailure()
         }
-        modelScope.launch(Dispatchers.IO) {
-            try {
-                val result = runNotificationMutation(token) {
-                    deleteRemoteNotification(item)
-                } ?: return@launch
-                reduceForSession(token) { current ->
-                    current.copy(
-                        inboxState = current.inboxState.afterNotificationAction(item, result),
-                    )
-                }
-                result.onNotificationFailure()
-            } finally {
-                reduceForSession(token) { current ->
-                    current.copy(
-                        pendingDeleteNotifications = current.pendingDeleteNotifications - item.identity,
-                    )
+    }
+
+    internal fun pendingAction(item: NotificationItemData): NotificationItemData.ActionData? =
+        (state.pendingMutations[item.identity] as? PendingNotificationMutation.Action)?.action
+
+    internal fun isNotificationPending(item: NotificationItemData): Boolean =
+        item.identity in state.pendingMutations
+
+    private fun launchReservedMutation(
+        item: NotificationItemData,
+        mutation: PendingNotificationMutation,
+        block: suspend (AccountSessionToken) -> Unit,
+    ) {
+        val token = SharedFlowCentre.currentSession.value?.token ?: return
+        modelScope.launch {
+            if (!stateStore.reserveMutation(token, item.identity, mutation)) return@launch
+            modelScope.launch(Dispatchers.IO) {
+                try {
+                    block(token)
+                } finally {
+                    finishNotificationMutation(item, token)
                 }
             }
         }
     }
 
-    internal fun pendingAction(item: NotificationItemData): NotificationItemData.ActionData? =
-        state.pendingNotificationActions[item.identity]
-
-    internal fun isNotificationPending(item: NotificationItemData): Boolean =
-        item.identity in state.pendingNotificationActions ||
-            item.identity in state.pendingReadNotifications ||
-            item.identity in state.pendingDeleteNotifications
-
-    private fun boopUser(
+    private suspend fun boopUser(
         item: NotificationItemData,
         token: AccountSessionToken,
         userId: String,
@@ -337,55 +315,43 @@ class NotificationCenterModel(
         alreadySentMessage: String,
         disabledMessage: String,
     ) {
-        modelScope.launch(Dispatchers.IO) {
-            try {
-                val result = boopService.send(userId, emojiId)
-                if (!SharedFlowCentre.isCurrentSession(token)) return@launch
-                reduceForSession(token) { current ->
-                    current.copy(inboxState = current.inboxState.afterBoopResult(item, result))
-                }
-                when (result) {
-                    BoopResult.Sent -> {
-                        SharedFlowCentre.toastText.emit(ToastText.Success(successMessage))
-                        runNotificationMutation(token) { deleteRemoteNotification(item) }
-                            ?.onNotificationFailure()
-                    }
-
-                    BoopResult.Cooldown -> SharedFlowCentre.toastText.emit(ToastText.Info(alreadySentMessage))
-                    BoopResult.Disabled -> SharedFlowCentre.toastText.emit(ToastText.Error(disabledMessage))
-                    is BoopResult.Failed -> Result.failure<Unit>(result.error).onNotificationFailure()
-                    BoopResult.InFlight, BoopResult.SessionChanged -> Unit
-                }
-            } finally {
-                finishNotificationAction(item, token)
+        val result = boopService.send(userId, emojiId)
+        if (!SharedFlowCentre.isCurrentSession(token)) return
+        reduceForSession(token) { current ->
+            current.copy(inboxState = current.inboxState.afterBoopResult(item, result))
+        }
+        when (result) {
+            BoopResult.Sent -> {
+                SharedFlowCentre.toastText.emit(ToastText.Success(successMessage))
+                runNotificationMutation(token) { deleteRemoteNotification(item) }
+                    ?.onNotificationFailure()
             }
+
+            BoopResult.Cooldown -> SharedFlowCentre.toastText.emit(ToastText.Info(alreadySentMessage))
+            BoopResult.Disabled -> SharedFlowCentre.toastText.emit(ToastText.Error(disabledMessage))
+            is BoopResult.Failed -> Result.failure<Unit>(result.error).onNotificationFailure()
+            BoopResult.InFlight, BoopResult.SessionChanged -> Unit
         }
     }
 
-    private fun notificationAction(
+    private suspend fun notificationAction(
         item: NotificationItemData,
         token: AccountSessionToken,
         action: suspend () -> Unit,
     ) {
-        modelScope.launch(Dispatchers.IO) {
-            try {
-                val result = runNotificationMutation(token) { action() } ?: return@launch
-                reduceForSession(token) { current ->
-                    current.copy(
-                        inboxState = current.inboxState.afterNotificationAction(item, result),
-                    )
-                }
-                result
-                    .onNotificationFailure()
-                    .onSuccess {
-                        if (SharedFlowCentre.isCurrentSession(token)) {
-                            queueNotificationRefresh(token)
-                        }
-                    }
-            } finally {
-                finishNotificationAction(item, token)
-            }
+        val result = runNotificationMutation(token) { action() } ?: return
+        reduceForSession(token) { current ->
+            current.copy(
+                inboxState = current.inboxState.afterNotificationAction(item, result),
+            )
         }
+        result
+            .onNotificationFailure()
+            .onSuccess {
+                if (SharedFlowCentre.isCurrentSession(token)) {
+                    queueNotificationRefresh(token)
+                }
+            }
     }
 
     private suspend fun deleteRemoteNotification(item: NotificationItemData) {
@@ -403,13 +369,13 @@ class NotificationCenterModel(
         return response.result.takeIf { SharedFlowCentre.isCurrentSession(response.sessionToken) }
     }
 
-    private fun finishNotificationAction(
+    private fun finishNotificationMutation(
         item: NotificationItemData,
         token: AccountSessionToken,
     ) {
         reduceForSession(token) { current ->
             current.copy(
-                pendingNotificationActions = current.pendingNotificationActions - item.identity,
+                pendingMutations = current.pendingMutations - item.identity,
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/notification/NotificationCenterStateStore.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/notification/NotificationCenterStateStore.kt
@@ -13,17 +13,22 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.launch
 
 internal data class NotificationCenterUiState(
     val sessionToken: AccountSessionToken? = null,
     val inboxState: NotificationInboxState = NotificationInboxState(),
-    val pendingNotificationActions: Map<NotificationIdentity, NotificationItemData.ActionData> = emptyMap(),
-    val pendingReadNotifications: Set<NotificationIdentity> = emptySet(),
-    val pendingDeleteNotifications: Set<NotificationIdentity> = emptySet(),
+    val pendingMutations: Map<NotificationIdentity, PendingNotificationMutation> = emptyMap(),
     val isRefreshing: Boolean = false,
     val hasRefreshError: Boolean = false,
 )
+
+internal sealed interface PendingNotificationMutation {
+    data class Action(val action: NotificationItemData.ActionData) : PendingNotificationMutation
+    data object Read : PendingNotificationMutation
+    data object Delete : PendingNotificationMutation
+}
 
 /**
  * Applies notification UI state reductions in FIFO order on the supplied UI dispatcher.
@@ -35,7 +40,7 @@ internal class NotificationCenterStateStore(
     reducerDispatcher: CoroutineDispatcher,
 ) {
     private var mutableValue by mutableStateOf(initialState)
-    private val reductions = Channel<PendingReduction>(Channel.UNLIMITED)
+    private val reductions = Channel<ReductionCommand>(Channel.UNLIMITED)
 
     val value: NotificationCenterUiState
         get() = mutableValue
@@ -45,13 +50,12 @@ internal class NotificationCenterStateStore(
             try {
                 for (pending in reductions) {
                     try {
-                        mutableValue = pending.reducer(mutableValue)
-                        pending.completion.complete(Unit)
+                        pending.execute()
                     } catch (cancellation: CancellationException) {
-                        pending.completion.cancel(cancellation)
+                        pending.cancel(cancellation)
                         throw cancellation
                     } catch (error: Throwable) {
-                        pending.completion.completeExceptionally(error)
+                        pending.fail(error)
                         throw error
                     }
                 }
@@ -60,7 +64,7 @@ internal class NotificationCenterStateStore(
                 val cancellation = CancellationException("Notification state reducer stopped")
                 while (true) {
                     val pending = reductions.tryReceive().getOrNull() ?: break
-                    pending.completion.cancel(cancellation)
+                    pending.cancel(cancellation)
                 }
             }
         }
@@ -70,18 +74,78 @@ internal class NotificationCenterStateStore(
         reducer: (NotificationCenterUiState) -> NotificationCenterUiState,
     ): Job {
         val completion = CompletableDeferred<Unit>()
-        if (reductions.trySend(PendingReduction(reducer, completion)).isFailure) {
-            completion.cancel(CancellationException("Notification state reducer is closed"))
-        }
+        enqueue(
+            ReductionCommandImpl(
+                reducer = { reducer(it) to Unit },
+                completion = completion,
+                skipIfCompletionCancelled = false,
+            ),
+        )
         return completion
+    }
+
+    suspend fun reserveMutation(
+        sessionToken: AccountSessionToken,
+        identity: NotificationIdentity,
+        mutation: PendingNotificationMutation,
+    ): Boolean = reduceWithResult { current ->
+        if (current.sessionToken != sessionToken || identity in current.pendingMutations) {
+            current to false
+        } else {
+            current.copy(
+                pendingMutations = current.pendingMutations + (identity to mutation),
+            ) to true
+        }
     }
 
     fun close() {
         reductions.close()
     }
 
-    private data class PendingReduction(
-        val reducer: (NotificationCenterUiState) -> NotificationCenterUiState,
-        val completion: CompletableDeferred<Unit>,
-    )
+    private suspend fun <T> reduceWithResult(
+        reducer: (NotificationCenterUiState) -> Pair<NotificationCenterUiState, T>,
+    ): T {
+        val completion = CompletableDeferred<T>(currentCoroutineContext()[Job])
+        enqueue(
+            ReductionCommandImpl(
+                reducer = reducer,
+                completion = completion,
+                skipIfCompletionCancelled = true,
+            ),
+        )
+        return completion.await()
+    }
+
+    private fun enqueue(command: ReductionCommand) {
+        if (reductions.trySend(command).isFailure) {
+            command.cancel(CancellationException("Notification state reducer is closed"))
+        }
+    }
+
+    private interface ReductionCommand {
+        fun execute()
+        fun cancel(cancellation: CancellationException)
+        fun fail(error: Throwable)
+    }
+
+    private inner class ReductionCommandImpl<T>(
+        private val reducer: (NotificationCenterUiState) -> Pair<NotificationCenterUiState, T>,
+        private val completion: CompletableDeferred<T>,
+        private val skipIfCompletionCancelled: Boolean,
+    ) : ReductionCommand {
+        override fun execute() {
+            if (skipIfCompletionCancelled && !completion.isActive) return
+            val (updated, result) = reducer(mutableValue)
+            mutableValue = updated
+            completion.complete(result)
+        }
+
+        override fun cancel(cancellation: CancellationException) {
+            completion.cancel(cancellation)
+        }
+
+        override fun fail(error: Throwable) {
+            completion.completeExceptionally(error)
+        }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/notification/NotificationCenterStateStore.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/notification/NotificationCenterStateStore.kt
@@ -1,0 +1,87 @@
+package io.github.vrcmteam.vrcm.presentation.screens.notification
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationIdentity
+import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationInboxState
+import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationItemData
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+
+internal data class NotificationCenterUiState(
+    val sessionToken: AccountSessionToken? = null,
+    val inboxState: NotificationInboxState = NotificationInboxState(),
+    val pendingNotificationActions: Map<NotificationIdentity, NotificationItemData.ActionData> = emptyMap(),
+    val pendingReadNotifications: Set<NotificationIdentity> = emptySet(),
+    val pendingDeleteNotifications: Set<NotificationIdentity> = emptySet(),
+    val isRefreshing: Boolean = false,
+    val hasRefreshError: Boolean = false,
+)
+
+/**
+ * Applies notification UI state reductions in FIFO order on the supplied UI dispatcher.
+ * Network jobs may submit concurrently; this actor remains the only Compose state writer.
+ */
+internal class NotificationCenterStateStore(
+    scope: CoroutineScope,
+    initialState: NotificationCenterUiState,
+    reducerDispatcher: CoroutineDispatcher,
+) {
+    private var mutableValue by mutableStateOf(initialState)
+    private val reductions = Channel<PendingReduction>(Channel.UNLIMITED)
+
+    val value: NotificationCenterUiState
+        get() = mutableValue
+
+    init {
+        scope.launch(reducerDispatcher) {
+            try {
+                for (pending in reductions) {
+                    try {
+                        mutableValue = pending.reducer(mutableValue)
+                        pending.completion.complete(Unit)
+                    } catch (cancellation: CancellationException) {
+                        pending.completion.cancel(cancellation)
+                        throw cancellation
+                    } catch (error: Throwable) {
+                        pending.completion.completeExceptionally(error)
+                        throw error
+                    }
+                }
+            } finally {
+                reductions.close()
+                val cancellation = CancellationException("Notification state reducer stopped")
+                while (true) {
+                    val pending = reductions.tryReceive().getOrNull() ?: break
+                    pending.completion.cancel(cancellation)
+                }
+            }
+        }
+    }
+
+    fun reduce(
+        reducer: (NotificationCenterUiState) -> NotificationCenterUiState,
+    ): Job {
+        val completion = CompletableDeferred<Unit>()
+        if (reductions.trySend(PendingReduction(reducer, completion)).isFailure) {
+            completion.cancel(CancellationException("Notification state reducer is closed"))
+        }
+        return completion
+    }
+
+    fun close() {
+        reductions.close()
+    }
+
+    private data class PendingReduction(
+        val reducer: (NotificationCenterUiState) -> NotificationCenterUiState,
+        val completion: CompletableDeferred<Unit>,
+    )
+}

--- a/composeApp/src/commonTest/kotlin/presentation/screens/notification/NotificationCenterStateStoreTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/notification/NotificationCenterStateStoreTest.kt
@@ -1,26 +1,105 @@
 package io.github.vrcmteam.vrcm.presentation.screens.notification
 
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
 import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationInboxState
 import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationItemData
 import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationSource
-import kotlinx.atomicfu.atomic
-import kotlinx.coroutines.CompletableDeferred
+import io.github.vrcmteam.vrcm.presentation.screens.home.data.identity
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.joinAll
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class NotificationCenterStateStoreTest {
     @Test
-    fun staleRefreshCannotRevertNotificationMarkedReadByEarlierMutation() = runBlocking {
+    fun queuedReservationsCannotStartMultipleMutationTypesForSameNotification() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(SupervisorJob() + dispatcher)
+        val token = AccountSessionToken(userId = "usr_test", generation = 1)
+        val store = NotificationCenterStateStore(
+            scope = scope,
+            initialState = NotificationCenterUiState(sessionToken = token),
+            reducerDispatcher = dispatcher,
+        )
         val target = notification("not_target")
-        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val action = NotificationItemData.ActionData(data = "", type = "Accept")
+
+        try {
+            val accepted = listOf(
+                async {
+                    store.reserveMutation(
+                        token,
+                        target.identity,
+                        PendingNotificationMutation.Action(action),
+                    )
+                },
+                async {
+                    store.reserveMutation(
+                        token,
+                        target.identity,
+                        PendingNotificationMutation.Read,
+                    )
+                },
+                async {
+                    store.reserveMutation(
+                        token,
+                        target.identity,
+                        PendingNotificationMutation.Delete,
+                    )
+                },
+            ).awaitAll()
+
+            assertEquals(1, accepted.count { it })
+        } finally {
+            store.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun cancelledReservationCannotLeavePendingMutation() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(SupervisorJob() + dispatcher)
+        val token = AccountSessionToken(userId = "usr_test", generation = 1)
+        val store = NotificationCenterStateStore(
+            scope = scope,
+            initialState = NotificationCenterUiState(sessionToken = token),
+            reducerDispatcher = dispatcher,
+        )
+        val target = notification("not_target")
+
+        try {
+            val reservation = launch(start = CoroutineStart.UNDISPATCHED) {
+                store.reserveMutation(
+                    token,
+                    target.identity,
+                    PendingNotificationMutation.Delete,
+                )
+            }
+            reservation.cancelAndJoin()
+            store.reduce { it }.join()
+
+            assertEquals(false, target.identity in store.value.pendingMutations)
+        } finally {
+            store.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun staleRefreshCannotRevertNotificationMarkedReadByEarlierMutation() = runTest {
+        val target = notification("not_target")
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(SupervisorJob() + dispatcher)
         val store = NotificationCenterStateStore(
             scope = scope,
             initialState = NotificationCenterUiState(
@@ -29,7 +108,7 @@ class NotificationCenterStateStoreTest {
                     listOf(target),
                 ),
             ),
-            reducerDispatcher = Dispatchers.Default,
+            reducerDispatcher = dispatcher,
         )
 
         try {
@@ -53,9 +132,10 @@ class NotificationCenterStateStoreTest {
     }
 
     @Test
-    fun staleRefreshCannotRestoreNotificationConsumedByConcurrentMutation() = runBlocking {
+    fun staleRefreshCannotRestoreNotificationConsumedByConcurrentMutation() = runTest {
         val target = notification("not_target")
-        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(SupervisorJob() + dispatcher)
         val store = NotificationCenterStateStore(
             scope = scope,
             initialState = NotificationCenterUiState(
@@ -64,20 +144,14 @@ class NotificationCenterStateStoreTest {
                     listOf(target),
                 ),
             ),
-            reducerDispatcher = Dispatchers.Default,
+            reducerDispatcher = dispatcher,
         )
-        val gate = ConcurrentReductionGate(participants = 2)
-        val mutationJob = CompletableDeferred<Job>()
 
         try {
             val mutation = store.reduce { state ->
-                gate.awaitPeers()
                 state.copy(inboxState = state.inboxState.consume(target))
             }
-            mutationJob.complete(mutation)
             val refresh = store.reduce { state ->
-                gate.awaitPeers()
-                runBlocking { mutationJob.await().join() }
                 state.copy(
                     inboxState = state.inboxState.replace(
                         NotificationSource.PIPELINE,
@@ -95,10 +169,11 @@ class NotificationCenterStateStoreTest {
     }
 
     @Test
-    fun concurrentMutationsConsumeBothNotificationsWithoutLostUpdate() = runBlocking {
+    fun concurrentMutationsConsumeBothNotificationsWithoutLostUpdate() = runTest {
         val first = notification("not_first")
         val second = notification("not_second")
-        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(SupervisorJob() + dispatcher)
         val store = NotificationCenterStateStore(
             scope = scope,
             initialState = NotificationCenterUiState(
@@ -107,20 +182,14 @@ class NotificationCenterStateStoreTest {
                     listOf(first, second),
                 ),
             ),
-            reducerDispatcher = Dispatchers.Default,
+            reducerDispatcher = dispatcher,
         )
-        val gate = ConcurrentReductionGate(participants = 2)
-        val firstMutationJob = CompletableDeferred<Job>()
 
         try {
             val firstMutation = store.reduce { state ->
-                gate.awaitPeers()
                 state.copy(inboxState = state.inboxState.consume(first))
             }
-            firstMutationJob.complete(firstMutation)
             val secondMutation = store.reduce { state ->
-                gate.awaitPeers()
-                runBlocking { firstMutationJob.await().join() }
                 state.copy(inboxState = state.inboxState.consume(second))
             }
             joinAll(firstMutation, secondMutation)
@@ -144,14 +213,4 @@ class NotificationCenterStateStoreTest {
         type = "boop",
         actions = emptyList(),
     )
-}
-
-private class ConcurrentReductionGate(private val participants: Int) {
-    private val entered = atomic(0)
-    private val release = CompletableDeferred<Unit>()
-
-    fun awaitPeers() = runBlocking {
-        if (entered.incrementAndGet() == participants) release.complete(Unit)
-        withTimeoutOrNull(1_000) { release.await() }
-    }
 }

--- a/composeApp/src/commonTest/kotlin/presentation/screens/notification/NotificationCenterStateStoreTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/notification/NotificationCenterStateStoreTest.kt
@@ -1,0 +1,157 @@
+package io.github.vrcmteam.vrcm.presentation.screens.notification
+
+import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationInboxState
+import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationItemData
+import io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationSource
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NotificationCenterStateStoreTest {
+    @Test
+    fun staleRefreshCannotRevertNotificationMarkedReadByEarlierMutation() = runBlocking {
+        val target = notification("not_target")
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val store = NotificationCenterStateStore(
+            scope = scope,
+            initialState = NotificationCenterUiState(
+                inboxState = NotificationInboxState().replace(
+                    NotificationSource.PIPELINE,
+                    listOf(target),
+                ),
+            ),
+            reducerDispatcher = Dispatchers.Default,
+        )
+
+        try {
+            store.reduce { state ->
+                state.copy(inboxState = state.inboxState.markSeen(target))
+            }.join()
+            store.reduce { state ->
+                state.copy(
+                    inboxState = state.inboxState.replace(
+                        NotificationSource.PIPELINE,
+                        listOf(target),
+                    ),
+                )
+            }.join()
+
+            assertEquals(true, store.value.inboxState.pipeline.single().seen)
+        } finally {
+            store.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun staleRefreshCannotRestoreNotificationConsumedByConcurrentMutation() = runBlocking {
+        val target = notification("not_target")
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val store = NotificationCenterStateStore(
+            scope = scope,
+            initialState = NotificationCenterUiState(
+                inboxState = NotificationInboxState().replace(
+                    NotificationSource.PIPELINE,
+                    listOf(target),
+                ),
+            ),
+            reducerDispatcher = Dispatchers.Default,
+        )
+        val gate = ConcurrentReductionGate(participants = 2)
+        val mutationJob = CompletableDeferred<Job>()
+
+        try {
+            val mutation = store.reduce { state ->
+                gate.awaitPeers()
+                state.copy(inboxState = state.inboxState.consume(target))
+            }
+            mutationJob.complete(mutation)
+            val refresh = store.reduce { state ->
+                gate.awaitPeers()
+                runBlocking { mutationJob.await().join() }
+                state.copy(
+                    inboxState = state.inboxState.replace(
+                        NotificationSource.PIPELINE,
+                        listOf(target),
+                    ),
+                )
+            }
+            joinAll(mutation, refresh)
+
+            assertEquals(emptyList(), store.value.inboxState.pipeline)
+        } finally {
+            store.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun concurrentMutationsConsumeBothNotificationsWithoutLostUpdate() = runBlocking {
+        val first = notification("not_first")
+        val second = notification("not_second")
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val store = NotificationCenterStateStore(
+            scope = scope,
+            initialState = NotificationCenterUiState(
+                inboxState = NotificationInboxState().replace(
+                    NotificationSource.PIPELINE,
+                    listOf(first, second),
+                ),
+            ),
+            reducerDispatcher = Dispatchers.Default,
+        )
+        val gate = ConcurrentReductionGate(participants = 2)
+        val firstMutationJob = CompletableDeferred<Job>()
+
+        try {
+            val firstMutation = store.reduce { state ->
+                gate.awaitPeers()
+                state.copy(inboxState = state.inboxState.consume(first))
+            }
+            firstMutationJob.complete(firstMutation)
+            val secondMutation = store.reduce { state ->
+                gate.awaitPeers()
+                runBlocking { firstMutationJob.await().join() }
+                state.copy(inboxState = state.inboxState.consume(second))
+            }
+            joinAll(firstMutation, secondMutation)
+
+            assertEquals(emptyList(), store.value.inboxState.pipeline)
+        } finally {
+            store.close()
+            scope.cancel()
+        }
+    }
+
+    private fun notification(id: String) = NotificationItemData(
+        id = id,
+        source = NotificationSource.PIPELINE,
+        imageUrl = "",
+        title = null,
+        message = "",
+        createdAt = "2026-08-30T00:00:00Z",
+        senderUserId = "usr_sender",
+        link = null,
+        type = "boop",
+        actions = emptyList(),
+    )
+}
+
+private class ConcurrentReductionGate(private val participants: Int) {
+    private val entered = atomic(0)
+    private val release = CompletableDeferred<Unit>()
+
+    fun awaitPeers() = runBlocking {
+        if (entered.incrementAndGet() == participants) release.complete(Unit)
+        withTimeoutOrNull(1_000) { release.await() }
+    }
+}


### PR DESCRIPTION
## 概要

- 引入 `NotificationCenterStateStore` actor，将通知刷新、已读、响应、删除和会话切换产生的 Compose 状态更新按 FIFO 串行归并。
- 以 `NotificationIdentity` 为键统一 action/read/delete 三类 pending 状态，并在 actor 内原子完成会话校验、跨类型查重和占位。
- 不同通知的网络 IO 仍可并行；只有成功取得 reservation 的调用会启动请求，完成或取消后统一释放占位。

## 代码流程

```mermaid
flowchart LR
    A["响应 已读 删除"] --> B["StateStore 原子 reservation"]
    B -->|已有同通知操作| C["拒绝重复请求"]
    B -->|占位成功| D["启动会话绑定的网络 IO"]
    D --> E["提交状态 reduction"]
    E --> F["actor FIFO 更新 Compose 状态"]
    F --> G["释放 pending 占位"]
    H["刷新与会话切换"] --> F
```

## 实现假设

- `NotificationIdentity` 能稳定区分不同通知源中的同名 ID。
- 同一通知同一时刻只允许一种 mutation，不同通知之间允许并行网络请求。
- `AccountSessionToken` 同时包含账户与 generation，可阻止旧会话结果写回新会话。
- `NotificationCenterStateStore` 是通知中心 Compose 状态的唯一写入者。

## 测试结果

- 修复前并发 reservation 红灯为 `expected 1, actual 3`，取消场景红灯为 `expected false, actual true`。
- `NotificationCenterStateStoreTest` 覆盖刷新/mutation 交错、并发 mutation、跨类型 reservation、旧刷新回退和取消清理。
- 完整 `desktopTest`：`785/785` 通过，0 失败、0 跳过。
- `./gradlew :composeApp:compileKotlinDesktop` 与 `git diff --check upstream/newui..HEAD` 通过。

## 剩余风险

- 未单独运行 Android/iOS 平台测试；并发入口由生产 StateStore 契约测试覆盖，未搭建完整网络 Model 集成测试。
- 用户资料补全 PR 也会修改 `NotificationCenterModel`；若其先合并，本分支需要基于最新 `newui` 重放。

## 实现假设清单

- `NotificationIdentity` 能稳定区分不同通知源中的同名 ID。
- 同一通知同一时刻只允许一种 mutation，不同通知之间允许并行网络请求。
- `AccountSessionToken` 同时包含账户与 generation，可阻止旧会话结果写回新会话。
- `NotificationCenterStateStore` 是通知中心 Compose 状态的唯一写入者。
