### PR TITLE
fix(friends): 恢复好友列表条目内容展示

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/compoments/SearchItemRenderers.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/SearchItemRenderers.kt
@@ -65,7 +65,7 @@ fun LazyItemScope.renderUserItem(
                 modifier = Modifier.sharedBoundsBy(
                     key = "${user.id}UserIcon",
                     suffixKey = sharedSuffixKey,
-                ),
+                ).size(48.dp),
                 iconUrl = user.iconUrl,
             )
         },


### PR DESCRIPTION
## 问题

通用用户条目为了支持大字体，已从固定高度改为最小高度；但头像仍只有宽高比，没有明确尺寸。好友目录复用该条目后，头像会按整行可用宽度测量，挤出名称、状态和最后活动时间，最终看起来只剩头像。

## 修改

- 为共享用户条目的 `UserStateIcon` 恢复 48dp 尺寸约束。
- 保留 `heightIn(min = 68.dp)` 的自适应高度，不回退大字体适配。
- 保留原有筛选、排序、点击导航和共享转场行为。
- 修复共享 renderer，因此好友目录、公开用户搜索和共同好友等同类列表都遵守同一头像尺寸契约。

## 验证

- `.\gradlew.bat :composeApp:compileKotlinDesktop`
- `.\gradlew.bat :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.presentation.compoments.UserStatusRowSharedTransitionTest" --tests "io.github.vrcmteam.vrcm.presentation.compoments.UserStateIconRequestTest" --tests "io.github.vrcmteam.vrcm.presentation.screens.home.pager.FriendListPagerModelTest"`
- `git diff --check`

以上命令均通过。该修改属于视觉布局修复，未新增重复实现细节的 UI 测试。

## 代码流程图

```mermaid
flowchart TD
    A[好友目录 FriendData] --> B[renderUserItems]
    B --> C[renderUserItem]
    C --> D[SearchResultItem / ListItem]
    D --> E[48dp UserStateIcon]
    D --> F[UserInfoRow 名称与代词]
    D --> G[UserStatusRow 状态]
    D --> H[离线最后活动时间]
    E --> I[稳定 leading 宽度]
    I --> F
    I --> G
    I --> H
```

## 实现假设清单

- 48dp 是共享列表 leading 头像的既有尺寸契约。
- 自适应条目高度必须保留，以继续支持大字体。
- 所有 `renderUserItem` 调用点都受同一测量问题影响，公共组件是根因修复位置。
- 本次不改变头像状态圈语义、数据流、筛选、排序或导航。

## 尚未人工验证

尚未在 Android、iOS 真机及窄窗口、超大系统字体组合下做截图核对；残余风险限于这些组合下的文本换行与尾部时间空间分配。
