### PR TITLE
fix(home): 固定首页位置与动态标签栏

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/screens/activity/FriendActivityTimelineScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/activity/FriendActivityTimelineScreen.kt
@@ -131,6 +131,7 @@ fun FriendActivityTimelineContent(
     modifier: Modifier = Modifier,
     listState: LazyListState = rememberLazyListState(),
     headerContent: (@Composable () -> Unit)? = null,
+    controlsInList: Boolean = headerContent != null,
     bottomNavigationPadding: Dp = 0.dp,
 ) {
     val contentState = state as? FriendActivityTimelineState.Content
@@ -151,7 +152,7 @@ fun FriendActivityTimelineContent(
         onLoadMore()
     }
 
-    if (headerContent == null) {
+    if (!controlsInList) {
         Column(modifier = modifier.fillMaxSize()) {
             ActivityTimelineFilters(filter, onFilterSelected)
             ActivityTimelineObservedHint()
@@ -165,6 +166,7 @@ fun FriendActivityTimelineContent(
                 onWorldClick = onWorldClick,
                 listState = listState,
                 modifier = Modifier.weight(1f),
+                headerContent = headerContent,
                 includeControls = false,
                 bottomNavigationPadding = bottomNavigationPadding,
             )

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
@@ -227,35 +227,33 @@ private fun HomeDestinationContent(
                 if (page == HomeTab.Activity.ordinal) activityActivated = true
             }
     }
-    HorizontalPager(
-        state = pagerState,
-        modifier = Modifier.fillMaxSize(),
-        key = { HomeTab.entries[it].name },
-    ) { page ->
-        stateHolder.SaveableStateProvider(HomeTab.entries[page].name) {
-            val tabRow: @Composable () -> Unit = {
-                HomeTabRow(
-                    pagerState = pagerState,
-                    onReselect = { scope.launch { SharedFlowCentre.toPagerTop.emit(Unit) } },
-                )
-            }
-            when (HomeTab.entries[page]) {
-                HomeTab.Location -> Box(Modifier.fillMaxSize()) {
-                    CompositionLocalProvider(LocalSharedSuffixKey provides FriendLocationPager.title) {
-                        FriendLocationPager.Content(
-                            headerContent = tabRow,
-                            isActive = { pagerState.settledPage == HomeTab.Location.ordinal },
-                        )
+    Column(Modifier.fillMaxSize()) {
+        HomeTabRow(
+            pagerState = pagerState,
+            onReselect = { scope.launch { SharedFlowCentre.toPagerTop.emit(Unit) } },
+        )
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.weight(1f).fillMaxWidth(),
+            key = { HomeTab.entries[it].name },
+        ) { page ->
+            stateHolder.SaveableStateProvider(HomeTab.entries[page].name) {
+                when (HomeTab.entries[page]) {
+                    HomeTab.Location -> Box(Modifier.fillMaxSize()) {
+                        CompositionLocalProvider(LocalSharedSuffixKey provides FriendLocationPager.title) {
+                            FriendLocationPager.Content(
+                                isActive = { pagerState.settledPage == HomeTab.Location.ordinal },
+                            )
+                        }
                     }
-                }
-                HomeTab.Activity -> if (activityActivated) {
-                    FriendActivityTimelineDestination(
-                        hasBottomNavigation = hasBottomNavigation,
-                        headerContent = tabRow,
-                        isActive = { pagerState.settledPage == HomeTab.Activity.ordinal },
-                    )
-                } else {
-                    ActivityTimelinePreview(headerContent = tabRow)
+                    HomeTab.Activity -> if (activityActivated) {
+                        FriendActivityTimelineDestination(
+                            hasBottomNavigation = hasBottomNavigation,
+                            isActive = { pagerState.settledPage == HomeTab.Activity.ordinal },
+                        )
+                    } else {
+                        ActivityTimelinePreview()
+                    }
                 }
             }
         }
@@ -294,7 +292,6 @@ private fun HomeTabRow(
 @Composable
 private fun FriendActivityTimelineDestination(
     hasBottomNavigation: Boolean,
-    headerContent: @Composable () -> Unit,
     isActive: () -> Boolean,
 ) {
     val model: FriendActivityTimelineModel = koinViewModel()
@@ -335,16 +332,13 @@ private fun FriendActivityTimelineDestination(
             )
         },
         listState = listState,
-        headerContent = headerContent,
         bottomNavigationPadding = if (hasBottomNavigation) 80.dp else 0.dp,
     )
 }
 
 @Composable
-private fun ActivityTimelinePreview(headerContent: @Composable () -> Unit) {
-    Box(Modifier.fillMaxSize()) {
-        headerContent()
-    }
+private fun ActivityTimelinePreview() {
+    Spacer(Modifier.fillMaxSize())
 }
 
 @OptIn(ExperimentalSharedTransitionApi::class)

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
@@ -332,6 +332,7 @@ private fun FriendActivityTimelineDestination(
             )
         },
         listState = listState,
+        controlsInList = true,
         bottomNavigationPadding = if (hasBottomNavigation) 80.dp else 0.dp,
     )
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendLocationPager.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendLocationPager.kt
@@ -56,10 +56,9 @@ object FriendLocationPager : Pager {
     @ExperimentalSharedTransitionApi
     @Composable
     fun Content(
-        headerContent: @Composable () -> Unit,
         isActive: () -> Boolean,
     ) {
-        ContentInternal(headerContent = headerContent, isActive = isActive)
+        ContentInternal(headerContent = null, isActive = isActive)
     }
 
     @ExperimentalSharedTransitionApi


### PR DESCRIPTION
## 问题与实现说明

首页“位置/动态”标签栏原本作为 headerContent 分别注入 HorizontalPager 的两个页面，并成为各自 LazyColumn 的首项。左右拖动时，标签栏处在页面坐标系内，因此会跟随页面内容横向移动。

本 PR 将 HomeTabRow 提升为 HomeDestinationContent 中唯一的共享标签栏，HorizontalPager 只占据其下方剩余空间并仅承载页面内容。同时：

- 保留每页 SaveableStateProvider，位置页与动态页的页面状态仍独立保存。
- 保留基于 settledPage 的当前页判断，toPagerTop 只影响稳定选中的页面。
- 保留动态页稳定进入后再创建时间线的懒加载行为。
- 保留动态页底部导航 padding 与位置页 LocalSharedSuffixKey 作用域。
- 收紧位置页入口，首页不再向位置页注入横向分页标题。

## 验证命令

~~~text
.\gradlew.bat :composeApp:compileKotlinDesktop
.\gradlew.bat :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.presentation.screens.home.HomeShellStateTest" --tests "io.github.vrcmteam.vrcm.presentation.screens.home.HomeMeetupCardGestureTest"
git diff --check
~~~

验证结果：Desktop 编译成功；HomeShellStateTest 3 项与 HomeMeetupCardGestureTest 1 项全部通过；git diff --check 无空白错误。编译仅输出仓库既有弃用与 expect/actual 警告。

## 代码流程图

~~~mermaid
flowchart TD
    A[HomeDestinationContent] --> B[唯一共享 HomeTabRow]
    A --> C[HorizontalPager]
    B -->|点击标签| D[animateScrollToTab]
    B -->|重复点击| E[SharedFlowCentre.toPagerTop]
    C --> F[Location 页面内容]
    C --> G[Activity 页面内容]
    F -->|settledPage 为 Location| H[位置列表响应回顶]
    G -->|settledPage 为 Activity| I[动态列表响应回顶]
    C --> J[SaveableStateProvider 按页保存状态]
~~~

## 实现假设清单

- [x] “位置/动态”属于两个首页页面共用的导航标签，应只渲染一个实例。
- [x] 左右滑动仍切换页面，但共享标签栏不参与 HorizontalPager 的横向位移。
- [x] 当前页以 settledPage 为准，拖动未稳定时不应让非当前页响应回顶。
- [x] 动态时间线继续在首次稳定进入动态页后创建，避免恢复预加载开销。
- [x] 标签栏提升到 Pager 外后固定在首页内容顶部，页面内部继续各自管理纵向内容。

## 未验证风险

- 未在登录后的 Android、iOS 与 Desktop 实际数据页面进行手势视觉回归。
- 未执行 Android/iOS 平台打包；本次共享 Compose 布局以 Desktop 编译与相关现有测试验证。
- 纯视觉位移未添加像素级或 Compose UI 断言，窄窗口、大字体及快速往返拖动仍需人工确认。