### PR TITLE
fix(notifications): 精简通知卡片操作并补全 Boop 回复

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/data/BoopNotificationResolver.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/data/BoopNotificationResolver.kt
@@ -32,7 +32,7 @@ internal class BoopNotificationResolver(
     ): List<NotificationItemData> {
         val cachedFallbacks = fallbackCacheLock.withLock { fallbackCache.toMap() }
         val missingUserIds = notifications.asSequence()
-            .filter { it.type == "boop" }
+            .filter { it.type.equals("boop", ignoreCase = true) }
             .mapNotNull { it.senderId }
             .distinct()
             .filterNot { it in friends || it in cachedFallbacks }
@@ -51,7 +51,7 @@ internal class BoopNotificationResolver(
 
         val presentations = cachedFallbacks + fetchedFallbacks + friends
         return notifications.map { notification ->
-            if (notification.type != "boop") return@map notification
+            if (!notification.type.equals("boop", ignoreCase = true)) return@map notification
             val presentation = notification.senderId?.let(presentations::get)
                 ?: return@map notification
             notification.copy(

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/data/NotificationItemData.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/data/NotificationItemData.kt
@@ -212,10 +212,18 @@ internal fun NotificationItemData.responseTarget(
 ): NotificationResponseTarget =
     if (action.type.equals("link", ignoreCase = true)) {
         NotificationResponseTarget.NAVIGATION_LINK
-    } else if (type == "boop" && action.icon.equals("reply", ignoreCase = true)) {
+    } else if (type.equals("boop", ignoreCase = true) && action.icon.equals("reply", ignoreCase = true)) {
         NotificationResponseTarget.BOOP_USER_API
     } else {
         NotificationResponseTarget.NOTIFICATION_API
+    }
+
+/** Resolves the server reply response, with a Users API fallback when a Boop omits responses. */
+internal val NotificationItemData.boopReplyAction: NotificationItemData.ActionData?
+    get() {
+        if (!type.equals("boop", ignoreCase = true)) return null
+        return actions.firstOrNull { responseTarget(it) == NotificationResponseTarget.BOOP_USER_API }
+            ?: NotificationItemData.ActionData(data = "", type = "boop", icon = "reply")
     }
 
 internal sealed interface NotificationActionTarget {

--- a/composeApp/src/commonMain/kotlin/presentation/screens/notification/NotificationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/notification/NotificationScreen.kt
@@ -9,20 +9,19 @@ import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Reply
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import io.github.vrcmteam.vrcm.core.extensions.capitalizeFirst
 import io.github.vrcmteam.vrcm.network.api.attributes.NotificationType
 import io.github.vrcmteam.vrcm.presentation.compoments.AImage
 import io.github.vrcmteam.vrcm.presentation.compoments.LocalSharedSuffixKey
@@ -36,8 +35,6 @@ import io.github.vrcmteam.vrcm.presentation.screens.home.data.*
 import io.github.vrcmteam.vrcm.presentation.screens.user.BoopSelectorDialog
 import io.github.vrcmteam.vrcm.presentation.screens.user.UserProfileScreen
 import io.github.vrcmteam.vrcm.presentation.screens.user.data.UserProfileVo
-import io.github.vrcmteam.vrcm.presentation.screens.world.WorldProfileScreen
-import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
 import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
 import io.github.vrcmteam.vrcm.service.isGroupNotificationType
@@ -92,12 +89,8 @@ fun NotificationCenterContent(
     val boopSuccess = strings.profileBoopSuccess
     val boopAlreadySent = strings.profileBoopAlreadySent
     val boopDisabled = strings.profileBoopDisabled
-    val onResponse: (NotificationItemData, NotificationItemData.ActionData) -> Unit = { item, action ->
-        if (item.responseTarget(action) == NotificationResponseTarget.BOOP_USER_API) {
-            boopReply = BoopReply(item, action)
-        } else {
-            model.respondToNotification(item, action, null, boopSuccess, boopAlreadySent, boopDisabled)
-        }
+    val onBoopReply: (NotificationItemData, NotificationItemData.ActionData) -> Unit = { item, action ->
+        boopReply = BoopReply(item, action)
     }
     val reply = boopReply
     val replySending = reply?.let { model.pendingAction(it.item) == it.action } == true
@@ -184,7 +177,7 @@ fun NotificationCenterContent(
                         pending = model.isNotificationPending(item),
                         onRead = { model.markNotificationAsRead(item) },
                         onDelete = { model.deleteNotification(item) },
-                        onResponse = onResponse,
+                        onBoopReply = onBoopReply,
                     )
                 }
             }
@@ -231,7 +224,7 @@ private fun LazyItemScope.NotificationItem(
     pending: Boolean,
     onRead: () -> Unit,
     onDelete: () -> Unit,
-    onResponse: (NotificationItemData, NotificationItemData.ActionData) -> Unit,
+    onBoopReply: (NotificationItemData, NotificationItemData.ActionData) -> Unit,
 ) {
     val identity = item.identity
     var expanded by remember(identity.stableKey) { mutableStateOf(false) }
@@ -248,6 +241,7 @@ private fun LazyItemScope.NotificationItem(
         }
     }
     val headline = item.announcementTitle ?: item.title ?: item.groupName ?: item.message
+    val boopReplyAction = item.boopReplyAction
     Box(
         Modifier.fillMaxWidth().animateItem().clip(MaterialTheme.shapes.large)
             .background(
@@ -319,55 +313,31 @@ private fun LazyItemScope.NotificationItem(
                     )
                 }
             }
-            FlowRow(
-                Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End,
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                item.actions.forEach { action ->
-                    val loading = loadingAction == action
-                    FilledTonalButton(
-                        onClick = {
-                            if (action.type.equals("link", true)) {
-                                if (!item.seen) onRead()
-                                when (val target = item.actionTarget(action)) {
-                                    is NotificationActionTarget.User -> navigator push UserProfileScreen(
-                                        UserProfileVo(id = target.id, profileImageUrl = item.imageUrl),
-                                        sharedSuffixKey,
-                                    )
-                                    is NotificationActionTarget.Group -> navigator push GroupProfileScreen(
-                                        GroupProfileVo(groupId = target.id),
-                                    )
-                                    is NotificationActionTarget.World -> navigator push WorldProfileScreen(
-                                        WorldProfileVo(worldId = target.id),
-                                    )
-                                    null -> Unit
-                                }
-                            } else onResponse(item, action)
-                        },
-                        enabled = !pending,
-                        modifier = Modifier.padding(start = 6.dp).animateContentSize(),
-                    ) {
-                        Box(contentAlignment = Alignment.Center) {
-                            Text(
-                                notificationActionLabel(item, action),
-                                Modifier.alpha(if (loading) 0f else 1f),
-                            )
-                            if (loading) CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp)
+            if (boopReplyAction != null || !item.seen || item.canDelete) {
+                FlowRow(
+                    Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    if (boopReplyAction != null) {
+                        val loading = loadingAction == boopReplyAction
+                        IconButton(
+                            enabled = !pending && senderId.isNotEmpty(),
+                            onClick = { onBoopReply(item, boopReplyAction) },
+                        ) {
+                            if (loading) {
+                                CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
+                            } else {
+                                Icon(Icons.AutoMirrored.Outlined.Reply, strings.notificationReplyBoop)
+                            }
                         }
                     }
-                }
-                if (!item.seen) IconButton(enabled = !pending, onClick = onRead) {
-                    Icon(Icons.Outlined.MarkEmailRead, strings.notificationMarkRead)
-                }
-                if (item.canDelete) IconButton(enabled = !pending, onClick = onDelete) {
-                    Icon(Icons.Default.DeleteOutline, strings.notificationDelete)
-                }
-                IconButton(enabled = !pending, onClick = { expanded = !expanded }) {
-                    Icon(
-                        if (expanded) AppIcons.ExpandLess else AppIcons.ExpandMore,
-                        if (expanded) strings.notificationCollapse else strings.notificationExpand,
-                    )
+                    if (!item.seen) IconButton(enabled = !pending, onClick = onRead) {
+                        Icon(Icons.Outlined.MarkEmailRead, strings.notificationMarkRead)
+                    }
+                    if (item.canDelete) IconButton(enabled = !pending, onClick = onDelete) {
+                        Icon(Icons.Default.DeleteOutline, strings.notificationDelete)
+                    }
                 }
             }
             AnimatedVisibility(expanded) {
@@ -400,18 +370,6 @@ private fun NotificationTypeLabel(item: NotificationItemData) {
         },
         style = MaterialTheme.typography.labelSmall,
     )
-}
-
-@Composable
-private fun notificationActionLabel(
-    item: NotificationItemData,
-    action: NotificationItemData.ActionData,
-) = when {
-    item.type == NotificationType.FriendRequest.value && action.type.equals("Accept", true) ->
-        strings.notificationAccept
-    item.type == NotificationType.FriendRequest.value -> strings.notificationIgnore
-    action.label.isNotBlank() -> action.label
-    else -> action.type.capitalizeFirst()
 }
 
 private fun boopIcon(emojiId: String?) = when (emojiId?.lowercase()) {

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
@@ -102,6 +102,7 @@ sealed class LocaleStrings {
     open val notificationRefreshFailed: String = "Notifications could not be refreshed. Existing items are still available."
     open val notificationMarkRead: String = "Mark as read"
     open val notificationDelete: String = "Delete notification"
+    open val notificationReplyBoop: String = "Reply to Boop"
     open val notificationAccept: String = "Accept"
     open val notificationIgnore: String = "Ignore"
     open val notificationExpand: String = "Show details"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
@@ -90,6 +90,7 @@ internal object LocaleStringsJa : LocaleStrings() {
     override val notificationRefreshFailed = "通知を更新できませんでした。既存の通知は引き続き表示されます。"
     override val notificationMarkRead = "既読にする"
     override val notificationDelete = "通知を削除"
+    override val notificationReplyBoop = "Boop に返信"
     override val notificationAccept = "承認"
     override val notificationIgnore = "無視"
     override val notificationExpand = "詳細を表示"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
@@ -89,6 +89,7 @@ internal object LocaleStringsZhHans : LocaleStrings() {
     override val notificationRefreshFailed = "通知刷新失败，已有通知仍可查看。"
     override val notificationMarkRead = "标为已读"
     override val notificationDelete = "删除通知"
+    override val notificationReplyBoop = "回复戳一戳"
     override val notificationAccept = "接受"
     override val notificationIgnore = "忽略"
     override val notificationExpand = "显示详情"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
@@ -89,6 +89,7 @@ internal object LocaleStringsZhHant : LocaleStrings() {
     override val notificationRefreshFailed = "通知重新整理失敗，已有通知仍可查看。"
     override val notificationMarkRead = "標為已讀"
     override val notificationDelete = "刪除通知"
+    override val notificationReplyBoop = "回覆戳一戳"
     override val notificationAccept = "接受"
     override val notificationIgnore = "忽略"
     override val notificationExpand = "顯示詳情"

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/data/BoopNotificationResolverTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/data/BoopNotificationResolverTest.kt
@@ -27,10 +27,51 @@ class BoopNotificationResolverTest {
         )
 
         assertEquals("reply", item.actions.single().icon)
+        assertEquals(item.actions.single(), item.boopReplyAction)
         assertEquals("usr_sender", item.senderId)
         assertEquals(
             NotificationResponseTarget.BOOP_USER_API,
             item.responseTarget(item.actions.single()),
+        )
+    }
+
+    @Test
+    fun boopReplyRoutingIgnoresNotificationTypeCase() {
+        val item = NotificationItemData(
+            notification(
+                link = null,
+                responses = listOf(
+                    ResponseData(
+                        responseData = "",
+                        icon = "reply",
+                        text = "Boop back",
+                        textKey = "notification.boop.reply",
+                        type = "boop",
+                    )
+                ),
+            ),
+        ).copy(type = "BOOP")
+
+        val replyAction = requireNotNull(item.boopReplyAction)
+        assertEquals(
+            NotificationResponseTarget.BOOP_USER_API,
+            item.responseTarget(replyAction),
+        )
+    }
+
+    @Test
+    fun boopWithoutResponseCanStillReplyThroughUsersApi() {
+        val item = NotificationItemData(
+            notification(
+                link = null,
+                responses = emptyList(),
+            ),
+        )
+
+        val replyAction = requireNotNull(item.boopReplyAction)
+        assertEquals(
+            NotificationResponseTarget.BOOP_USER_API,
+            item.responseTarget(replyAction),
         )
     }
 

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/data/BoopNotificationResolverTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/data/BoopNotificationResolverTest.kt
@@ -112,6 +112,27 @@ class BoopNotificationResolverTest {
     }
 
     @Test
+    fun uppercaseBoopTypeStillEnrichesSenderPresentation() = runTest {
+        val resolver = BoopNotificationResolver()
+        val item = boop(id = "uppercase").copy(type = "BOOP")
+
+        val result = resolver.resolve(
+            notifications = listOf(item),
+            friends = mapOf(
+                "usr_sender" to NotificationUserPresentation(
+                    imageUrl = "https://example.com/sender.png",
+                    displayName = "Sender",
+                )
+            ),
+        ) {
+            error("sender in friend snapshot should not use the network")
+        }
+
+        assertEquals("https://example.com/sender.png", result.single().imageUrl)
+        assertEquals("Sender", result.single().title)
+    }
+
+    @Test
     fun duplicateSenderUsesOneFallbackRequestAndCachesIt() = runTest {
         val resolver = BoopNotificationResolver()
         val notifications = listOf(boop("first"), boop("second"))


### PR DESCRIPTION
## 问题

通知卡片会把服务端所有 `responses` 直接渲染成文字按钮，并额外显示展开按钮，导致操作区冗余。Boop 回复还依赖服务端提供 `reply` action，且类型判断区分大小写，无法保证每张 Boop 卡片都有回复入口。

## 修改

- 移除通知卡片中的文字响应按钮和独立展开图标；卡片点击仍可展开详情。
- 非 Boop 只保留“标为已读”和“删除”图标按钮。
- Boop 在操作区最前显示回复按钮，之后按状态显示“标为已读”和“删除”。
- 优先复用服务端真实 reply action；`responses` 为空时构造仅路由到现有 Users API 的本地回复动作。
- Boop 类型和 reply 图标识别改为大小写无关。
- pending 期间禁用卡片操作；发送回复时在回复按钮内显示进度，继续复用现有 mutation 串行化。
- 新增英文基准、日语、简体中文和繁体中文回复可访问性文案。

## 按钮顺序

- Boop：回复、标为已读（仅未读）、删除（仅 `canDelete`）。
- 非 Boop：标为已读（仅未读）、删除（仅 `canDelete`）。
- Boop 缺少发送者 ID 时回复按钮仍显示，但保持禁用。

## 验证

- `.\gradlew.bat :composeApp:compileKotlinDesktop`
- `.\gradlew.bat :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.presentation.screens.home.data.BoopNotificationResolverTest" --tests "io.github.vrcmteam.vrcm.presentation.screens.home.data.NotificationItemDataTest" --tests "io.github.vrcmteam.vrcm.presentation.screens.notification.NotificationInboxStateTest" --tests "io.github.vrcmteam.vrcm.presentation.screens.notification.NotificationCenterStateStoreTest" --tests "io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStringsStructureTest"`
- `git diff --check`

以上命令均通过；新增的大小写兼容和空 responses 回归测试均已确认修复前失败、修复后通过。

## 代码流程图

```mermaid
flowchart TD
    A[渲染通知卡片] --> B{类型为 Boop}
    B -- 是 --> C{存在真实 reply action}
    C -- 是 --> D[复用服务端 action]
    C -- 否 --> E[构造 Users API 回复动作]
    D --> F[首位显示回复按钮]
    E --> F
    B -- 否 --> G{通知未读}
    F --> G
    G -- 是 --> H[显示标为已读]
    G -- 否 --> I{允许删除}
    H --> I
    I -- 是 --> J[显示删除]
    I -- 否 --> K[结束]
    J --> K
```

## 实现假设

- “收到消息/确认收到”对应现有 `markNotificationAsRead`，不是服务端 response。
- “只保留”包含移除展开图标，但保留整张卡片点击展开详情。
- VRChat 不保证 Boop 的 `responses` 非空，因此需要本地回复动作回退。
- 有效 Boop 通常包含 `senderUserId`；缺失时不发送无目标请求。
- 删除能力继续严格服从 `canDelete`。

## 尚未人工验证

尚未用真实登录通知数据检查窄窗口、RTL 和不同实际通知内容下的图标观感；操作区继续使用可换行 `FlowRow` 和固定 `IconButton` 几何。

## 实现假设清单

本次实现的假设已在上文“实现假设”中完整列明，没有额外未经验证的行为假设。
