### PR TITLE
feat(world): 显示世界平台包体大小

### DIFF
--- a/composeApp/src/commonMain/kotlin/network/api/files/FileApi.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/files/FileApi.kt
@@ -147,7 +147,7 @@ class FileApi(private val client: HttpClient) {
      * @return 文件信息
      */
     suspend fun getFileInfo(fileId: String): Result<FileResponse> = runCatching {
-        client.get("$FILES_API_PREFIX/$fileId").checkSuccess<FileResponse>()
+        client.get("$FILE_API_PREFIX/$fileId").checkSuccess<FileResponse>()
     }
     /**
      * 删除指定文件

--- a/composeApp/src/commonMain/kotlin/network/api/files/data/FileResponse.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/files/data/FileResponse.kt
@@ -25,7 +25,7 @@ data class FileVersionResponse(
     val status: String,
     @SerialName("created_at")
     val createdAt: String,
-    val file: FileDetailsResponse
+    val file: FileDetailsResponse? = null,
 )
 
 /**
@@ -35,9 +35,9 @@ data class FileVersionResponse(
 data class FileDetailsResponse(
     val category: String,
     val fileName: String,
-    val md5: String,
+    val md5: String? = null,
     val sizeInBytes: Long,
     val status: String,
     val uploadId: String,
-    val url: String
+    val url: String,
 )

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
@@ -183,21 +183,23 @@ class WorldProfileScreenModel internal constructor(
 
     private fun loadPlatformFileSizes(worldData: WorldData) {
         val job = viewModelScope.launch(Dispatchers.IO, start = CoroutineStart.LAZY) {
-            val platformFileSizes = worldPlatformService.getWorldPlatformFileSizes(worldData)
+            val result = worldPlatformService.getWorldPlatformFileSizes(worldData)
             _worldProfileState.update { currentProfile ->
                 if (currentProfile?.worldId == worldData.id) {
-                    currentProfile.copy(platformFileSizes = platformFileSizes)
+                    currentProfile.copy(platformFileSizes = result.platformFileSizes)
                 } else {
                     currentProfile
                 }
             }
-            worldProfileCacheStore.save(
-                WorldProfileCache(
-                    world = worldData,
-                    cachedAtEpochMilliseconds = Clock.System.now().toEpochMilliseconds(),
-                    platformFileSizes = platformFileSizes,
+            if (result.isComplete) {
+                worldProfileCacheStore.save(
+                    WorldProfileCache(
+                        world = worldData,
+                        cachedAtEpochMilliseconds = Clock.System.now().toEpochMilliseconds(),
+                        platformFileSizes = result.platformFileSizes,
+                    )
                 )
-            )
+            }
         }
         platformFileSizesJob.getAndSet(job)?.cancel()
         job.invokeOnCompletion { platformFileSizesJob.compareAndSet(job, null) }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
@@ -13,6 +13,7 @@ import io.github.vrcmteam.vrcm.network.api.instances.InstancesApi
 import io.github.vrcmteam.vrcm.network.api.invite.InviteApi
 import io.github.vrcmteam.vrcm.network.api.users.UsersApi
 import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
+import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
 import io.github.vrcmteam.vrcm.presentation.compoments.ToastText
 import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntrySource
 import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntryState
@@ -25,9 +26,12 @@ import io.github.vrcmteam.vrcm.service.AuthService
 import io.github.vrcmteam.vrcm.service.WorldPlatformService
 import io.github.vrcmteam.vrcm.storage.WorldProfileCacheStore
 import io.github.vrcmteam.vrcm.storage.data.WorldProfileCache
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
-import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
@@ -55,6 +59,7 @@ class WorldProfileScreenModel internal constructor(
     // 加载状态
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+    private val platformFileSizesJob = atomic<Job?>(null)
 
     private val favoriteEntry = FavoriteEntryStateModel(
         favoriteType = FavoriteType.World,
@@ -71,6 +76,9 @@ class WorldProfileScreenModel internal constructor(
      * 刷新世界数据
      */
     fun loadWorldData(worldProfileVO: WorldProfileVo) {
+        if (_worldProfileState.value?.worldId != worldProfileVO.worldId) {
+            platformFileSizesJob.getAndSet(null)?.cancel()
+        }
         _worldProfileState.value = worldProfileVO
         val worldId = worldProfileVO.worldId
         favoriteEntry.load(worldId)
@@ -85,13 +93,14 @@ class WorldProfileScreenModel internal constructor(
             _worldProfileState.value = WorldProfileVo(
                 world = cached.world,
                 instancesList = worldProfileVO.instances,
-                platformFileSizes = worldProfileVO.platformFileSizes,
+                platformFileSizes = cached.platformFileSizes ?: worldProfileVO.platformFileSizes,
             )
         }
 
         val shouldRefreshProfile = cached == null ||
             cached.isExpired(Clock.System.now().toEpochMilliseconds()) ||
-            cached.world.instances == null
+            cached.world.instances == null ||
+            cached.platformFileSizes == null
         if (shouldRefreshProfile) {
             refreshWorldData()
         } else {
@@ -145,27 +154,19 @@ class WorldProfileScreenModel internal constructor(
                 WorldProfileCache(
                     world = worldData,
                     cachedAtEpochMilliseconds = Clock.System.now().toEpochMilliseconds(),
+                    platformFileSizes = null,
                 )
             )
             if (_worldProfileState.value?.worldId != worldId) return@onSuccess
 
-            // TODO
-//            val platformFileSizes = mutableStateListOf<PlatformFileSize>()
             // 更新世界基本信息
             _worldProfileState.value =
                 WorldProfileVo(
-                    world = worldData, 
+                    world = worldData,
                     instancesList = _worldProfileState.value?.instances ?: mutableListOf(),
-//                    platformFileSizes = platformFileSizes,
+                    platformFileSizes = _worldProfileState.value?.platformFileSizes.orEmpty(),
                 )
-//            viewModelScope.launch(Dispatchers.IO) {
-//                // 获取平台文件大小信息
-//                runCatching {
-//                    platformFileSizes.addAll(worldPlatformService.getWorldPlatformFileSizes(worldData))
-//                }.onFailure {
-//                    SharedFlowCentre.toastText.emit(ToastText.Error("Failed to load platform file sizes: ${it.message}"))
-//                }
-//            }
+            loadPlatformFileSizes(worldData)
             // 获取实例ID列表
             val mergeInstanceIds = collectInstanceIds(
                 profile = _worldProfileState.value ?: return@onSuccess,
@@ -178,6 +179,29 @@ class WorldProfileScreenModel internal constructor(
         }.onFailure {
             SharedFlowCentre.toastText.emit(ToastText.Error(it.message ?: "Failed to load world data"))
         }
+    }
+
+    private fun loadPlatformFileSizes(worldData: WorldData) {
+        val job = viewModelScope.launch(Dispatchers.IO, start = CoroutineStart.LAZY) {
+            val platformFileSizes = worldPlatformService.getWorldPlatformFileSizes(worldData)
+            _worldProfileState.update { currentProfile ->
+                if (currentProfile?.worldId == worldData.id) {
+                    currentProfile.copy(platformFileSizes = platformFileSizes)
+                } else {
+                    currentProfile
+                }
+            }
+            worldProfileCacheStore.save(
+                WorldProfileCache(
+                    world = worldData,
+                    cachedAtEpochMilliseconds = Clock.System.now().toEpochMilliseconds(),
+                    platformFileSizes = platformFileSizes,
+                )
+            )
+        }
+        platformFileSizesJob.getAndSet(job)?.cancel()
+        job.invokeOnCompletion { platformFileSizesJob.compareAndSet(job, null) }
+        job.start()
     }
 
     private fun collectInstanceIds(

--- a/composeApp/src/commonMain/kotlin/service/WorldPlatformService.kt
+++ b/composeApp/src/commonMain/kotlin/service/WorldPlatformService.kt
@@ -2,29 +2,37 @@ package io.github.vrcmteam.vrcm.service
 
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.files.FileApi
-import io.github.vrcmteam.vrcm.network.api.files.FileApi.Companion.findFileId
-import io.github.vrcmteam.vrcm.network.api.files.FileApi.Companion.findFileVersion
 import io.github.vrcmteam.vrcm.network.api.files.data.PlatformFileSize
 import io.github.vrcmteam.vrcm.network.api.files.data.PlatformType
 import io.github.vrcmteam.vrcm.network.api.worlds.data.UnityPackage
 import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
 import io.github.vrcmteam.vrcm.presentation.compoments.ToastText
+import io.ktor.http.Url
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 
+/** 平台大小查询结果，以及结果是否可以作为完整缓存保存。 */
+data class WorldPlatformFileSizesResult(
+    val platformFileSizes: List<PlatformFileSize>,
+    val isComplete: Boolean,
+)
+
 /**
  * 用于处理世界平台相关操作的服务
  */
-class WorldPlatformService(private val fileApi: FileApi) {
+class WorldPlatformService(
+    private val fileApi: FileApi,
+    private val authService: AuthService,
+) {
 
     /**
      * 获取世界的所有平台文件大小
      * @param worldData 世界数据
-     * @return 平台文件大小列表
+     * @return 成功解析的平台大小，以及所有已发起查询是否都成功
      */
-    suspend fun getWorldPlatformFileSizes(worldData: WorldData): List<PlatformFileSize> = coroutineScope {
+    suspend fun getWorldPlatformFileSizes(worldData: WorldData): WorldPlatformFileSizesResult = coroutineScope {
         // 按平台对UnityPackages进行分组，并按创建日期排序（最新的在前）
         val platformPackages = worldData.unityPackages.platformPackages
 
@@ -35,12 +43,15 @@ class WorldPlatformService(private val fileApi: FileApi) {
 
             // 如果此平台有包且有assetUrl，则获取其文件大小
             latestPackage?.assetUrl?.let { assetUrl ->
-                async { getPlatformFileSize(platform, displayName, assetUrl).getOrNull() }
+                async { getPlatformFileSize(platform, displayName, assetUrl) }
             }
         }
 
-        // 等待所有请求完成并过滤掉空值
-        deferredResults.awaitAll().filterNotNull().toList()
+        val results = deferredResults.awaitAll()
+        WorldPlatformFileSizesResult(
+            platformFileSizes = results.mapNotNull { it.getOrNull() },
+            isComplete = results.all { it.isSuccess },
+        )
     }
 
     /**
@@ -54,19 +65,19 @@ class WorldPlatformService(private val fileApi: FileApi) {
         displayName: String,
         assetUrl: String,
     ): Result<PlatformFileSize> = try {
-        val fileId = findFileId(assetUrl)
-        if (fileId.isEmpty()) throw IllegalArgumentException("Invalid resource URL: $assetUrl")
-        val fileVersion = findFileVersion(assetUrl).toIntOrNull()
-            ?: throw IllegalArgumentException("Invalid resource version: $assetUrl")
+        val reference = parseFileReference(assetUrl)
+            ?: throw IllegalArgumentException("Invalid resource URL: $assetUrl")
 
-        val fileInfo = fileApi.getFileInfo(fileId).getOrThrow()
-        val packageVersion = fileInfo.versions.firstOrNull { it.version == fileVersion }
-            ?: error("Version $fileVersion of file $fileId was not found")
+        val fileInfo = authService.reTryAuth { fileApi.getFileInfo(reference.fileId) }.getOrThrow()
+        val packageVersion = fileInfo.versions.firstOrNull { it.version == reference.version }
+            ?: error("Version ${reference.version} of file ${reference.fileId} was not found")
+        val sizeInBytes = packageVersion.file?.sizeInBytes
+            ?: error("Version ${reference.version} of file ${reference.fileId} has no file data")
 
         Result.success(
             PlatformFileSize(
                 platform = platform,
-                sizeInBytes = packageVersion.file.sizeInBytes,
+                sizeInBytes = sizeInBytes,
                 displayName = displayName,
             )
         )
@@ -79,7 +90,18 @@ class WorldPlatformService(private val fileApi: FileApi) {
         Result.failure(error)
     }
 
+    private fun parseFileReference(assetUrl: String): FileReference? {
+        val segments = runCatching { Url(assetUrl).segments }.getOrNull() ?: return null
+        if (segments.size < FILE_REFERENCE_SEGMENT_COUNT) return null
+        val (resource, fileId, versionText, fileType) = segments.takeLast(FILE_REFERENCE_SEGMENT_COUNT)
+        val version = versionText.toIntOrNull()?.takeIf { it > 0 } ?: return null
+        if (resource != "file" || fileType != "file" || !fileIdRegex.matches(fileId)) return null
+        return FileReference(fileId, version)
+    }
+
     private companion object {
+        private const val FILE_REFERENCE_SEGMENT_COUNT = 4
+        private val fileIdRegex = Regex("file_[\\w-]+")
         private val supportedPlatforms = listOf(
             PlatformType.Windows to "PC",
             PlatformType.Android to "Android",
@@ -87,6 +109,11 @@ class WorldPlatformService(private val fileApi: FileApi) {
         )
     }
 }
+
+private data class FileReference(
+    val fileId: String,
+    val version: Int,
+)
 
 val List<UnityPackage>.platformPackages: Map<PlatformType, List<UnityPackage>>
     get() = this.groupBy { it.platform }

--- a/composeApp/src/commonMain/kotlin/service/WorldPlatformService.kt
+++ b/composeApp/src/commonMain/kotlin/service/WorldPlatformService.kt
@@ -3,11 +3,13 @@ package io.github.vrcmteam.vrcm.service
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.files.FileApi
 import io.github.vrcmteam.vrcm.network.api.files.FileApi.Companion.findFileId
+import io.github.vrcmteam.vrcm.network.api.files.FileApi.Companion.findFileVersion
 import io.github.vrcmteam.vrcm.network.api.files.data.PlatformFileSize
 import io.github.vrcmteam.vrcm.network.api.files.data.PlatformType
 import io.github.vrcmteam.vrcm.network.api.worlds.data.UnityPackage
 import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
 import io.github.vrcmteam.vrcm.presentation.compoments.ToastText
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -27,13 +29,13 @@ class WorldPlatformService(private val fileApi: FileApi) {
         val platformPackages = worldData.unityPackages.platformPackages
 
         // 处理每个支持的平台
-        val deferredResults = PlatformType.entries.mapNotNull { platform ->
+        val deferredResults = supportedPlatforms.mapNotNull { (platform, displayName) ->
             // 获取此平台的最新包
             val latestPackage = platformPackages[platform]?.firstOrNull()
 
             // 如果此平台有包且有assetUrl，则获取其文件大小
             latestPackage?.assetUrl?.let { assetUrl ->
-                async { getPlatformFileSize(platform, assetUrl).getOrNull() }
+                async { getPlatformFileSize(platform, displayName, assetUrl).getOrNull() }
             }
         }
 
@@ -47,26 +49,43 @@ class WorldPlatformService(private val fileApi: FileApi) {
      * @param assetUrl UnityPackage中的资源URL
      * @return 平台文件大小信息
      */
-    private suspend fun getPlatformFileSize(platform: PlatformType, assetUrl: String): Result<PlatformFileSize> =
-        runCatching {
-            val fileId = findFileId(assetUrl)
-            if (fileId.isEmpty()) error(IllegalArgumentException("Invalid resource URL: $assetUrl"))
+    private suspend fun getPlatformFileSize(
+        platform: PlatformType,
+        displayName: String,
+        assetUrl: String,
+    ): Result<PlatformFileSize> = try {
+        val fileId = findFileId(assetUrl)
+        if (fileId.isEmpty()) throw IllegalArgumentException("Invalid resource URL: $assetUrl")
+        val fileVersion = findFileVersion(assetUrl).toIntOrNull()
+            ?: throw IllegalArgumentException("Invalid resource version: $assetUrl")
 
-            val fileInfoResult = fileApi.getFileInfo(fileId)
-            if (fileInfoResult.isFailure) error(fileInfoResult.exceptionOrNull() ?: Exception("failed to get file information"))
+        val fileInfo = fileApi.getFileInfo(fileId).getOrThrow()
+        val packageVersion = fileInfo.versions.firstOrNull { it.version == fileVersion }
+            ?: error("Version $fileVersion of file $fileId was not found")
 
-            val fileInfo = fileInfoResult.getOrThrow()
-            // 获取最新版本
-            val latestVersion = fileInfo.versions.maxByOrNull { it.version }
-                ?: error("The version of file $fileId was not found")
+        Result.success(
+            PlatformFileSize(
+                platform = platform,
+                sizeInBytes = packageVersion.file.sizeInBytes,
+                displayName = displayName,
+            )
+        )
+    } catch (error: CancellationException) {
+        throw error
+    } catch (error: Throwable) {
+        SharedFlowCentre.toastText.emit(
+            ToastText.Error(error.message ?: "Failed to get platform file size")
+        )
+        Result.failure(error)
+    }
 
-            val sizeInBytes = latestVersion.file.sizeInBytes
-            val displayName = platform.name
-
-            PlatformFileSize(platform, sizeInBytes, displayName)
-        }.onFailure {
-            SharedFlowCentre.toastText.emit(ToastText.Error(it.message ?: "Failed to get platform file size"))
-        }
+    private companion object {
+        private val supportedPlatforms = listOf(
+            PlatformType.Windows to "PC",
+            PlatformType.Android to "Android",
+            PlatformType.Ios to "iOS",
+        )
+    }
 }
 
 val List<UnityPackage>.platformPackages: Map<PlatformType, List<UnityPackage>>

--- a/composeApp/src/commonMain/kotlin/storage/data/WorldProfileCache.kt
+++ b/composeApp/src/commonMain/kotlin/storage/data/WorldProfileCache.kt
@@ -1,5 +1,6 @@
 package io.github.vrcmteam.vrcm.storage.data
 
+import io.github.vrcmteam.vrcm.network.api.files.data.PlatformFileSize
 import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
 import kotlinx.serialization.Serializable
 
@@ -7,6 +8,8 @@ import kotlinx.serialization.Serializable
 data class WorldProfileCache(
     val world: WorldData,
     val cachedAtEpochMilliseconds: Long,
+    /** `null` 表示尚未解析；空列表表示已解析但世界没有可显示的平台包。 */
+    val platformFileSizes: List<PlatformFileSize>? = null,
 ) {
     fun isExpired(
         nowEpochMilliseconds: Long,

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldPlatformFileSizesTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldPlatformFileSizesTest.kt
@@ -1,0 +1,265 @@
+package io.github.vrcmteam.vrcm.presentation.screens.world
+
+import androidx.lifecycle.ViewModelStore
+import com.russhwolf.settings.MapSettings
+import io.github.vrcmteam.vrcm.di.supports.PersistentCookiesStorage
+import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
+import io.github.vrcmteam.vrcm.network.api.auth.AuthApi
+import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteData
+import io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteGroupData
+import io.github.vrcmteam.vrcm.network.api.files.FileApi
+import io.github.vrcmteam.vrcm.network.api.files.data.PlatformType
+import io.github.vrcmteam.vrcm.network.api.groups.GroupsApi
+import io.github.vrcmteam.vrcm.network.api.instances.InstancesApi
+import io.github.vrcmteam.vrcm.network.api.invite.InviteApi
+import io.github.vrcmteam.vrcm.network.api.users.UsersApi
+import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
+import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntrySource
+import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
+import io.github.vrcmteam.vrcm.service.AuthService
+import io.github.vrcmteam.vrcm.service.WorldPlatformService
+import io.github.vrcmteam.vrcm.storage.AccountCacheManager
+import io.github.vrcmteam.vrcm.storage.AccountDao
+import io.github.vrcmteam.vrcm.storage.InMemoryFriendListCacheStore
+import io.github.vrcmteam.vrcm.storage.InMemorySecureStorage
+import io.github.vrcmteam.vrcm.storage.InMemoryUserProfileCacheStore
+import io.github.vrcmteam.vrcm.storage.WorldProfileCacheStore
+import io.github.vrcmteam.vrcm.storage.data.WorldProfileCache
+import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardAssetStore
+import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardConfigDao
+import io.github.vrcmteam.vrcm.testing.MainDispatcherTest
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import kotlinx.serialization.json.Json
+import org.koin.core.logger.EmptyLogger
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WorldPlatformFileSizesTest : MainDispatcherTest() {
+    private val models = mutableListOf<WorldProfileScreenModel>()
+    private val clients = mutableListOf<HttpClient>()
+
+    @AfterTest
+    fun disposeResources() {
+        models.forEach(::clearModel)
+        clients.forEach(HttpClient::close)
+    }
+
+    @Test
+    fun worldLoadPublishesAndCachesReferencedPlatformPackageSizes() = runBlocking {
+        val worldRequests = atomic(0)
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.encodedPath) {
+                        "/worlds/$WORLD_ID" -> {
+                            worldRequests.incrementAndGet()
+                            jsonResponse(worldJson())
+                        }
+                        "/file/file_pc_current" -> jsonResponse(
+                            fileJson(
+                                fileId = "file_pc_current",
+                                versions = listOf(1 to 64L * MEBIBYTE, 2 to 128L * MEBIBYTE),
+                            )
+                        )
+                        "/file/file_pc_old" -> jsonResponse(
+                            fileJson("file_pc_old", listOf(1 to 512L * MEBIBYTE))
+                        )
+                        "/file/file_android" -> jsonResponse(
+                            fileJson("file_android", listOf(3 to 48L * MEBIBYTE))
+                        )
+                        "/file/file_ios" -> jsonResponse(
+                            fileJson("file_ios", listOf(1 to 40L * MEBIBYTE))
+                        )
+                        else -> error("Unexpected request: ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }.also(clients::add)
+        val cache = RecordingWorldProfileCacheStore()
+        val firstModel = createModel(client, cache)
+
+        firstModel.loadWorldData(WorldProfileVo(worldId = WORLD_ID))
+        awaitProfile {
+            firstModel.worldProfileState.value?.platformFileSizes?.size == 3 &&
+                cache.value.value?.platformFileSizes?.size == 3
+        }
+
+        val firstSizes = firstModel.worldProfileState.value.orEmptyPlatformSizes()
+        assertEquals(
+            listOf(PlatformType.Windows, PlatformType.Android, PlatformType.Ios),
+            firstSizes.map { it.platform },
+        )
+        assertEquals(listOf("PC", "Android", "iOS"), firstSizes.map { it.displayName })
+        assertEquals(listOf(64L, 48L, 40L), firstSizes.map { it.sizeInBytes / MEBIBYTE })
+        assertEquals(1, worldRequests.value)
+
+        clearModel(firstModel)
+        models.remove(firstModel)
+        val cachedModel = createModel(client, cache)
+        cachedModel.loadWorldData(WorldProfileVo(worldId = WORLD_ID))
+        awaitProfile { cachedModel.worldProfileState.value?.platformFileSizes?.size == 3 }
+
+        assertEquals(firstSizes, cachedModel.worldProfileState.value.orEmptyPlatformSizes())
+        assertEquals(1, worldRequests.value)
+    }
+
+    private fun createModel(
+        client: HttpClient,
+        cache: WorldProfileCacheStore,
+    ): WorldProfileScreenModel {
+        val logger = EmptyLogger()
+        val authService = AuthService(
+            authApi = AuthApi(client),
+            accountDao = AccountDao(MapSettings(), InMemorySecureStorage()),
+            cookiesStorage = PersistentCookiesStorage(logger),
+            accountCacheManager = AccountCacheManager(
+                friendListCacheStore = InMemoryFriendListCacheStore(),
+                userProfileCacheStore = InMemoryUserProfileCacheStore(),
+                friendActivityStore = io.github.vrcmteam.vrcm.storage.NoOpFriendActivityCacheStore,
+                meetupCardConfigDao = MeetupCardConfigDao(MapSettings()),
+                meetupCardAssetStore = MeetupCardAssetStore(
+                    FakeFileSystem(),
+                    "/meetup-assets".toPath(),
+                ),
+            ),
+        )
+        return WorldProfileScreenModel(
+            worldsApi = WorldsApi(client),
+            instancesApi = InstancesApi(client),
+            usersApi = UsersApi(client),
+            groupsApi = GroupsApi(client),
+            authService = authService,
+            favoriteEntrySource = CachedNotFavoriteSource,
+            inviteApi = InviteApi(client),
+            worldPlatformService = WorldPlatformService(FileApi(client)),
+            worldProfileCacheStore = cache,
+        ).also(models::add)
+    }
+
+    private fun clearModel(model: WorldProfileScreenModel) {
+        ViewModelStore().apply {
+            put("test", model)
+            clear()
+        }
+    }
+
+    private companion object {
+        const val WORLD_ID = "wrld_platform_sizes"
+        const val MEBIBYTE = 1024L * 1024L
+    }
+}
+
+private data object CachedNotFavoriteSource : FavoriteEntrySource {
+    private val favorites = MutableStateFlow<Map<FavoriteGroupData, List<FavoriteData>>>(emptyMap())
+
+    override fun favoritesByGroup(type: FavoriteType): StateFlow<Map<FavoriteGroupData, List<FavoriteData>>> =
+        favorites
+
+    override suspend fun load(type: FavoriteType): Result<Unit> = Result.success(Unit)
+
+    override suspend fun cachedFavorite(type: FavoriteType, favoriteId: String): Boolean = false
+}
+
+private class RecordingWorldProfileCacheStore : WorldProfileCacheStore {
+    val value = MutableStateFlow<WorldProfileCache?>(null)
+
+    override suspend fun load(worldId: String): WorldProfileCache? = value.value
+
+    override suspend fun save(cache: WorldProfileCache) {
+        value.value = cache
+    }
+
+    override suspend fun clearAll() {
+        value.value = null
+    }
+}
+
+private fun WorldProfileVo?.orEmptyPlatformSizes() = this?.platformFileSizes.orEmpty()
+
+private suspend fun awaitProfile(predicate: () -> Boolean) {
+    withTimeout(2_000) {
+        while (!predicate()) yield()
+    }
+}
+
+private fun MockRequestHandleScope.jsonResponse(content: String) = respond(
+    content = content,
+    status = HttpStatusCode.OK,
+    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+)
+
+private fun worldJson() = """
+    {
+      "authorId":"usr_author","authorName":"Author","capacity":16,"created_at":null,
+      "description":null,"favorites":0,"featured":false,"heat":0,"id":"wrld_platform_sizes",
+      "imageUrl":"","labsPublicationDate":"","name":"Platform World","namespace":null,
+      "organization":"","popularity":0,"privateOccupants":0,"publicOccupants":0,
+      "publicationDate":"","recommendedCapacity":16,"releaseStatus":"public","tags":[],
+      "thumbnailImageUrl":null,"udonProducts":[],"instances":[],"updated_at":null,"version":1,
+      "visits":0,
+      "unityPackages":[
+        {
+          "assetUrl":"https://api.vrchat.cloud/api/1/file/file_pc_old/1/file","assetVersion":1,
+          "created_at":"2025-01-01T00:00:00.000Z","id":"unp_pc_old",
+          "platform":"standalonewindows","pluginUrl":null,"unitySortNumber":1,
+          "unityVersion":"2022.3.22f1"
+        },
+        {
+          "assetUrl":"https://api.vrchat.cloud/api/1/file/file_pc_current/1/file","assetVersion":1,
+          "created_at":"2026-01-01T00:00:00.000Z","id":"unp_pc_current",
+          "platform":"standalonewindows","pluginUrl":null,"unitySortNumber":2,
+          "unityVersion":"2022.3.22f1"
+        },
+        {
+          "assetUrl":"https://api.vrchat.cloud/api/1/file/file_android/3/file","assetVersion":3,
+          "created_at":"2026-01-01T00:00:00.000Z","id":"unp_android",
+          "platform":"android","pluginUrl":null,"unitySortNumber":2,"unityVersion":"2022.3.22f1"
+        },
+        {
+          "assetUrl":"https://api.vrchat.cloud/api/1/file/file_ios/1/file","assetVersion":1,
+          "created_at":"2026-01-01T00:00:00.000Z","id":"unp_ios",
+          "platform":"ios","pluginUrl":null,"unitySortNumber":2,"unityVersion":"2022.3.22f1"
+        }
+      ]
+    }
+""".trimIndent()
+
+private fun fileJson(fileId: String, versions: List<Pair<Int, Long>>) = """
+    {
+      "id":"$fileId","name":"$fileId","ownerId":"usr_author",
+      "mimeType":"application/x-avatar","extension":".vrcw",
+      "versions":[
+        ${versions.joinToString(",") { (version, size) ->
+            """
+              {
+                "version":$version,"status":"complete","created_at":"2026-01-01T00:00:00.000Z",
+                "file":{
+                  "category":"simple","fileName":"world.vrcw","md5":"md5","sizeInBytes":$size,
+                  "status":"complete","uploadId":"upl_$version","url":"https://example.com/world.vrcw"
+                }
+              }
+            """.trimIndent()
+        }}
+      ]
+    }
+""".trimIndent()

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldPlatformFileSizesTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldPlatformFileSizesTest.kt
@@ -2,6 +2,7 @@ package io.github.vrcmteam.vrcm.presentation.screens.world
 
 import androidx.lifecycle.ViewModelStore
 import com.russhwolf.settings.MapSettings
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.di.supports.PersistentCookiesStorage
 import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
 import io.github.vrcmteam.vrcm.network.api.auth.AuthApi
@@ -18,6 +19,7 @@ import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntrySource
 import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
 import io.github.vrcmteam.vrcm.service.AuthService
 import io.github.vrcmteam.vrcm.service.WorldPlatformService
+import io.github.vrcmteam.vrcm.service.data.AccountDto
 import io.github.vrcmteam.vrcm.storage.AccountCacheManager
 import io.github.vrcmteam.vrcm.storage.AccountDao
 import io.github.vrcmteam.vrcm.storage.InMemoryFriendListCacheStore
@@ -50,6 +52,7 @@ import okio.fakefilesystem.FakeFileSystem
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class WorldPlatformFileSizesTest : MainDispatcherTest() {
     private val models = mutableListOf<WorldProfileScreenModel>()
@@ -59,6 +62,9 @@ class WorldPlatformFileSizesTest : MainDispatcherTest() {
     fun disposeResources() {
         models.forEach(::clearModel)
         clients.forEach(HttpClient::close)
+        runBlocking {
+            if (SharedFlowCentre.currentSession.value != null) SharedFlowCentre.emitLogout()
+        }
     }
 
     @Test
@@ -72,12 +78,7 @@ class WorldPlatformFileSizesTest : MainDispatcherTest() {
                             worldRequests.incrementAndGet()
                             jsonResponse(worldJson())
                         }
-                        "/file/file_pc_current" -> jsonResponse(
-                            fileJson(
-                                fileId = "file_pc_current",
-                                versions = listOf(1 to 64L * MEBIBYTE, 2 to 128L * MEBIBYTE),
-                            )
-                        )
+                        "/file/file_pc_current" -> jsonResponse(fileJsonWithOptionalFields())
                         "/file/file_pc_old" -> jsonResponse(
                             fileJson("file_pc_old", listOf(1 to 512L * MEBIBYTE))
                         )
@@ -123,14 +124,171 @@ class WorldPlatformFileSizesTest : MainDispatcherTest() {
         assertEquals(1, worldRequests.value)
     }
 
+    @Test
+    fun partialPlatformFailureRemainsUnresolvedAndRetriesOnNextLoad() = runBlocking {
+        val worldRequests = atomic(0)
+        val androidRequests = atomic(0)
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.encodedPath) {
+                        "/worlds/$WORLD_ID" -> {
+                            worldRequests.incrementAndGet()
+                            jsonResponse(worldJson())
+                        }
+                        "/file/file_pc_current" -> jsonResponse(
+                            fileJson("file_pc_current", listOf(1 to 64L * MEBIBYTE))
+                        )
+                        "/file/file_android" -> {
+                            if (androidRequests.incrementAndGet() == 1) {
+                                respond("temporarily unavailable", HttpStatusCode.ServiceUnavailable)
+                            } else {
+                                jsonResponse(fileJson("file_android", listOf(3 to 48L * MEBIBYTE)))
+                            }
+                        }
+                        "/file/file_ios" -> jsonResponse(
+                            fileJson("file_ios", listOf(1 to 40L * MEBIBYTE))
+                        )
+                        else -> error("Unexpected request: ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }.also(clients::add)
+        val cache = RecordingWorldProfileCacheStore()
+        val firstModel = createModel(client, cache)
+
+        firstModel.loadWorldData(WorldProfileVo(worldId = WORLD_ID))
+        awaitProfile { firstModel.worldProfileState.value?.platformFileSizes?.size == 2 }
+
+        assertEquals(
+            listOf(PlatformType.Windows, PlatformType.Ios),
+            firstModel.worldProfileState.value.orEmptyPlatformSizes().map { it.platform },
+        )
+        assertNull(cache.value.value?.platformFileSizes)
+
+        clearModel(firstModel)
+        models.remove(firstModel)
+        val retriedModel = createModel(client, cache)
+        retriedModel.loadWorldData(WorldProfileVo(worldId = WORLD_ID))
+        awaitProfile {
+            androidRequests.value == 2 &&
+                retriedModel.worldProfileState.value?.platformFileSizes?.size == 3 &&
+                cache.value.value?.platformFileSizes?.size == 3
+        }
+
+        assertEquals(2, worldRequests.value)
+    }
+
+    @Test
+    fun versionlessPackageUrlDoesNotFallBackToVersionOne() = runBlocking {
+        val androidRequests = atomic(0)
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.encodedPath) {
+                        "/worlds/$WORLD_ID" -> jsonResponse(
+                            worldJson(
+                                androidAssetUrl =
+                                    "https://api.vrchat.cloud/api/1/file/file_android/file",
+                            )
+                        )
+                        "/file/file_pc_current" -> jsonResponse(
+                            fileJson("file_pc_current", listOf(1 to 64L * MEBIBYTE))
+                        )
+                        "/file/file_android" -> {
+                            androidRequests.incrementAndGet()
+                            jsonResponse(fileJson("file_android", listOf(1 to 48L * MEBIBYTE)))
+                        }
+                        "/file/file_ios" -> jsonResponse(
+                            fileJson("file_ios", listOf(1 to 40L * MEBIBYTE))
+                        )
+                        else -> error("Unexpected request: ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }.also(clients::add)
+        val cache = RecordingWorldProfileCacheStore()
+        val model = createModel(client, cache)
+
+        model.loadWorldData(WorldProfileVo(worldId = WORLD_ID))
+        awaitProfile { model.worldProfileState.value?.platformFileSizes?.isNotEmpty() == true }
+
+        assertEquals(0, androidRequests.value)
+        assertEquals(
+            listOf(PlatformType.Windows, PlatformType.Ios),
+            model.worldProfileState.value.orEmptyPlatformSizes().map { it.platform },
+        )
+        assertNull(cache.value.value?.platformFileSizes)
+    }
+
+    @Test
+    fun fileRequestReauthenticatesAfterUnauthorizedResponse() = runBlocking {
+        val pcRequests = atomic(0)
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.encodedPath) {
+                        "/worlds/$WORLD_ID" -> jsonResponse(worldJson())
+                        "/file/file_pc_current" -> {
+                            if (pcRequests.incrementAndGet() == 1) {
+                                respond("expired", HttpStatusCode.Unauthorized)
+                            } else {
+                                jsonResponse(fileJson("file_pc_current", listOf(1 to 64L * MEBIBYTE)))
+                            }
+                        }
+                        "/file/file_android" -> jsonResponse(
+                            fileJson("file_android", listOf(3 to 48L * MEBIBYTE))
+                        )
+                        "/file/file_ios" -> jsonResponse(
+                            fileJson("file_ios", listOf(1 to 40L * MEBIBYTE))
+                        )
+                        "/auth/user" -> jsonResponse(currentUserJson())
+                        else -> error("Unexpected request: ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }.also(clients::add)
+        val cache = RecordingWorldProfileCacheStore()
+        val model = createModel(
+            client = client,
+            cache = cache,
+            account = AccountDto(
+                userId = "usr_cached",
+                username = "cached-user",
+                password = "cached-password",
+                current = true,
+            ),
+        )
+
+        model.loadWorldData(WorldProfileVo(worldId = WORLD_ID))
+        awaitProfile { model.worldProfileState.value?.platformFileSizes?.isNotEmpty() == true }
+
+        assertEquals(3, model.worldProfileState.value.orEmptyPlatformSizes().size)
+        assertEquals(2, pcRequests.value)
+        assertEquals(3, cache.value.value?.platformFileSizes?.size)
+    }
+
     private fun createModel(
         client: HttpClient,
         cache: WorldProfileCacheStore,
+        account: AccountDto? = null,
     ): WorldProfileScreenModel {
         val logger = EmptyLogger()
+        val accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also { dao ->
+            account?.let(dao::saveAccountInfo)
+        }
         val authService = AuthService(
             authApi = AuthApi(client),
-            accountDao = AccountDao(MapSettings(), InMemorySecureStorage()),
+            accountDao = accountDao,
             cookiesStorage = PersistentCookiesStorage(logger),
             accountCacheManager = AccountCacheManager(
                 friendListCacheStore = InMemoryFriendListCacheStore(),
@@ -151,7 +309,7 @@ class WorldPlatformFileSizesTest : MainDispatcherTest() {
             authService = authService,
             favoriteEntrySource = CachedNotFavoriteSource,
             inviteApi = InviteApi(client),
-            worldPlatformService = WorldPlatformService(FileApi(client)),
+            worldPlatformService = WorldPlatformService(FileApi(client), authService),
             worldProfileCacheStore = cache,
         ).also(models::add)
     }
@@ -208,7 +366,9 @@ private fun MockRequestHandleScope.jsonResponse(content: String) = respond(
     headers = headersOf(HttpHeaders.ContentType, "application/json"),
 )
 
-private fun worldJson() = """
+private fun worldJson(
+    androidAssetUrl: String = "https://api.vrchat.cloud/api/1/file/file_android/3/file",
+) = """
     {
       "authorId":"usr_author","authorName":"Author","capacity":16,"created_at":null,
       "description":null,"favorites":0,"featured":false,"heat":0,"id":"wrld_platform_sizes",
@@ -231,7 +391,7 @@ private fun worldJson() = """
           "unityVersion":"2022.3.22f1"
         },
         {
-          "assetUrl":"https://api.vrchat.cloud/api/1/file/file_android/3/file","assetVersion":3,
+          "assetUrl":"$androidAssetUrl","assetVersion":3,
           "created_at":"2026-01-01T00:00:00.000Z","id":"unp_android",
           "platform":"android","pluginUrl":null,"unitySortNumber":2,"unityVersion":"2022.3.22f1"
         },
@@ -239,6 +399,25 @@ private fun worldJson() = """
           "assetUrl":"https://api.vrchat.cloud/api/1/file/file_ios/1/file","assetVersion":1,
           "created_at":"2026-01-01T00:00:00.000Z","id":"unp_ios",
           "platform":"ios","pluginUrl":null,"unitySortNumber":2,"unityVersion":"2022.3.22f1"
+        }
+      ]
+    }
+""".trimIndent()
+
+private fun fileJsonWithOptionalFields() = """
+    {
+      "id":"file_pc_current","name":"file_pc_current","ownerId":"usr_author",
+      "mimeType":"application/x-avatar","extension":".vrcw",
+      "versions":[
+        {
+          "version":0,"status":"waiting","created_at":"2025-01-01T00:00:00.000Z"
+        },
+        {
+          "version":1,"status":"complete","created_at":"2026-01-01T00:00:00.000Z",
+          "file":{
+            "category":"simple","fileName":"world.vrcw","sizeInBytes":${64L * 1024L * 1024L},
+            "status":"complete","uploadId":"upl_1","url":"https://example.com/world.vrcw"
+          }
         }
       ]
     }
@@ -261,5 +440,38 @@ private fun fileJson(fileId: String, versions: List<Pair<Int, Long>>) = """
             """.trimIndent()
         }}
       ]
+    }
+""".trimIndent()
+
+private fun currentUserJson() = """
+    {
+      "requiresTwoFactorAuth":null,
+      "ageVerificationStatus":"verified","ageVerified":true,
+      "acceptedPrivacyVersion":0,"acceptedTOSVersion":0,
+      "accountDeletionDate":null,"accountDeletionLog":null,"activeFriends":[],
+      "allowAvatarCopying":true,"bio":null,"bioLinks":[],
+      "currentAvatar":"","currentAvatarAssetUrl":null,"currentAvatarImageUrl":"",
+      "currentAvatarTags":[],"currentAvatarThumbnailImageUrl":"","date_joined":"",
+      "developerType":"none","displayName":"cached-user","emailVerified":true,
+      "fallbackAvatar":"","friendGroupNames":[],"friendKey":"","friends":[],
+      "googleId":"","hasBirthday":true,"hasEmail":true,
+      "hasLoggedInFromClient":true,"hasPendingEmail":false,
+      "hideContentFilterSettings":false,"homeLocation":"","id":"usr_cached",
+      "isFriend":false,"last_activity":"","last_login":"",
+      "last_platform":"standalonewindows","obfuscatedEmail":"",
+      "obfuscatedPendingEmail":"","oculusId":"","offlineFriends":[],
+      "onlineFriends":[],"pastDisplayNames":[],"picoId":"",
+      "presence":{
+        "avatarThumbnail":null,"displayName":"cached-user","groups":[],
+        "id":"usr_cached","instance":"","instanceType":"","isRejoining":null,
+        "platform":"standalonewindows","profilePicOverride":null,"status":"active",
+        "travelingToInstance":"","travelingToWorld":"","world":""
+      },
+      "profilePicOverride":"","state":"online","status":"active",
+      "statusDescription":"","statusFirstTime":false,"statusHistory":[],
+      "steamDetails":{},"steamId":"","tags":[],"twoFactorAuthEnabled":false,
+      "twoFactorAuthEnabledDate":null,"unsubscribe":false,"updated_at":"",
+      "userIcon":"","userLanguage":null,"userLanguageCode":null,
+      "username":"cached-user","viveId":"","pronouns":null
     }
 """.trimIndent()


### PR DESCRIPTION
## 变更说明

- 接通世界详情页的平台包体大小加载链，在基础资料和实例加载之外异步查询 PC、Android 与 iOS 包体大小。
- 按平台选择最新 Unity package，并严格读取其资源 URL 所引用的文件版本，避免误用同一文件的其他版本大小。
- 修正文件详情请求端点，并让单个平台失败不影响其他平台结果。
- 将已解析的平台大小随世界详情缓存保存；旧缓存会触发一次刷新，之后可直接恢复平台卡片。
- 文件详情查询接入现有认证重试；部分平台失败时仍展示成功结果，但保持缓存为未解析以便下次加载重试。
- 兼容文件版本列表中省略 `file` 的无关版本，以及目标文件详情省略可选 `md5` 的合法响应。

## 实现假设清单

- VRChat 世界详情响应中的 `unityPackages` 包含平台、创建时间和带文件版本的 `assetUrl`。
- VRChat 文件详情接口会返回该文件的版本列表，目标版本的 `file.sizeInBytes` 表示需要展示的压缩包体大小。
- VRCM 现有 World 详情信息区已经按 `WorldProfileVo.platformFileSizes` 渲染平台卡片，本次只需恢复数据来源并提供稳定的平台名称与顺序。
- 旧版详情缓存不包含平台大小字段；缺失字段按未解析处理，而空列表表示已成功解析但没有可显示的平台包。
- 文件版本列表中的无关版本允许缺少 `file`，文件详情中的 `md5` 允许缺失；只有资源 URL 明确引用的目标版本必须提供 `file.sizeInBytes`。

## 验证

- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.presentation.screens.world.WorldPlatformFileSizesTest"`：4 项通过，覆盖完整缓存、部分失败重试、无版本 URL 拒绝和 401 认证恢复。
- `:composeApp:compileKotlinDesktop`：随上述定向测试完成并通过。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest`：806 项中 2 项失败；一项是无图形环境下 `DesktopWindowTitleBarLocaleTest` 的已知 `HeadlessException`，另一项是基线已有的后台收藏限制请求泄漏，在后续 Meetup 测试开始前报未捕获异常。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.presentation.screens.meetup.MeetupCardScreenModelTest"`：隔离运行通过，确认上述 Meetup 失败来自跨测试基线泄漏。
- `git diff --check`：通过。

## 代码逻辑图

```mermaid
flowchart TD
    A[打开 World 详情] --> B[读取 WorldProfileCache]
    B --> C{缓存资料 实例和平台结果可用且未过期}
    C -- 是 --> D[恢复平台卡片并加载缓存实例]
    C -- 否 --> E[经认证重试请求世界详情]
    E --> F[保存 platformFileSizes 为 null 的未解析缓存]
    F --> G[创建新的 platformFileSizesJob]
    G --> H[原子替换并取消前一个平台查询任务]
    H --> I[按 PC Android iOS 选择最新 Unity package]
    I --> J[严格解析 assetUrl 的 fileId 与 version]
    J --> K[并发经认证重试请求各平台文件详情]
    K --> L[各平台独立返回成功或失败 Result]
    L --> M[将成功平台立即更新到 WorldProfile StateFlow]
    M --> N{所有已发起的平台查询都成功}
    N -- 是 --> O[缓存完整平台列表 包括合法空列表]
    N -- 否 --> P[保持缓存未解析 下次加载再次请求]
    H -. 切换世界或 ViewModel 清除 .-> Q[取消任务并停止后续状态与缓存写入]
```
