### PR TITLE
feat(friends): 支持批量删除好友

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/compoments/GenericSearchList.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/GenericSearchList.kt
@@ -176,6 +176,7 @@ fun <T> SearchResultItem(
     item: T,
     onClick: (T) -> Unit,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     leadingContent: @Composable () -> Unit,
     headlineContent: @Composable () -> Unit,
     supportingContent: @Composable (() -> Unit)? = null,
@@ -187,7 +188,7 @@ fun <T> SearchResultItem(
             .heightIn(min = 68.dp)
             .padding(horizontal = 6.dp)
             .clip(MaterialTheme.shapes.large)
-            .clickable { onClick(item) },
+            .clickable(enabled = enabled) { onClick(item) },
         leadingContent = leadingContent,
         headlineContent = headlineContent,
         supportingContent = supportingContent ?: {},

--- a/composeApp/src/commonMain/kotlin/presentation/compoments/SearchItemRenderers.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/SearchItemRenderers.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -45,6 +46,22 @@ fun LazyListScope.renderUserItems(
     }
 }
 
+fun LazyListScope.renderSelectableUserItems(
+    users: List<IUser>,
+    selectedUserIds: Set<String>,
+    enabled: Boolean,
+    onSelectionToggle: (String) -> Unit,
+) {
+    items(users, key = { it.id }) { user ->
+        renderUserItem(
+            user = user,
+            onUserClick = { selectedUser, _ -> onSelectionToggle(selectedUser.id) },
+            selected = user.id in selectedUserIds,
+            enabled = enabled,
+        )
+    }
+}
+
 /**
  * 单个用户项渲染
  */
@@ -52,7 +69,9 @@ fun LazyListScope.renderUserItems(
 @Composable
 fun LazyItemScope.renderUserItem(
     user: IUser,
-    onUserClick: (IUser, String) -> Unit
+    onUserClick: (IUser, String) -> Unit,
+    selected: Boolean? = null,
+    enabled: Boolean = true,
 ) {
     val sharedSuffixKey = rememberContainerTransformToken("user:${user.id}")
         ?: LocalSharedSuffixKey.current
@@ -60,6 +79,7 @@ fun LazyItemScope.renderUserItem(
         item = user,
         onClick = { onUserClick(it, sharedSuffixKey) },
         modifier = Modifier.animateItem(),
+        enabled = enabled,
         leadingContent = {
             UserStateIcon(
                 modifier = Modifier.sharedBoundsBy(
@@ -87,6 +107,14 @@ fun LazyItemScope.renderUserItem(
             )
         },
         trailingContent = {
+            if (selected != null) {
+                Checkbox(
+                    checked = selected,
+                    onCheckedChange = null,
+                    enabled = enabled,
+                )
+                return@SearchResultItem
+            }
             // 离线用户显示最后活动时间
             val lastSeenAt = user.lastSeenAt()
             if (user.status != UserStatus.Offline || lastSeenAt == null) return@SearchResultItem

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
@@ -10,6 +10,9 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.DeleteOutline
+import androidx.compose.material.icons.outlined.PersonRemove
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
@@ -152,7 +155,7 @@ object HomeScreen : AppListRoute {
                         ) {
                             when (selectedDestination) {
                                 HomeDestination.Notifications -> NotificationRefreshAction(notificationModel)
-                                HomeDestination.Friends -> FriendRefreshAction(requireNotNull(friendListModel))
+                                HomeDestination.Friends -> FriendDirectoryActions(requireNotNull(friendListModel))
                                 else -> Unit
                             }
                         }
@@ -473,14 +476,51 @@ private fun NotificationRefreshAction(model: NotificationCenterModel) {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun FriendRefreshAction(model: FriendListPagerModel) {
+private fun FriendDirectoryActions(model: FriendListPagerModel) {
     val isRefreshing by model.directoryRefreshing.collectAsState()
-    IconButton(enabled = !isRefreshing, onClick = model::refreshFriendDirectory) {
-        if (isRefreshing) {
-            CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
-        } else {
-            Icon(AppIcons.Update, strings.refresh)
+    val total by model.friendTotal.collectAsState()
+    val removalState by model.friendRemovalState.collectAsState()
+
+    if (removalState.selectionMode) {
+        ATooltipBox(tooltip = { Text(strings.cancel) }) {
+            IconButton(
+                enabled = !removalState.isSubmitting,
+                onClick = model::exitFriendSelectionMode,
+            ) {
+                Icon(AppIcons.Close, strings.cancel)
+            }
+        }
+        ATooltipBox(tooltip = { Text(strings.friendDirectoryRemoveSelected) }) {
+            IconButton(
+                enabled = removalState.selectedUserIds.isNotEmpty() && !removalState.isSubmitting,
+                onClick = model::requestFriendRemovalConfirmation,
+            ) {
+                if (removalState.isSubmitting) {
+                    CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
+                } else {
+                    Icon(Icons.Outlined.DeleteOutline, strings.friendDirectoryRemoveSelected)
+                }
+            }
+        }
+    } else {
+        ATooltipBox(tooltip = { Text(strings.friendDirectorySelect) }) {
+            IconButton(
+                enabled = total > 0 && !isRefreshing,
+                onClick = model::enterFriendSelectionMode,
+            ) {
+                Icon(Icons.Outlined.PersonRemove, strings.friendDirectorySelect)
+            }
+        }
+        ATooltipBox(tooltip = { Text(strings.refresh) }) {
+            IconButton(enabled = !isRefreshing, onClick = model::refreshFriendDirectory) {
+                if (isRefreshing) {
+                    CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
+                } else {
+                    Icon(AppIcons.Update, strings.refresh)
+                }
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPager.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPager.kt
@@ -19,6 +19,7 @@ import io.github.vrcmteam.vrcm.presentation.compoments.*
 import io.github.vrcmteam.vrcm.presentation.extensions.animateScrollToFirst
 import io.github.vrcmteam.vrcm.presentation.extensions.currentNavigator
 import io.github.vrcmteam.vrcm.presentation.extensions.getInsetPadding
+import io.github.vrcmteam.vrcm.presentation.navigation.HandleBackNavigation
 import io.github.vrcmteam.vrcm.presentation.screens.home.compoments.GroupOptionsUI
 import io.github.vrcmteam.vrcm.presentation.screens.user.UserProfileScreen
 import io.github.vrcmteam.vrcm.presentation.screens.user.data.UserProfileVo
@@ -69,14 +70,26 @@ fun FriendsDirectoryContent(
     val total by model.friendTotal.collectAsState()
     val refreshing by model.directoryRefreshing.collectAsState()
     val refreshFailed by model.directoryRefreshFailed.collectAsState()
+    val removalState by model.friendRemovalState.collectAsState()
     val listState = rememberLazyListState()
+    val localeStrings = strings
+    val visibleUserIds = remember(friends) { friends.mapTo(mutableSetOf()) { it.id } }
+    val allVisibleSelected = visibleUserIds.isNotEmpty() &&
+        visibleUserIds.all { it in removalState.selectedUserIds }
 
-    LaunchedEffect(model) { model.activateFriendDirectory() }
+    LaunchedEffect(model, localeStrings) {
+        model.updateFriendDirectoryLocale(localeStrings)
+        model.activateFriendDirectory()
+    }
     LaunchedEffect(listState) {
         SharedFlowCentre.toPagerTop.collect {
             runCatching { listState.animateScrollToFirst() }
         }
     }
+    HandleBackNavigation(
+        enabled = removalState.selectionMode && !removalState.isSubmitting,
+        onBack = model::exitFriendSelectionMode,
+    )
 
     Box(modifier.fillMaxSize()) {
         LazyColumn(
@@ -102,11 +115,55 @@ fun FriendsDirectoryContent(
                         getSelectedGroup = FriendGroupOptions::selectedGroup,
                         updateOptions = { current, selected -> current.copy(selectedGroup = selected) },
                     )
+                    if (removalState.selectionMode) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = if (removalState.isSubmitting) {
+                                    localeStrings.friendDirectoryRemovingProgress
+                                        .replaceFirst("%d", removalState.completedCount.toString())
+                                        .replaceFirst("%d", removalState.totalCount.toString())
+                                } else {
+                                    localeStrings.friendDirectorySelectedCount.replaceFirst(
+                                        "%d",
+                                        removalState.selectedUserIds.size.toString(),
+                                    )
+                                },
+                                modifier = Modifier.weight(1f),
+                                style = MaterialTheme.typography.labelLarge,
+                            )
+                            TextButton(
+                                enabled = !removalState.isSubmitting && visibleUserIds.isNotEmpty(),
+                                onClick = {
+                                    model.toggleVisibleFriendSelection(visibleUserIds)
+                                },
+                            ) {
+                                Text(
+                                    if (allVisibleSelected) {
+                                        localeStrings.friendDirectoryClearSelection
+                                    } else {
+                                        localeStrings.friendDirectorySelectAll
+                                    }
+                                )
+                            }
+                        }
+                    }
                 }
             }
 
-            renderUserItems(friends) { friend, suffix ->
-                navigator push UserProfileScreen(UserProfileVo(friend), suffix)
+            if (removalState.selectionMode) {
+                renderSelectableUserItems(
+                    users = friends,
+                    selectedUserIds = removalState.selectedUserIds,
+                    enabled = !removalState.isSubmitting,
+                    onSelectionToggle = model::toggleFriendSelection,
+                )
+            } else {
+                renderUserItems(friends) { friend, suffix ->
+                    navigator push UserProfileScreen(UserProfileVo(friend), suffix)
+                }
             }
         }
 
@@ -132,6 +189,34 @@ fun FriendsDirectoryContent(
                 onRetry = model::refreshFriendDirectory,
             )
         }
+    }
+
+    if (removalState.confirmationVisible) {
+        AlertDialog(
+            onDismissRequest = model::dismissFriendRemovalConfirmation,
+            title = { Text(localeStrings.friendDirectoryRemoveConfirmTitle) },
+            text = {
+                Text(
+                    localeStrings.friendDirectoryRemoveConfirmMessage.replaceFirst(
+                        "%d",
+                        removalState.selectedUserIds.size.toString(),
+                    )
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = removalState.selectedUserIds.isNotEmpty() && !removalState.isSubmitting,
+                    onClick = model::confirmFriendRemoval,
+                ) {
+                    Text(localeStrings.friendDirectoryRemoveSelected)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = model::dismissFriendRemovalConfirmation) {
+                    Text(localeStrings.cancel)
+                }
+            },
+        )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
@@ -36,6 +36,9 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -60,6 +63,28 @@ data class WorldGroupOptions(
 data class AvatarGroupOptions(
     val selectedGroup: FavoriteGroupData? = null
 )
+
+internal data class FriendRemovalResult(
+    val userId: String,
+    val errorMessage: String? = null,
+) {
+    val succeeded: Boolean get() = errorMessage == null
+}
+
+internal data class FriendRemovalState(
+    val selectionMode: Boolean = false,
+    val selectedUserIds: Set<String> = emptySet(),
+    val confirmationVisible: Boolean = false,
+    val isSubmitting: Boolean = false,
+    val completedCount: Int = 0,
+    val totalCount: Int = 0,
+    val results: Map<String, FriendRemovalResult> = emptyMap(),
+) {
+    val successCount: Int get() = results.values.count(FriendRemovalResult::succeeded)
+    val failureCount: Int get() = results.size - successCount
+}
+
+private const val FRIEND_REMOVAL_CONCURRENCY = 3
 
 internal fun FriendStateSnapshot.friendsForSession(sessionToken: AccountSessionToken?): List<FriendData> =
     if (sessionToken != null && this.sessionToken == sessionToken) friends.values.toList() else emptyList()
@@ -186,12 +211,17 @@ class FriendListPagerModel(
         initialValue = friendService.hasRefreshError.value,
     )
     private var directoryRefreshJob: Job? = null
+    private var friendRemovalJob: Job? = null
     private val refreshJobsByTab = mutableMapOf<Int, Job>()
     private var activeSessionToken: AccountSessionToken? = null
     private var accountGeneration = 0L
     private var friendDirectoryActivated = false
     private var favoritesPageActivated = false
     private var favoriteLocale: LocaleStrings? = null
+    private var friendDirectoryLocale: LocaleStrings? = null
+
+    private val _friendRemovalState = MutableStateFlow(FriendRemovalState())
+    internal val friendRemovalState: StateFlow<FriendRemovalState> = _friendRemovalState.asStateFlow()
 
     val friendDirectoryFriends: StateFlow<List<FriendData>> = combine(
         _friendSnapshot,
@@ -240,6 +270,7 @@ class FriendListPagerModel(
                 val friends = snapshot.friendsForSession(token)
                 _friendTotal.value = friends.size
                 updateFriendSnapshot(friends)
+                retainExistingFriendSelections(friends.mapTo(mutableSetOf(), FriendData::id))
             }
         }
     }
@@ -252,6 +283,9 @@ class FriendListPagerModel(
         refreshJobsByTab.clear()
         directoryRefreshJob?.cancel()
         directoryRefreshJob = null
+        friendRemovalJob?.cancel()
+        friendRemovalJob = null
+        _friendRemovalState.value = FriendRemovalState()
         friendSnapshotJob?.cancel()
         friendSnapshotJob = null
         if (userChanged) {
@@ -293,6 +327,183 @@ class FriendListPagerModel(
 
     fun updateFavoriteLocale(locale: LocaleStrings) {
         favoriteLocale = locale
+    }
+
+    fun updateFriendDirectoryLocale(locale: LocaleStrings) {
+        friendDirectoryLocale = locale
+    }
+
+    fun enterFriendSelectionMode() {
+        if (_friendRemovalState.value.isSubmitting || _friendSnapshot.value.isEmpty()) return
+        _friendRemovalState.value = FriendRemovalState(selectionMode = true)
+    }
+
+    fun exitFriendSelectionMode() {
+        if (_friendRemovalState.value.isSubmitting) return
+        _friendRemovalState.value = FriendRemovalState()
+    }
+
+    fun toggleFriendSelection(userId: String) {
+        val availableIds = _friendSnapshot.value.mapTo(mutableSetOf(), FriendData::id)
+        if (userId !in availableIds) return
+        _friendRemovalState.update { state ->
+            if (!state.selectionMode || state.isSubmitting) return@update state
+            val selected = if (userId in state.selectedUserIds) {
+                state.selectedUserIds - userId
+            } else {
+                state.selectedUserIds + userId
+            }
+            state.copy(
+                selectedUserIds = selected,
+                confirmationVisible = false,
+                completedCount = 0,
+                totalCount = 0,
+                results = emptyMap(),
+            )
+        }
+    }
+
+    fun toggleVisibleFriendSelection(visibleUserIds: Set<String>) {
+        val availableIds = _friendSnapshot.value.mapTo(mutableSetOf(), FriendData::id)
+        val selectableIds = visibleUserIds intersect availableIds
+        _friendRemovalState.update { state ->
+            if (!state.selectionMode || state.isSubmitting || selectableIds.isEmpty()) {
+                return@update state
+            }
+            val allVisibleSelected = selectableIds.all { it in state.selectedUserIds }
+            state.copy(
+                selectedUserIds = if (allVisibleSelected) {
+                    state.selectedUserIds - selectableIds
+                } else {
+                    state.selectedUserIds + selectableIds
+                },
+                confirmationVisible = false,
+                completedCount = 0,
+                totalCount = 0,
+                results = emptyMap(),
+            )
+        }
+    }
+
+    fun requestFriendRemovalConfirmation() {
+        retainExistingFriendSelections(_friendSnapshot.value.mapTo(mutableSetOf(), FriendData::id))
+        _friendRemovalState.update { state ->
+            if (!state.selectionMode || state.isSubmitting || state.selectedUserIds.isEmpty()) state
+            else state.copy(confirmationVisible = true)
+        }
+    }
+
+    fun dismissFriendRemovalConfirmation() {
+        _friendRemovalState.update { state ->
+            if (state.isSubmitting) state else state.copy(confirmationVisible = false)
+        }
+    }
+
+    fun confirmFriendRemoval() {
+        val state = _friendRemovalState.value
+        if (!state.selectionMode || state.isSubmitting || !state.confirmationVisible) return
+        val sessionToken = activeSessionToken ?: return
+        val generation = accountGeneration
+        val currentFriendIds = friendService.friendStateSnapshot.value.friendsForSession(sessionToken)
+            .mapTo(mutableSetOf(), FriendData::id)
+        val selectedUserIds = state.selectedUserIds.filter { it in currentFriendIds }
+        if (selectedUserIds.isEmpty()) {
+            _friendRemovalState.update {
+                it.copy(selectedUserIds = emptySet(), confirmationVisible = false)
+            }
+            return
+        }
+
+        _friendRemovalState.value = state.copy(
+            selectedUserIds = selectedUserIds.toSet(),
+            confirmationVisible = false,
+            isSubmitting = true,
+            completedCount = 0,
+            totalCount = selectedUserIds.size,
+            results = emptyMap(),
+        )
+        friendRemovalJob = viewModelScope.launch(Dispatchers.IO) {
+            try {
+                selectedUserIds.chunked(FRIEND_REMOVAL_CONCURRENCY).forEach { batch ->
+                    coroutineScope {
+                        batch.map { userId ->
+                            async {
+                                val result = try {
+                                    friendService.unfriend(userId)
+                                } catch (cancelled: CancellationException) {
+                                    throw cancelled
+                                } catch (error: Throwable) {
+                                    Result.failure(error)
+                                }
+                                if (acceptsAccount(sessionToken, generation)) {
+                                    val itemResult = FriendRemovalResult(
+                                        userId = userId,
+                                        errorMessage = result.exceptionOrNull()?.message
+                                            ?.ifBlank { "Request failed" }
+                                            ?: if (result.isFailure) "Request failed" else null,
+                                    )
+                                    _friendRemovalState.update { current ->
+                                        current.copy(
+                                            selectedUserIds = if (itemResult.succeeded) {
+                                                current.selectedUserIds - userId
+                                            } else {
+                                                current.selectedUserIds
+                                            },
+                                            completedCount = current.completedCount + 1,
+                                            results = current.results + (userId to itemResult),
+                                        )
+                                    }
+                                }
+                            }
+                        }.awaitAll()
+                    }
+                }
+
+                if (!acceptsAccount(sessionToken, generation)) return@launch
+                val completed = _friendRemovalState.value
+                val failedIds = completed.results.values
+                    .filterNot(FriendRemovalResult::succeeded)
+                    .mapTo(mutableSetOf(), FriendRemovalResult::userId)
+                    .intersect(friendService.friendState.value.keys)
+                _friendRemovalState.value = completed.copy(
+                    selectionMode = failedIds.isNotEmpty(),
+                    selectedUserIds = failedIds,
+                    isSubmitting = false,
+                )
+                showFriendRemovalSummary(completed.successCount, completed.failureCount)
+            } finally {
+                if (acceptsAccount(sessionToken, generation)) {
+                    friendRemovalJob = null
+                }
+            }
+        }
+    }
+
+    private fun retainExistingFriendSelections(friendIds: Set<String>) {
+        _friendRemovalState.update { state ->
+            val retained = state.selectedUserIds intersect friendIds
+            if (retained == state.selectedUserIds) state
+            else state.copy(
+                selectedUserIds = retained,
+                confirmationVisible = state.confirmationVisible && retained.isNotEmpty(),
+            )
+        }
+    }
+
+    private suspend fun showFriendRemovalSummary(successCount: Int, failureCount: Int) {
+        val locale = friendDirectoryLocale ?: return
+        val message = when {
+            failureCount == 0 -> locale.friendDirectoryRemoveSuccess
+                .replaceFirst("%d", successCount.toString())
+            successCount == 0 -> locale.friendDirectoryRemoveFailed
+                .replaceFirst("%d", failureCount.toString())
+            else -> locale.friendDirectoryRemovePartialFailure
+                .replaceFirst("%d", successCount.toString())
+                .replaceFirst("%d", failureCount.toString())
+        }
+        SharedFlowCentre.toastText.emit(
+            if (failureCount == 0) ToastText.Success(message) else ToastText.Error(message)
+        )
     }
 
     /** Marks the Favorites page as active and refreshes its world and avatar tabs. */

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/pager/FriendListPagerModel.kt
@@ -27,6 +27,7 @@ import io.github.vrcmteam.vrcm.service.AuthService
 import io.github.vrcmteam.vrcm.service.FavoriteService
 import io.github.vrcmteam.vrcm.service.FriendService
 import io.github.vrcmteam.vrcm.service.FriendStateSnapshot
+import io.github.vrcmteam.vrcm.service.MAX_CONCURRENT_FRIEND_REMOVALS
 import io.github.vrcmteam.vrcm.service.UserProfileEnrichmentService
 import io.github.vrcmteam.vrcm.storage.AccountCacheManager
 import io.github.vrcmteam.vrcm.storage.AccountCacheWriteToken
@@ -36,9 +37,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -83,8 +81,6 @@ internal data class FriendRemovalState(
     val successCount: Int get() = results.values.count(FriendRemovalResult::succeeded)
     val failureCount: Int get() = results.size - successCount
 }
-
-private const val FRIEND_REMOVAL_CONCURRENCY = 3
 
 internal fun FriendStateSnapshot.friendsForSession(sessionToken: AccountSessionToken?): List<FriendData> =
     if (sessionToken != null && this.sessionToken == sessionToken) friends.values.toList() else emptyList()
@@ -424,38 +420,35 @@ class FriendListPagerModel(
         )
         friendRemovalJob = viewModelScope.launch(Dispatchers.IO) {
             try {
-                selectedUserIds.chunked(FRIEND_REMOVAL_CONCURRENCY).forEach { batch ->
-                    coroutineScope {
-                        batch.map { userId ->
-                            async {
-                                val result = try {
-                                    friendService.unfriend(userId)
-                                } catch (cancelled: CancellationException) {
-                                    throw cancelled
-                                } catch (error: Throwable) {
-                                    Result.failure(error)
-                                }
-                                if (acceptsAccount(sessionToken, generation)) {
-                                    val itemResult = FriendRemovalResult(
-                                        userId = userId,
-                                        errorMessage = result.exceptionOrNull()?.message
-                                            ?.ifBlank { "Request failed" }
-                                            ?: if (result.isFailure) "Request failed" else null,
-                                    )
-                                    _friendRemovalState.update { current ->
-                                        current.copy(
-                                            selectedUserIds = if (itemResult.succeeded) {
-                                                current.selectedUserIds - userId
-                                            } else {
-                                                current.selectedUserIds
-                                            },
-                                            completedCount = current.completedCount + 1,
-                                            results = current.results + (userId to itemResult),
-                                        )
-                                    }
-                                }
-                            }
-                        }.awaitAll()
+                selectedUserIds.chunked(MAX_CONCURRENT_FRIEND_REMOVALS).forEach { batch ->
+                    val batchResults = try {
+                        friendService.unfriendBatch(batch)
+                    } catch (cancelled: CancellationException) {
+                        throw cancelled
+                    } catch (error: Throwable) {
+                        batch.associateWith { Result.failure(error) }
+                    }
+                    if (!acceptsAccount(sessionToken, generation)) return@launch
+                    batch.forEach { userId ->
+                        val result = batchResults[userId]
+                            ?: Result.failure(IllegalStateException("Missing removal result"))
+                        val itemResult = FriendRemovalResult(
+                            userId = userId,
+                            errorMessage = result.exceptionOrNull()?.message
+                                ?.ifBlank { "Request failed" }
+                                ?: if (result.isFailure) "Request failed" else null,
+                        )
+                        _friendRemovalState.update { current ->
+                            current.copy(
+                                selectedUserIds = if (itemResult.succeeded) {
+                                    current.selectedUserIds - userId
+                                } else {
+                                    current.selectedUserIds
+                                },
+                                completedCount = current.completedCount + 1,
+                                results = current.results + (userId to itemResult),
+                            )
+                        }
                     }
                 }
 

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
@@ -235,6 +235,18 @@ sealed class LocaleStrings {
     open val friendDirectoryEmpty: String = "No friends yet"
     open val friendDirectoryNoMatches: String = "No friends match this filter"
     open val friendDirectoryLoadFailed: String = "Couldn't refresh friends"
+    open val friendDirectorySelect: String = "Select friends to remove"
+    open val friendDirectorySelectedCount: String = "%d selected"
+    open val friendDirectorySelectAll: String = "Select all shown"
+    open val friendDirectoryClearSelection: String = "Clear shown"
+    open val friendDirectoryRemoveSelected: String = "Remove selected friends"
+    open val friendDirectoryRemoveConfirmTitle: String = "Remove friends?"
+    open val friendDirectoryRemoveConfirmMessage: String =
+        "This will remove %d selected friends. This action cannot be undone."
+    open val friendDirectoryRemovingProgress: String = "Removing %d of %d"
+    open val friendDirectoryRemoveSuccess: String = "Removed %d friends"
+    open val friendDirectoryRemovePartialFailure: String = "Removed %d friends; %d failed"
+    open val friendDirectoryRemoveFailed: String = "Failed to remove %d friends"
 
     // WorldProfileScreen
     open val worldProfileDescription: String = "World Description"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
@@ -219,6 +219,18 @@ internal object LocaleStringsJa : LocaleStrings() {
     override val friendDirectoryEmpty = "フレンドがいません"
     override val friendDirectoryNoMatches = "条件に一致するフレンドはいません"
     override val friendDirectoryLoadFailed = "フレンド一覧を更新できませんでした"
+    override val friendDirectorySelect = "解除するフレンドを選択"
+    override val friendDirectorySelectedCount = "%d人選択中"
+    override val friendDirectorySelectAll = "表示中をすべて選択"
+    override val friendDirectoryClearSelection = "表示中の選択を解除"
+    override val friendDirectoryRemoveSelected = "選択したフレンドを解除"
+    override val friendDirectoryRemoveConfirmTitle = "フレンドを解除しますか？"
+    override val friendDirectoryRemoveConfirmMessage =
+        "選択した%d人のフレンドを解除します。この操作は元に戻せません。"
+    override val friendDirectoryRemovingProgress = "%d / %d人を解除中"
+    override val friendDirectoryRemoveSuccess = "%d人のフレンドを解除しました"
+    override val friendDirectoryRemovePartialFailure = "%d人を解除し、%d人は失敗しました"
+    override val friendDirectoryRemoveFailed = "%d人のフレンド解除に失敗しました"
     override val friendListPagerAllWorlds = "すべてのワールド"
 
     // WorldProfileScreen

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
@@ -218,6 +218,17 @@ internal object LocaleStringsZhHans : LocaleStrings() {
     override val friendDirectoryEmpty = "暂无好友"
     override val friendDirectoryNoMatches = "没有符合筛选条件的好友"
     override val friendDirectoryLoadFailed = "无法刷新好友列表"
+    override val friendDirectorySelect = "选择要删除的好友"
+    override val friendDirectorySelectedCount = "已选择 %d 人"
+    override val friendDirectorySelectAll = "全选当前结果"
+    override val friendDirectoryClearSelection = "清除当前选择"
+    override val friendDirectoryRemoveSelected = "删除所选好友"
+    override val friendDirectoryRemoveConfirmTitle = "删除好友？"
+    override val friendDirectoryRemoveConfirmMessage = "将删除所选的 %d 位好友，此操作无法撤销。"
+    override val friendDirectoryRemovingProgress = "正在删除 %d/%d"
+    override val friendDirectoryRemoveSuccess = "已删除 %d 位好友"
+    override val friendDirectoryRemovePartialFailure = "已删除 %d 位好友，%d 位失败"
+    override val friendDirectoryRemoveFailed = "%d 位好友删除失败"
     override val friendListPagerAllWorlds = "全部世界"
 
     // WorldProfileScreen

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
@@ -218,6 +218,17 @@ internal object LocaleStringsZhHant : LocaleStrings() {
     override val friendDirectoryEmpty = "暫無好友"
     override val friendDirectoryNoMatches = "沒有符合篩選條件的好友"
     override val friendDirectoryLoadFailed = "無法重新整理好友列表"
+    override val friendDirectorySelect = "選擇要刪除的好友"
+    override val friendDirectorySelectedCount = "已選擇 %d 人"
+    override val friendDirectorySelectAll = "全選目前結果"
+    override val friendDirectoryClearSelection = "清除目前選擇"
+    override val friendDirectoryRemoveSelected = "刪除所選好友"
+    override val friendDirectoryRemoveConfirmTitle = "刪除好友？"
+    override val friendDirectoryRemoveConfirmMessage = "將刪除所選的 %d 位好友，此操作無法復原。"
+    override val friendDirectoryRemovingProgress = "正在刪除 %d/%d"
+    override val friendDirectoryRemoveSuccess = "已刪除 %d 位好友"
+    override val friendDirectoryRemovePartialFailure = "已刪除 %d 位好友，%d 位失敗"
+    override val friendDirectoryRemoveFailed = "%d 位好友刪除失敗"
     override val friendListPagerAllWorlds = "全部世界"
 
     // WorldProfileScreen

--- a/composeApp/src/commonMain/kotlin/service/FriendService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendService.kt
@@ -6,6 +6,7 @@ import io.github.vrcmteam.vrcm.core.shared.AccountWebSocketEvent
 import io.github.vrcmteam.vrcm.core.shared.AuthenticatedAccount
 import io.github.vrcmteam.vrcm.network.api.attributes.LocationType
 import io.github.vrcmteam.vrcm.network.api.attributes.UserStatus
+import io.github.vrcmteam.vrcm.network.api.attributes.VRChatResponse
 import io.github.vrcmteam.vrcm.network.api.auth.data.CurrentUserData
 import io.github.vrcmteam.vrcm.network.api.friends.FriendsApi
 import io.github.vrcmteam.vrcm.network.api.friends.date.FriendData
@@ -636,8 +637,21 @@ class FriendService(
     suspend fun deleteFriendRequest(userId: String) =
         authService.reTryAuthCatching { friendsApi.deleteFriendRequest(userId) }
 
-    suspend fun unfriend(userId: String) =
-        authService.reTryAuthCatching { friendsApi.unfriend(userId) }
+    suspend fun unfriend(userId: String): Result<VRChatResponse> {
+        val sessionToken = synchronized(friendMapLock) { activeSessionToken }
+            ?: return Result.failure(IllegalStateException("No active account session"))
+        if (!isCurrentSession(sessionToken)) {
+            return Result.failure(IllegalStateException("Account session changed"))
+        }
+
+        val result = authService.reTryAuthCatching { friendsApi.unfriend(userId) }
+        if (result.isFailure) return result
+        if (!removeFriend(sessionToken, userId)) {
+            return Result.failure(IllegalStateException("Account session changed"))
+        }
+        emitFriendUpdate(sessionToken, FriendUpdateEvent.Delete(userId))
+        return result
+    }
 }
 
 data class FriendPresence(val location: String, val travelingToLocation: String = "")

--- a/composeApp/src/commonMain/kotlin/service/FriendService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendService.kt
@@ -662,17 +662,22 @@ class FriendService(
 
     suspend fun unfriend(userId: String): Result<VRChatResponse> {
         val sessionToken = synchronized(friendMapLock) { activeSessionToken }
-            ?: return Result.failure(IllegalStateException("No active account session"))
+            ?: return friendSessionChangedResult()
         if (!isCurrentSession(sessionToken)) {
-            return Result.failure(IllegalStateException("Account session changed"))
+            return friendSessionChangedResult()
         }
 
-        val result = authService.reTryAuthCatching { friendsApi.unfriend(userId) }
+        val response = authService.runSessionBoundCatching(sessionToken) {
+            friendsApi.unfriend(userId)
+        } ?: return friendSessionChangedResult()
+        val result = response.result
         if (result.isFailure) return result
-        if (!removeFriend(sessionToken, userId)) {
-            return Result.failure(IllegalStateException("Account session changed"))
+        val activeSessionToken = resolveActiveFriendSession(response.sessionToken)
+            ?: return friendSessionChangedResult()
+        if (!removeFriend(activeSessionToken, userId)) {
+            return friendSessionChangedResult()
         }
-        emitFriendUpdate(sessionToken, FriendUpdateEvent.Delete(userId))
+        emitFriendUpdate(activeSessionToken, FriendUpdateEvent.Delete(userId))
         return result
     }
 

--- a/composeApp/src/commonMain/kotlin/service/FriendService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendService.kt
@@ -640,8 +640,8 @@ class FriendService(
         combine(_friendStateSnapshot, SharedFlowCentre.currentSession) { snapshot, session ->
             snapshot.sessionToken to session?.token
         }.first { (snapshotToken, currentToken) ->
-            currentToken?.userId != sessionToken.userId || snapshotToken == currentToken
-        }.second?.takeIf { it.userId == sessionToken.userId }
+            currentToken != sessionToken || snapshotToken == currentToken
+        }.second?.takeIf { it == sessionToken }
 
     fun preloadFriendList() {
         val sessionToken = synchronized(friendMapLock) { activeSessionToken } ?: return

--- a/composeApp/src/commonMain/kotlin/service/FriendService.kt
+++ b/composeApp/src/commonMain/kotlin/service/FriendService.kt
@@ -31,7 +31,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.Flow
@@ -41,6 +44,8 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.retry
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -49,6 +54,8 @@ import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlinx.serialization.json.Json
 import org.koin.core.logger.Logger
+
+internal const val MAX_CONCURRENT_FRIEND_REMOVALS = 3
 
 class FriendService(
     private val friendsApi: FriendsApi,
@@ -483,6 +490,13 @@ class FriendService(
             friendStore.removeFromEvent(userId)
         }
 
+    private fun removeFriends(
+        sessionToken: AccountSessionToken,
+        userIds: Collection<String>,
+    ): Boolean = mutateFriendStore(sessionToken) {
+        userIds.forEach(friendStore::removeFromEvent)
+    }
+
     private inline fun mutateFriendStore(
         sessionToken: AccountSessionToken,
         update: () -> Unit,
@@ -620,6 +634,15 @@ class FriendService(
     private fun isCurrentSessionLocked(sessionToken: AccountSessionToken): Boolean =
         activeSessionToken == sessionToken && SharedFlowCentre.isCurrentSession(sessionToken)
 
+    private suspend fun resolveActiveFriendSession(
+        sessionToken: AccountSessionToken,
+    ): AccountSessionToken? =
+        combine(_friendStateSnapshot, SharedFlowCentre.currentSession) { snapshot, session ->
+            snapshot.sessionToken to session?.token
+        }.first { (snapshotToken, currentToken) ->
+            currentToken?.userId != sessionToken.userId || snapshotToken == currentToken
+        }.second?.takeIf { it.userId == sessionToken.userId }
+
     fun preloadFriendList() {
         val sessionToken = synchronized(friendMapLock) { activeSessionToken } ?: return
         preloadFriendList(sessionToken)
@@ -652,7 +675,62 @@ class FriendService(
         emitFriendUpdate(sessionToken, FriendUpdateEvent.Delete(userId))
         return result
     }
+
+    /** Runs one account-bound group while preserving independent results for each friend. */
+    internal suspend fun unfriendBatch(
+        requestedUserIds: List<String>,
+    ): Map<String, Result<VRChatResponse>> {
+        val userIds = requestedUserIds.distinct()
+        if (userIds.isEmpty()) return emptyMap()
+        require(userIds.size <= MAX_CONCURRENT_FRIEND_REMOVALS)
+        val sessionToken = synchronized(friendMapLock) { activeSessionToken }
+            ?: return friendSessionChangedResults(userIds)
+        if (!isCurrentSession(sessionToken)) {
+            return friendSessionChangedResults(userIds)
+        }
+
+        val response = authService.runSessionBoundCatching(sessionToken) {
+            coroutineScope {
+                userIds.map { userId ->
+                    async {
+                        userId to try {
+                            Result.success(friendsApi.unfriend(userId))
+                        } catch (cancelled: CancellationException) {
+                            throw cancelled
+                        } catch (error: Throwable) {
+                            Result.failure(error)
+                        }
+                    }
+                }.awaitAll().toMap()
+            }
+        } ?: return friendSessionChangedResults(userIds)
+        val results = response.result.getOrElse { error ->
+            return userIds.associateWith { Result.failure(error) }
+        }
+        val activeSessionToken = resolveActiveFriendSession(response.sessionToken)
+            ?: return friendSessionChangedResults(userIds)
+        val succeededUserIds = results.filterValues { it.isSuccess }.keys
+        if (succeededUserIds.isNotEmpty() && !removeFriends(activeSessionToken, succeededUserIds)) {
+            return results.mapValues { (_, result) ->
+                if (result.isSuccess) friendSessionChangedResult() else result
+            }
+        }
+        succeededUserIds.forEach { userId ->
+            emitFriendUpdate(activeSessionToken, FriendUpdateEvent.Delete(userId))
+        }
+        return results
+    }
 }
+
+private data object FriendSessionChangedException :
+    IllegalStateException("Account session changed during friend removal")
+
+private fun friendSessionChangedResult(): Result<VRChatResponse> =
+    Result.failure(FriendSessionChangedException)
+
+private fun friendSessionChangedResults(
+    userIds: Collection<String>,
+): Map<String, Result<VRChatResponse>> = userIds.associateWith { friendSessionChangedResult() }
 
 data class FriendPresence(val location: String, val travelingToLocation: String = "")
 

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
@@ -784,6 +784,80 @@ class FriendListPagerModelTest : MainDispatcherTest() {
         }
     }
 
+    @Test
+    fun singleRemovalRejectsSameAccountReauthenticationDuringRequest() = runBlocking {
+        SharedFlowCentre.emitLogout()
+        val account = AccountDto(
+            userId = "usr_single_removal_stale_owner",
+            username = "single-removal-stale-owner",
+            password = "single-removal-stale-password",
+        )
+        SharedFlowCentre.emitAuthenticated(account)
+        val initialSession = assertNotNull(SharedFlowCentre.currentSession.value)
+        val json = Json { ignoreUnknownKeys = true }
+        val friendId = "usr_single_removal_stale_friend"
+        val requestStarted = CompletableDeferred<Unit>()
+        val releaseRequest = CompletableDeferred<Unit>()
+        val remoteRemoved = atomic(false)
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    val path = request.url.encodedPath
+                    when {
+                        request.method == HttpMethod.Delete && path.endsWith("/$friendId") -> {
+                            requestStarted.complete(Unit)
+                            withContext(NonCancellable) { releaseRequest.await() }
+                            remoteRemoved.value = true
+                            jsonResponse(successResponseJson())
+                        }
+                        path == "/auth/user/friends" -> {
+                            val offline = request.url.parameters["offline"] == "true"
+                            val friends = if (!offline) {
+                                listOf(cachedFriend(friendId, "Stale Removal Friend", UserStatus.Active))
+                            } else {
+                                emptyList()
+                            }
+                            jsonResponse(json.encodeToString(friends))
+                        }
+                        path == "/auth/user/favoritelimits" -> jsonResponse(favoriteLimitsJson())
+                        path == "/favorites" || path == "/favorite/groups" -> jsonResponse("[]")
+                        path == "/auth/user" -> jsonResponse(currentUserJson(account))
+                        else -> error("Unexpected request: ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) { json(json) }
+        }
+        val fixture = createRemovalFixture(account, client, json)
+
+        try {
+            emitFriendUntilObserved(
+                fixture.friendService,
+                initialSession,
+                friendId,
+                activeFriendEvent(json, friendId, "Stale Removal Friend"),
+            )
+            awaitCachedFriendIds(fixture, account.userId, setOf(friendId))
+
+            val removal = async { fixture.friendService.unfriend(friendId) }
+            withTimeout(3_000) { requestStarted.await() }
+
+            SharedFlowCentre.emitAuthenticated(account)
+            val renewedSession = assertNotNull(SharedFlowCentre.currentSession.value)
+            assertFalse(renewedSession.token == initialSession.token)
+            awaitUntil { fixture.friendService.friendStateSnapshot.value.sessionToken == renewedSession.token }
+            releaseRequest.complete(Unit)
+
+            assertTrue(removal.await().isFailure)
+            assertTrue(remoteRemoved.value)
+            assertTrue(friendId in fixture.friendService.friendState.value)
+        } finally {
+            releaseRequest.complete(Unit)
+            fixture.close()
+            SharedFlowCentre.emitLogout()
+        }
+    }
+
     private fun createRemovalFixture(
         account: AccountDto,
         client: HttpClient,

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
@@ -42,9 +42,11 @@ import io.ktor.client.engine.mock.MockRequestHandleScope
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -65,7 +67,9 @@ import okio.fakefilesystem.FakeFileSystem
 import org.koin.core.logger.EmptyLogger
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class FriendListPagerModelTest : MainDispatcherTest() {
     @Test
@@ -104,7 +108,8 @@ class FriendListPagerModelTest : MainDispatcherTest() {
                             jsonResponse("[]")
                         }
                         "/auth/user" -> respond("unavailable", HttpStatusCode.InternalServerError)
-                        "/auth/user/favoritelimits", "/favorites", "/favorite/groups" -> jsonResponse("[]")
+                        "/auth/user/favoritelimits" -> jsonResponse(favoriteLimitsJson())
+                        "/favorites", "/favorite/groups" -> jsonResponse("[]")
                         else -> error("Unexpected request: ${request.url}")
                     }
                 }
@@ -433,6 +438,252 @@ class FriendListPagerModelTest : MainDispatcherTest() {
         }
     }
 
+    @Test
+    fun batchRemovalKeepsIndependentResultsAndLimitsConcurrentRequests() = runBlocking {
+        SharedFlowCentre.emitLogout()
+        val account = AccountDto(userId = "usr_removal_owner", username = "removal-owner")
+        SharedFlowCentre.emitAuthenticated(account)
+        val session = assertNotNull(SharedFlowCentre.currentSession.value)
+        val json = Json { ignoreUnknownKeys = true }
+        val friendIds = (1..5).map { "usr_removal_$it" }
+        val failedId = friendIds[1]
+        val activeRequests = atomic(0)
+        val maxActiveRequests = atomic(0)
+        val requestCounts = friendIds.associateWith { atomic(0) }
+        val firstBatchStarted = CompletableDeferred<Unit>()
+        val releaseRequests = CompletableDeferred<Unit>()
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    val path = request.url.encodedPath
+                    when {
+                        request.method == HttpMethod.Delete && path.startsWith("/auth/user/friends/") -> {
+                            val userId = path.substringAfterLast('/')
+                            requestCounts.getValue(userId).incrementAndGet()
+                            val active = activeRequests.incrementAndGet()
+                            while (true) {
+                                val currentMax = maxActiveRequests.value
+                                if (active <= currentMax ||
+                                    maxActiveRequests.compareAndSet(currentMax, active)
+                                ) break
+                            }
+                            if (activeRequests.value == 3) firstBatchStarted.complete(Unit)
+                            releaseRequests.await()
+                            activeRequests.decrementAndGet()
+                            if (userId == failedId) {
+                                respond("failed", HttpStatusCode.InternalServerError)
+                            } else {
+                                jsonResponse(successResponseJson())
+                            }
+                        }
+                        path == "/auth/user/friends" -> jsonResponse("[]")
+                        path == "/auth/user/favoritelimits" -> jsonResponse(favoriteLimitsJson())
+                        path == "/favorites" || path == "/favorite/groups" -> jsonResponse("[]")
+                        path == "/auth/user" -> respond("unavailable", HttpStatusCode.InternalServerError)
+                        else -> error("Unexpected request: ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) { json(json) }
+        }
+        val fixture = createRemovalFixture(account, client, json)
+
+        try {
+            fixture.model.activateFriendDirectory()
+            friendIds.forEachIndexed { index, userId ->
+                emitFriendUntilObserved(
+                    fixture.friendService,
+                    session,
+                    userId,
+                    activeFriendEvent(json, userId, "Removal Friend $index"),
+                )
+            }
+            awaitFriendIds(fixture.model, friendIds.toSet())
+
+            fixture.model.enterFriendSelectionMode()
+            fixture.model.requestFriendRemovalConfirmation()
+            assertFalse(fixture.model.friendRemovalState.value.confirmationVisible)
+
+            fixture.model.toggleVisibleFriendSelection(friendIds.toSet())
+            fixture.model.requestFriendRemovalConfirmation()
+            assertTrue(fixture.model.friendRemovalState.value.confirmationVisible)
+            fixture.model.confirmFriendRemoval()
+            fixture.model.confirmFriendRemoval()
+            fixture.model.requestFriendRemovalConfirmation()
+
+            withTimeout(3_000) { firstBatchStarted.await() }
+            repeat(20) { yield() }
+            assertEquals(3, activeRequests.value)
+            assertEquals(3, maxActiveRequests.value)
+            assertTrue(fixture.model.friendRemovalState.value.isSubmitting)
+
+            releaseRequests.complete(Unit)
+            awaitUntil {
+                val state = fixture.model.friendRemovalState.value
+                !state.isSubmitting && state.completedCount == friendIds.size
+            }
+
+            val state = fixture.model.friendRemovalState.value
+            assertEquals(4, state.successCount)
+            assertEquals(1, state.failureCount)
+            assertEquals(friendIds.toSet(), state.results.keys)
+            assertTrue(state.results.getValue(failedId).errorMessage?.isNotBlank() == true)
+            assertEquals(setOf(failedId), state.selectedUserIds)
+            assertTrue(state.selectionMode)
+            assertEquals(setOf(failedId), fixture.friendService.friendState.value.keys)
+            assertTrue(requestCounts.values.all { it.value == 1 })
+            assertTrue(maxActiveRequests.value <= 3)
+        } finally {
+            releaseRequests.complete(Unit)
+            fixture.close()
+            SharedFlowCentre.emitLogout()
+        }
+    }
+
+    @Test
+    fun accountSwitchCancelsRemovalAndRejectsLateSuccess() = runBlocking {
+        SharedFlowCentre.emitLogout()
+        val accountA = AccountDto(userId = "usr_removal_owner_a", username = "removal-owner-a")
+        val accountB = AccountDto(userId = "usr_removal_owner_b", username = "removal-owner-b")
+        SharedFlowCentre.emitAuthenticated(accountA)
+        val sessionA = assertNotNull(SharedFlowCentre.currentSession.value)
+        val json = Json { ignoreUnknownKeys = true }
+        val oldFriendId = "usr_removal_old_friend"
+        val newFriendId = "usr_removal_new_friend"
+        val oldRequestStarted = CompletableDeferred<Unit>()
+        val releaseOldRequest = CompletableDeferred<Unit>()
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    val path = request.url.encodedPath
+                    when {
+                        request.method == HttpMethod.Delete && path.endsWith("/$oldFriendId") -> {
+                            oldRequestStarted.complete(Unit)
+                            withContext(NonCancellable) { releaseOldRequest.await() }
+                            jsonResponse(successResponseJson())
+                        }
+                        path == "/auth/user/friends" -> jsonResponse("[]")
+                        path == "/auth/user/favoritelimits" -> jsonResponse(favoriteLimitsJson())
+                        path == "/favorites" || path == "/favorite/groups" -> jsonResponse("[]")
+                        path == "/auth/user" -> respond("unavailable", HttpStatusCode.InternalServerError)
+                        else -> error("Unexpected request: ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) { json(json) }
+        }
+        val fixture = createRemovalFixture(accountA, client, json)
+
+        try {
+            fixture.model.activateFriendDirectory()
+            emitFriendUntilObserved(
+                fixture.friendService,
+                sessionA,
+                oldFriendId,
+                activeFriendEvent(json, oldFriendId, "Old Session Friend"),
+            )
+            awaitFriendIds(fixture.model, setOf(oldFriendId))
+            fixture.model.enterFriendSelectionMode()
+            fixture.model.toggleFriendSelection(oldFriendId)
+            fixture.model.requestFriendRemovalConfirmation()
+            fixture.model.confirmFriendRemoval()
+            withTimeout(3_000) { oldRequestStarted.await() }
+
+            SharedFlowCentre.emitAuthenticated(accountB)
+            val sessionB = assertNotNull(SharedFlowCentre.currentSession.value)
+            awaitUntil { fixture.model.friendRemovalState.value == FriendRemovalState() }
+            emitFriendUntilObserved(
+                fixture.friendService,
+                sessionB,
+                newFriendId,
+                activeFriendEvent(json, newFriendId, "New Session Friend"),
+            )
+            awaitFriendIds(fixture.model, setOf(newFriendId))
+
+            releaseOldRequest.complete(Unit)
+            repeat(20) { yield() }
+
+            assertEquals(FriendRemovalState(), fixture.model.friendRemovalState.value)
+            assertEquals(setOf(newFriendId), fixture.friendService.friendState.value.keys)
+            assertEquals(setOf(newFriendId), fixture.model.friendDirectoryFriends.value.map { it.id }.toSet())
+        } finally {
+            releaseOldRequest.complete(Unit)
+            fixture.close()
+            SharedFlowCentre.emitLogout()
+        }
+    }
+
+    private fun createRemovalFixture(
+        account: AccountDto,
+        client: HttpClient,
+        json: Json,
+    ): RemovalFixture {
+        val friendListCacheStore = InMemoryFriendListCacheStore()
+        val favoriteListCacheStore = InMemoryFavoriteListCacheStore()
+        val accountCacheManager = AccountCacheManager(
+            friendListCacheStore = friendListCacheStore,
+            userProfileCacheStore = InMemoryUserProfileCacheStore(),
+            friendActivityStore = io.github.vrcmteam.vrcm.storage.NoOpFriendActivityCacheStore,
+            meetupCardConfigDao = MeetupCardConfigDao(MapSettings()),
+            meetupCardAssetStore = MeetupCardAssetStore(
+                FakeFileSystem(),
+                "/meetup-assets".toPath(),
+            ),
+            favoriteListCacheStore = favoriteListCacheStore,
+        )
+        val authService = AuthService(
+            authApi = AuthApi(client),
+            accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also {
+                it.saveAccountInfo(account)
+            },
+            cookiesStorage = PersistentCookiesStorage(EmptyLogger()),
+            accountCacheManager = accountCacheManager,
+        )
+        val friendService = FriendService(
+            friendsApi = FriendsApi(client),
+            authService = authService,
+            json = json,
+            friendListCacheStore = friendListCacheStore,
+            accountCacheManager = accountCacheManager,
+            logger = EmptyLogger(),
+        )
+        val favoriteService = FavoriteService(
+            favoriteApi = FavoriteApi(client),
+            favoriteLocalDao = FavoriteLocalDao(MapSettings()),
+        )
+        val profileScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = FriendListPagerModel(
+            userProfileEnrichmentService = UserProfileEnrichmentService(UsersApi(client), profileScope),
+            friendService = friendService,
+            authService = authService,
+            favoriteService = favoriteService,
+            worldsApi = WorldsApi(client),
+            avatarsApi = AvatarsApi(client),
+            favoriteListCacheStore = favoriteListCacheStore,
+            accountCacheManager = accountCacheManager,
+        )
+        return RemovalFixture(model, friendService, favoriteService, profileScope, client)
+    }
+
+    private data class RemovalFixture(
+        val model: FriendListPagerModel,
+        val friendService: FriendService,
+        val favoriteService: FavoriteService,
+        val profileScope: CoroutineScope,
+        val client: HttpClient,
+    ) {
+        fun close() {
+            profileScope.cancel()
+            ViewModelStore().apply {
+                put("friend-list-pager-removal", model)
+                clear()
+            }
+            friendService.dispose()
+            favoriteService.dispose()
+            client.close()
+        }
+    }
+
     private suspend fun emitFriendUntilObserved(
         friendService: FriendService,
         session: AuthenticatedAccount,
@@ -595,6 +846,10 @@ private fun MockRequestHandleScope.jsonResponse(content: String) = respond(
     status = HttpStatusCode.OK,
     headers = headersOf(HttpHeaders.ContentType, "application/json"),
 )
+
+private fun successResponseJson() = """
+    {"success":{"message":"Friend removed","status_code":200}}
+""".trimIndent()
 
 private fun favoriteLimitsJson() = """
     {

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
@@ -703,6 +703,87 @@ class FriendListPagerModelTest : MainDispatcherTest() {
         }
     }
 
+    @Test
+    fun singleRemovalCommitsAfterSameAccountReauthentication() = runBlocking {
+        SharedFlowCentre.emitLogout()
+        val account = AccountDto(
+            userId = "usr_single_removal_owner",
+            username = "single-removal-owner",
+            password = "single-removal-password",
+        )
+        SharedFlowCentre.emitAuthenticated(account)
+        val initialSession = assertNotNull(SharedFlowCentre.currentSession.value)
+        val json = Json { ignoreUnknownKeys = true }
+        val friendId = "usr_single_removal_friend"
+        val deleteRequests = atomic(0)
+        val authenticationRequests = atomic(0)
+        val remoteRemoved = atomic(false)
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    val path = request.url.encodedPath
+                    when {
+                        request.method == HttpMethod.Delete && path.endsWith("/$friendId") -> {
+                            if (deleteRequests.incrementAndGet() == 1) {
+                                respond("expired", HttpStatusCode.Unauthorized)
+                            } else {
+                                remoteRemoved.value = true
+                                jsonResponse(successResponseJson())
+                            }
+                        }
+                        path == "/auth/user/friends" -> {
+                            val offset = request.url.parameters["offset"]?.toIntOrNull() ?: 0
+                            val offline = request.url.parameters["offline"] == "true"
+                            val friends = if (!remoteRemoved.value && !offline && offset == 0) {
+                                listOf(cachedFriend(friendId, "Single Removal Friend", UserStatus.Active))
+                            } else {
+                                emptyList()
+                            }
+                            jsonResponse(json.encodeToString(friends))
+                        }
+                        path == "/auth/user/favoritelimits" -> jsonResponse(favoriteLimitsJson())
+                        path == "/favorites" || path == "/favorite/groups" -> jsonResponse("[]")
+                        path == "/auth/user" -> {
+                            if (request.headers[HttpHeaders.Authorization] != null) {
+                                authenticationRequests.incrementAndGet()
+                            }
+                            jsonResponse(currentUserJson(account))
+                        }
+                        else -> error("Unexpected request: ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) { json(json) }
+        }
+        val fixture = createRemovalFixture(account, client, json)
+
+        try {
+            emitFriendUntilObserved(
+                fixture.friendService,
+                initialSession,
+                friendId,
+                activeFriendEvent(json, friendId, "Single Removal Friend"),
+            )
+            awaitCachedFriendIds(fixture, account.userId, setOf(friendId))
+
+            val result = fixture.friendService.unfriend(friendId)
+
+            assertTrue(result.isSuccess)
+            val renewedSession = assertNotNull(SharedFlowCentre.currentSession.value)
+            assertFalse(renewedSession.token == initialSession.token)
+            awaitUntil {
+                fixture.friendService.friendStateSnapshot.value.sessionToken == renewedSession.token &&
+                    fixture.friendService.friendState.value.isEmpty()
+            }
+            awaitCachedFriendIds(fixture, account.userId, emptySet())
+            assertEquals(2, deleteRequests.value)
+            assertEquals(1, authenticationRequests.value)
+        } finally {
+            fixture.close()
+            SharedFlowCentre.emitLogout()
+        }
+    }
+
     private fun createRemovalFixture(
         account: AccountDto,
         client: HttpClient,
@@ -753,7 +834,15 @@ class FriendListPagerModelTest : MainDispatcherTest() {
             favoriteListCacheStore = favoriteListCacheStore,
             accountCacheManager = accountCacheManager,
         )
-        return RemovalFixture(model, friendService, favoriteService, accountDao, profileScope, client)
+        return RemovalFixture(
+            model,
+            friendService,
+            favoriteService,
+            accountDao,
+            friendListCacheStore,
+            profileScope,
+            client,
+        )
     }
 
     private data class RemovalFixture(
@@ -761,6 +850,7 @@ class FriendListPagerModelTest : MainDispatcherTest() {
         val friendService: FriendService,
         val favoriteService: FavoriteService,
         val accountDao: AccountDao,
+        val friendListCacheStore: InMemoryFriendListCacheStore,
         val profileScope: CoroutineScope,
         val client: HttpClient,
     ) {
@@ -793,6 +883,22 @@ class FriendListPagerModelTest : MainDispatcherTest() {
     private suspend fun awaitFriendIds(model: FriendListPagerModel, expectedIds: Set<String>) {
         awaitUntil {
             model.friendDirectoryFriends.value.mapTo(mutableSetOf()) { it.id } == expectedIds
+        }
+    }
+
+    private suspend fun awaitCachedFriendIds(
+        fixture: RemovalFixture,
+        accountUserId: String,
+        expectedIds: Set<String>,
+    ) {
+        withTimeout(3_000) {
+            while (
+                fixture.friendListCacheStore.load(accountUserId)?.let { cache ->
+                    cache.friends.mapTo(mutableSetOf(), FriendData::id) == expectedIds
+                } != true
+            ) {
+                yield()
+            }
         }
     }
 
@@ -941,6 +1047,39 @@ private fun MockRequestHandleScope.jsonResponse(content: String) = respond(
 
 private fun successResponseJson() = """
     {"success":{"message":"Friend removed","status_code":200}}
+""".trimIndent()
+
+private fun currentUserJson(account: AccountDto): String = """
+    {
+      "requiresTwoFactorAuth":null,
+      "ageVerificationStatus":"verified","ageVerified":true,
+      "acceptedPrivacyVersion":0,"acceptedTOSVersion":0,
+      "accountDeletionDate":null,"accountDeletionLog":null,"activeFriends":[],
+      "allowAvatarCopying":true,"bio":null,"bioLinks":[],
+      "currentAvatar":"","currentAvatarAssetUrl":null,"currentAvatarImageUrl":"",
+      "currentAvatarTags":[],"currentAvatarThumbnailImageUrl":"","date_joined":"",
+      "developerType":"none","displayName":"${account.username}","emailVerified":true,
+      "fallbackAvatar":"","friendGroupNames":[],"friendKey":"","friends":[],
+      "googleId":"","hasBirthday":true,"hasEmail":true,
+      "hasLoggedInFromClient":true,"hasPendingEmail":false,
+      "hideContentFilterSettings":false,"homeLocation":"","id":"${account.userId}",
+      "isFriend":false,"last_activity":"","last_login":"",
+      "last_platform":"standalonewindows","obfuscatedEmail":"",
+      "obfuscatedPendingEmail":"","oculusId":"","offlineFriends":[],
+      "onlineFriends":[],"pastDisplayNames":[],"picoId":"",
+      "presence":{
+        "avatarThumbnail":null,"displayName":"${account.username}","groups":[],
+        "id":"${account.userId}","instance":"","instanceType":"",
+        "isRejoining":null,"platform":"standalonewindows","profilePicOverride":null,
+        "status":"active","travelingToInstance":"","travelingToWorld":"","world":""
+      },
+      "profilePicOverride":"","state":"online","status":"active",
+      "statusDescription":"","statusFirstTime":false,"statusHistory":[],
+      "steamDetails":{},"steamId":"","tags":[],"twoFactorAuthEnabled":false,
+      "twoFactorAuthEnabledDate":null,"unsubscribe":false,"updated_at":"",
+      "userIcon":"","userLanguage":null,"userLanguageCode":null,
+      "username":"${account.username}","viveId":"","pronouns":null
+    }
 """.trimIndent()
 
 private fun favoriteLimitsJson() = """

--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.job
@@ -613,6 +614,95 @@ class FriendListPagerModelTest : MainDispatcherTest() {
         }
     }
 
+    @Test
+    fun unauthorizedBatchRemovalDoesNotReauthenticateAfterAccountSwitch() = runBlocking {
+        SharedFlowCentre.emitLogout()
+        val accountA = AccountDto(
+            userId = "usr_removal_auth_owner_a",
+            username = "removal-auth-owner-a",
+            password = "password-a",
+        )
+        val accountB = AccountDto(
+            userId = "usr_removal_auth_owner_b",
+            username = "removal-auth-owner-b",
+            password = "password-b",
+        )
+        SharedFlowCentre.emitAuthenticated(accountA)
+        val sessionA = assertNotNull(SharedFlowCentre.currentSession.value)
+        val json = Json { ignoreUnknownKeys = true }
+        val oldFriendId = "usr_removal_auth_old_friend"
+        val newFriendId = "usr_removal_auth_new_friend"
+        val deleteRequests = atomic(0)
+        val authenticationRequests = atomic(0)
+        val firstDeleteStarted = CompletableDeferred<Unit>()
+        val releaseFirstDelete = CompletableDeferred<Unit>()
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    val path = request.url.encodedPath
+                    when {
+                        request.method == HttpMethod.Delete && path.endsWith("/$oldFriendId") -> {
+                            val attempt = deleteRequests.incrementAndGet()
+                            if (attempt == 1) {
+                                firstDeleteStarted.complete(Unit)
+                                releaseFirstDelete.await()
+                                respond("expired", HttpStatusCode.Unauthorized)
+                            } else {
+                                jsonResponse(successResponseJson())
+                            }
+                        }
+                        path == "/auth/user/friends" -> jsonResponse("[]")
+                        path == "/auth/user/favoritelimits" -> jsonResponse(favoriteLimitsJson())
+                        path == "/favorites" || path == "/favorite/groups" -> jsonResponse("[]")
+                        path == "/auth/user" -> {
+                            if (request.headers[HttpHeaders.Authorization] != null) {
+                                authenticationRequests.incrementAndGet()
+                            }
+                            respond("unavailable", HttpStatusCode.InternalServerError)
+                        }
+                        else -> error("Unexpected request: ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) { json(json) }
+        }
+        val fixture = createRemovalFixture(accountA, client, json)
+
+        try {
+            emitFriendUntilObserved(
+                fixture.friendService,
+                sessionA,
+                oldFriendId,
+                activeFriendEvent(json, oldFriendId, "Old Auth Friend"),
+            )
+            val removal = async {
+                fixture.friendService.unfriendBatch(listOf(oldFriendId)).getValue(oldFriendId)
+            }
+            withTimeout(3_000) { firstDeleteStarted.await() }
+
+            fixture.accountDao.saveAccountInfo(accountB)
+            SharedFlowCentre.emitAuthenticated(accountB)
+            val sessionB = assertNotNull(SharedFlowCentre.currentSession.value)
+            emitFriendUntilObserved(
+                fixture.friendService,
+                sessionB,
+                newFriendId,
+                activeFriendEvent(json, newFriendId, "New Auth Friend"),
+            )
+            releaseFirstDelete.complete(Unit)
+
+            assertTrue(removal.await().isFailure)
+            repeat(20) { yield() }
+            assertEquals(1, deleteRequests.value)
+            assertEquals(0, authenticationRequests.value)
+            assertEquals(setOf(newFriendId), fixture.friendService.friendState.value.keys)
+        } finally {
+            releaseFirstDelete.complete(Unit)
+            fixture.close()
+            SharedFlowCentre.emitLogout()
+        }
+    }
+
     private fun createRemovalFixture(
         account: AccountDto,
         client: HttpClient,
@@ -631,11 +721,12 @@ class FriendListPagerModelTest : MainDispatcherTest() {
             ),
             favoriteListCacheStore = favoriteListCacheStore,
         )
+        val accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also {
+            it.saveAccountInfo(account)
+        }
         val authService = AuthService(
             authApi = AuthApi(client),
-            accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also {
-                it.saveAccountInfo(account)
-            },
+            accountDao = accountDao,
             cookiesStorage = PersistentCookiesStorage(EmptyLogger()),
             accountCacheManager = accountCacheManager,
         )
@@ -662,13 +753,14 @@ class FriendListPagerModelTest : MainDispatcherTest() {
             favoriteListCacheStore = favoriteListCacheStore,
             accountCacheManager = accountCacheManager,
         )
-        return RemovalFixture(model, friendService, favoriteService, profileScope, client)
+        return RemovalFixture(model, friendService, favoriteService, accountDao, profileScope, client)
     }
 
     private data class RemovalFixture(
         val model: FriendListPagerModel,
         val friendService: FriendService,
         val favoriteService: FavoriteService,
+        val accountDao: AccountDao,
         val profileScope: CoroutineScope,
         val client: HttpClient,
     ) {

--- a/composeApp/src/commonTest/kotlin/presentation/settings/locale/LocaleActionMessagesTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/settings/locale/LocaleActionMessagesTest.kt
@@ -65,4 +65,33 @@ class LocaleActionMessagesTest {
             assertTrue(locale.printEditorReadFailed.contains("%s"))
         }
     }
+
+    @Test
+    fun friendRemovalMessagesKeepTheirCountPlaceholders() {
+        val locales = listOf(
+            LocaleStringsEn,
+            LocaleStringsJa,
+            LocaleStringsZhHans,
+            LocaleStringsZhHant,
+        )
+
+        locales.forEach { locale ->
+            val messages = listOf(
+                locale.friendDirectorySelect,
+                locale.friendDirectorySelectAll,
+                locale.friendDirectoryClearSelection,
+                locale.friendDirectoryRemoveSelected,
+                locale.friendDirectoryRemoveConfirmTitle,
+            )
+            assertTrue(messages.all { it.isNotBlank() })
+            assertTrue(locale.friendDirectorySelectedCount.countPlaceholderCount() == 1)
+            assertTrue(locale.friendDirectoryRemoveConfirmMessage.countPlaceholderCount() == 1)
+            assertTrue(locale.friendDirectoryRemovingProgress.countPlaceholderCount() == 2)
+            assertTrue(locale.friendDirectoryRemoveSuccess.countPlaceholderCount() == 1)
+            assertTrue(locale.friendDirectoryRemovePartialFailure.countPlaceholderCount() == 2)
+            assertTrue(locale.friendDirectoryRemoveFailed.countPlaceholderCount() == 1)
+        }
+    }
 }
+
+private fun String.countPlaceholderCount(): Int = windowed(size = 2).count { it == "%d" }


### PR DESCRIPTION
## 变更说明

- 在好友目录增加多选模式、全选当前结果、二次确认和进行中状态。
- 删除请求按每批最多 3 项执行；每个批次只捕获一次账号会话，并在同一个会话绑定请求内并发调用接口。
- 批次内逐项保留成功或失败；认证失败作为该项失败返回，由用户重试，不在并发批次中触发跨请求续期。
- 批次返回后再次核对账号会话，只将成功项一次性从权威好友状态移除，并更新会话绑定快照与本地缓存。
- 单人删除保留 401 后自动续期与重试，并使用响应返回的新会话令牌提交成功结果，避免同账号续期后误报失败。
- 账号切换会取消旧批次并拒绝迟到结果；单人删除也不会将旧账号结果提交到新账号状态。
- 新增英文、日文、简体中文和繁体中文文案及占位符契约测试。

## 实现假设清单

- 官方单好友删除接口对每位好友独立返回结果，因此批次允许部分成功。
- 每批最多 3 项是并发上限，也是好友服务批次入口的调用契约。
- 并发批次内发生认证失败时，应保留失败项供用户重试，不能在其他请求仍在途时切换认证上下文。
- 单人删除允许沿用既有 401 自动续期，但重试成功后必须使用认证响应返回的最新同账号会话令牌提交状态。
- 账号会话变化后，旧账号请求的结果不应写入新账号状态；同账号会话续期后可对齐到最新会话令牌。
- 好友目录现有的会话绑定好友快照是列表展示和删除成功后的唯一权威状态源。
- 本次仅提供批量删除，不包含屏蔽、收藏整理、导入导出或其他批量操作。

## 代码逻辑图

```mermaid
flowchart TD
    A[进入好友多选模式] --> B[选择并确认好友]
    B --> C[切分为最多 3 项的批次]
    C --> D[捕获当前账号会话令牌]
    D --> E[在一次会话绑定请求内并发调用删除接口]
    E --> F{逐项请求是否成功}
    F -- 是 --> G[记录成功项]
    F -- 否 --> H[保留失败项供重试]
    G --> I{响应完整会话令牌是否仍为当前会话}
    H --> I
    I -- 否 --> J[丢弃旧批次状态]
    I -- 是 --> K[一次性提交成功项并发布会话绑定快照]
    K --> L[写入好友缓存并汇总逐项结果]

    M[发起单人删除] --> N[捕获当前账号会话令牌]
    N --> O[发送会话绑定删除请求]
    O --> P{是否返回 401}
    P -- 是 --> Q[同账号续期并重试]
    P -- 否 --> R{请求是否成功}
    Q --> R
    R -- 否 --> S[返回请求失败]
    R -- 是 --> T[将响应令牌对齐到当前好友会话]
    T --> U{账号会话是否有效}
    U -- 否 --> V[拒绝迟到结果]
    U -- 是 --> W[移除好友并提交缓存]
```

## 验证

- `./gradlew :composeApp:compileKotlinDesktop`
- `./gradlew :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.presentation.screens.home.pager.FriendListPagerModelTest.singleRemovalCommitsAfterSameAccountReauthentication"`
- `./gradlew :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.presentation.screens.home.pager.FriendListPagerModelTest"`
- `./gradlew :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStringsStructureTest" --tests "io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleActionMessagesTest" :composeApp:compileKotlinDesktop`
- `./gradlew :composeApp:desktopTest`（807 项，零失败）
- `git diff --check origin/newui...HEAD`
