### PR TITLE
fix(home): 修正好友动态底部菜单遮挡

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/screens/activity/FriendActivityTimelineScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/activity/FriendActivityTimelineScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.github.vrcmteam.vrcm.presentation.compoments.AImage
 import io.github.vrcmteam.vrcm.presentation.navigation.AppDetailRoute
@@ -130,6 +131,7 @@ fun FriendActivityTimelineContent(
     modifier: Modifier = Modifier,
     listState: LazyListState = rememberLazyListState(),
     headerContent: (@Composable () -> Unit)? = null,
+    bottomNavigationPadding: Dp = 0.dp,
 ) {
     val contentState = state as? FriendActivityTimelineState.Content
     LaunchedEffect(
@@ -164,6 +166,7 @@ fun FriendActivityTimelineContent(
                 listState = listState,
                 modifier = Modifier.weight(1f),
                 includeControls = false,
+                bottomNavigationPadding = bottomNavigationPadding,
             )
         }
     } else {
@@ -179,6 +182,7 @@ fun FriendActivityTimelineContent(
             modifier = modifier,
             headerContent = headerContent,
             includeControls = true,
+            bottomNavigationPadding = bottomNavigationPadding,
         )
     }
 }
@@ -196,13 +200,14 @@ private fun ActivityTimelineList(
     modifier: Modifier,
     headerContent: (@Composable () -> Unit)? = null,
     includeControls: Boolean,
+    bottomNavigationPadding: Dp,
 ) {
     LazyColumn(
         modifier = modifier.fillMaxSize().navigationBarsPadding(),
         state = listState,
         contentPadding = PaddingValues(
             top = if (includeControls) 0.dp else 16.dp,
-            bottom = 16.dp,
+            bottom = 16.dp + bottomNavigationPadding,
         ),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
@@ -336,11 +336,7 @@ private fun FriendActivityTimelineDestination(
         },
         listState = listState,
         headerContent = headerContent,
-        modifier = Modifier
-            .windowInsetsPadding(
-                WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom),
-            )
-            .padding(bottom = if (hasBottomNavigation) 80.dp else 0.dp),
+        bottomNavigationPadding = if (hasBottomNavigation) 80.dp else 0.dp,
     )
 }
 


### PR DESCRIPTION
## 问题

首页好友动态此前把系统安全区和 80dp 底栏避让作为整个时间线容器的外层 `Modifier`，时间线内部又使用 `navigationBarsPadding()`。列表 viewport 因此在底部菜单处提前截止，并可能重复计算系统底部 inset；其他首页列表则通过列表内容边距避让浮动菜单。

## 修改

- 为 `FriendActivityTimelineContent` 增加应用底栏内容边距参数。
- 将首页的 80dp 底栏避让合并到 `LazyColumn.contentPadding.bottom`。
- 保留 `LazyColumn` 铺满父容器，末项仍可滚动到菜单上方。
- 系统导航栏继续由原有 `navigationBarsPadding()` 处理。
- 宽屏 Rail 和独立动态详情页继续使用 0dp 应用底栏边距。

## 验证

- `.\\gradlew.bat :composeApp:compileKotlinDesktop`
- `.\\gradlew.bat :composeApp:desktopTest --tests "...FriendActivityTimelineModelTest" --tests "...HomeShellStateTest"`
- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD^ HEAD`

以上命令均通过。该修改属于视觉布局修复，未新增重复实现细节的 UI 测试。

## 代码流程图

```mermaid
flowchart TD
    A[首页好友动态] --> B{显示底部导航}
    B -- 是 --> C[传入 80dp 应用底栏边距]
    B -- 否 --> D[传入 0dp]
    C --> E[FriendActivityTimelineContent]
    D --> E
    E --> F[LazyColumn 保持 fillMaxSize]
    F --> G[contentPadding.bottom = 16dp + 底栏边距]
    F --> H[navigationBarsPadding 处理系统栏]
    G --> I[末项可滚动至菜单上方]
```

## 实现假设

- 80dp 是首页现有浮动底栏的布局契约，与通知页保持一致。
- 新参数只表示应用底栏，不包含系统导航栏 inset。
- 独立动态详情页使用默认 0dp，保持现有布局。
- 分页、滚动状态、共享元素和导航回调不需要改变。

## 尚未人工验证

尚未在 Android、iOS 真机及窄窗口、大字体组合下核对实际系统 inset；残余风险限于平台特定的底部视觉间距。

## 实现假设清单

- 80dp 是首页现有浮动底栏的布局契约，与通知页保持一致。
- 新增的应用底栏边距参数不包含系统导航栏 inset，系统 inset 仍由 `navigationBarsPadding()` 处理。
- 宽屏 Rail 和独立动态详情页继续使用 0dp 应用底栏边距。
- 本轮只补充正文结构，不改变原始需求、验收项或实现行为。
