### PR TITLE
feat(world): 支持世界发布状态切换

### DIFF
--- a/composeApp/src/commonMain/kotlin/network/api/worlds/WorldsApi.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/worlds/WorldsApi.kt
@@ -5,6 +5,7 @@ import io.github.vrcmteam.vrcm.network.api.attributes.WORLDS_API_PREFIX
 import io.github.vrcmteam.vrcm.network.api.instances.data.InstanceData
 import io.github.vrcmteam.vrcm.network.api.worlds.data.FavoritedWorld
 import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
+import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldPublishStatus
 import io.github.vrcmteam.vrcm.network.extensions.checkSuccess
 import io.ktor.client.*
 import io.ktor.client.request.*
@@ -23,6 +24,17 @@ class WorldsApi(private val client: HttpClient)  {
      */
     suspend fun getWorldById(worldId: String): WorldData =
         client.get("$WORLDS_API_PREFIX/$worldId").checkSuccess()
+
+    suspend fun getWorldPublishStatus(worldId: String): WorldPublishStatus =
+        client.get("$WORLDS_API_PREFIX/$worldId/publish").checkSuccess()
+
+    suspend fun publishWorld(worldId: String) {
+        client.put("$WORLDS_API_PREFIX/$worldId/publish").checkSuccess { Unit }
+    }
+
+    suspend fun unpublishWorld(worldId: String) {
+        client.delete("$WORLDS_API_PREFIX/$worldId/publish").checkSuccess { Unit }
+    }
 
     suspend fun getRecentWorlds(
         n: Int = 50,

--- a/composeApp/src/commonMain/kotlin/network/api/worlds/data/WorldPublishStatus.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/worlds/data/WorldPublishStatus.kt
@@ -1,0 +1,8 @@
+package io.github.vrcmteam.vrcm.network.api.worlds.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WorldPublishStatus(
+    val canPublish: Boolean,
+)

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
@@ -893,7 +893,7 @@ private fun WorldPublicationActionButton(
 ) {
     val action = state.action ?: return
     val description = when (state.blockReason) {
-        WorldPublicationBlockReason.WeeklyLimit -> strings.worldPublishUnavailable
+        WorldPublicationBlockReason.Unavailable -> strings.worldPublishUnavailable
         WorldPublicationBlockReason.CheckFailed -> strings.worldPublishAvailabilityCheckFailed
         WorldPublicationBlockReason.RefreshRequired -> strings.worldPublicationRefreshRequired
         null -> when (action) {

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
@@ -805,8 +805,9 @@ private fun RenderTopBar(
             .zIndex(20f) // 确保在所有内容之上
     ) {
         val topBarRatio = (1 - blurProgress).coerceIn(0f, 1f)
-        val reservedWidth = if (publicationState.action == null) 208.dp else 304.dp
-        val titleMaxWidth = (maxWidth - reservedWidth).coerceIn(0.dp, 200.dp)
+        val actionCount = 2 + if (publicationState.action == null) 0 else 1
+        val leftActionSlot = 68.dp
+        val rightActionSlot = 10.dp + 48.dp * actionCount
 
         // 添加TopMenuBar
         TopMenuBar(
@@ -859,12 +860,15 @@ private fun RenderTopBar(
             Row(
                 modifier = Modifier
                     .align(Alignment.Center)
+                    .fillMaxWidth()
                     .simpleClickable(onClick = onCollapse),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
+                Spacer(modifier = Modifier.width(leftActionSlot))
                 Text(
-                    modifier = Modifier.widthIn(max = titleMaxWidth),
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 8.dp),
                     text = worldName,
                     textAlign = TextAlign.Center,
                     fontWeight = FontWeight.Bold,
@@ -873,7 +877,7 @@ private fun RenderTopBar(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
-
+                Spacer(modifier = Modifier.width(rightActionSlot))
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
@@ -96,6 +96,9 @@ internal fun WorldPublicationNotice.localizedToast(locale: LocaleStrings): Toast
         is WorldPublicationNotice.RefreshFailed -> ToastText.Error(
             locale.worldPublicationRefreshRequired.withOptionalDetail(message)
         )
+        is WorldPublicationNotice.CacheSyncFailed -> ToastText.Error(
+            locale.worldPublicationCacheSyncFailed.withOptionalDetail(message)
+        )
     }
 
 private fun String.withOptionalDetail(detail: String?): String =

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
@@ -58,6 +58,7 @@ import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import io.github.vrcmteam.vrcm.core.extensions.toLocalDate
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
 import io.github.vrcmteam.vrcm.network.api.files.data.PlatformType.*
 import io.github.vrcmteam.vrcm.presentation.compoments.*
@@ -72,10 +73,33 @@ import io.github.vrcmteam.vrcm.presentation.screens.world.components.InstanceCar
 import io.github.vrcmteam.vrcm.presentation.screens.world.components.InstancesDialog
 import io.github.vrcmteam.vrcm.presentation.screens.world.data.*
 import io.github.vrcmteam.vrcm.presentation.screens.world.data.SheetState
+import io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStrings
 import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
 import presentation.compoments.TopMenuBar
 import kotlin.math.abs
+
+internal fun WorldPublicationNotice.localizedToast(locale: LocaleStrings): ToastText =
+    when (this) {
+        is WorldPublicationNotice.Changed -> ToastText.Success(
+            when (action) {
+                WorldPublicationAction.Publish -> locale.worldPublishSuccess
+                WorldPublicationAction.Unpublish -> locale.worldUnpublishSuccess
+            }
+        )
+        is WorldPublicationNotice.ChangeFailed -> ToastText.Error(
+            when (action) {
+                WorldPublicationAction.Publish -> locale.worldPublishFailed
+                WorldPublicationAction.Unpublish -> locale.worldUnpublishFailed
+            }.withOptionalDetail(message)
+        )
+        is WorldPublicationNotice.RefreshFailed -> ToastText.Error(
+            locale.worldPublicationRefreshRequired.withOptionalDetail(message)
+        )
+    }
+
+private fun String.withOptionalDetail(detail: String?): String =
+    detail?.takeIf { it.isNotBlank() }?.let { "$this: $it" } ?: this
 
 /**
  *
@@ -103,10 +127,17 @@ class WorldProfileScreen(
         // 收集ViewModel状态
         val profileVoState by screenModel.worldProfileState.collectAsState()
         val isLoading by screenModel.isLoading.collectAsState()
+        val publicationState by screenModel.publicationState.collectAsState()
         val currentNavigator = currentNavigator
+        val localeStrings = strings
         // 组件首次加载时自动刷新数据
         LaunchedEffect(Unit) {
             screenModel.loadWorldData(worldProfileVO)
+        }
+        LaunchedEffect(screenModel, localeStrings) {
+            screenModel.publicationNotices.collect { notice ->
+                SharedFlowCentre.toastText.emit(notice.localizedToast(localeStrings))
+            }
         }
 
         CompositionLocalProvider(
@@ -118,6 +149,8 @@ class WorldProfileScreen(
                 onMenu = { /* 打开菜单 */ },
                 isRefreshing = isLoading,
                 onRefresh = screenModel::refreshWorldData,
+                publicationState = publicationState,
+                onPublicationAction = screenModel::changeWorldPublication,
                 sharedKeyPrefix = sharedKeyPrefix,
                 sharedImageCacheKey = sharedImageCacheKey,
             )
@@ -126,17 +159,46 @@ class WorldProfileScreen(
 
     // 主要内容组件
     @Composable
-    fun WorldProfileContent(
+    private fun WorldProfileContent(
         worldProfileVo: WorldProfileVo,
         onReturn: () -> Unit = {},
         onMenu: () -> Unit = {},
         isRefreshing: Boolean = false,
         onRefresh: () -> Unit = {},
+        publicationState: WorldPublicationUiState = WorldPublicationUiState(),
+        onPublicationAction: (WorldPublicationAction) -> Unit = {},
         sharedKeyPrefix: String = "",
         sharedImageCacheKey: String? = null,
     ) {
         // 模糊效果状态
         val hazeState = remember { HazeState() }
+        var publicationConfirmation by rememberSaveable(worldProfileVo.worldId) {
+            mutableStateOf<WorldPublicationAction?>(null)
+        }
+        LaunchedEffect(
+            worldProfileVo.worldId,
+            publicationState.action,
+            publicationState.canExecute,
+        ) {
+            val pendingAction = publicationConfirmation ?: return@LaunchedEffect
+            if (publicationState.action != pendingAction || !publicationState.canExecute) {
+                publicationConfirmation = null
+            }
+        }
+
+        publicationConfirmation?.let { action ->
+            WorldPublicationConfirmationDialog(
+                action = action,
+                worldName = worldProfileVo.worldName,
+                enabled = publicationState.action == action && publicationState.canExecute &&
+                    !publicationState.isChanging && !isRefreshing,
+                onDismiss = { publicationConfirmation = null },
+                onConfirm = {
+                    onPublicationAction(action)
+                    publicationConfirmation = null
+                },
+            )
+        }
 
         BoxWithConstraints(
             modifier = Modifier.fillMaxSize()
@@ -227,7 +289,9 @@ class WorldProfileScreen(
                 onMenu = onMenu,
                 onCollapse = { sheetState = SheetState.COLLAPSED },
                 isRefreshing = isRefreshing,
-                onRefresh = onRefresh
+                onRefresh = onRefresh,
+                publicationState = publicationState,
+                onPublicationAction = { publicationConfirmation = it },
             )
 
             // ========== BottomSheet ==========
@@ -729,6 +793,8 @@ private fun RenderTopBar(
     onCollapse: () -> Unit,
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
+    publicationState: WorldPublicationUiState = WorldPublicationUiState(),
+    onPublicationAction: (WorldPublicationAction) -> Unit = {},
 ) {
     BoxWithConstraints(
         modifier = Modifier
@@ -736,7 +802,8 @@ private fun RenderTopBar(
             .zIndex(20f) // 确保在所有内容之上
     ) {
         val topBarRatio = (1 - blurProgress).coerceIn(0f, 1f)
-        val titleMaxWidth = (maxWidth - 208.dp).coerceIn(40.dp, 200.dp)
+        val reservedWidth = if (publicationState.action == null) 208.dp else 304.dp
+        val titleMaxWidth = (maxWidth - reservedWidth).coerceIn(0.dp, 200.dp)
 
         // 添加TopMenuBar
         TopMenuBar(
@@ -748,12 +815,18 @@ private fun RenderTopBar(
             onReturn = onReturn,
             onMenu = null,
             actions = { colors ->
+                WorldPublicationActionButton(
+                    state = publicationState,
+                    colors = colors,
+                    pageRefreshing = isRefreshing,
+                    onClick = onPublicationAction,
+                )
                 OfficialUrlShareButton(
                     url = "https://vrchat.com/home/world/$worldId",
                     colors = colors,
                 )
                 IconButton(
-                    enabled = !isRefreshing,
+                    enabled = !isRefreshing && !publicationState.isChanging,
                     colors = colors,
                     onClick = onRefresh,
                 ) {
@@ -801,6 +874,94 @@ private fun RenderTopBar(
             }
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun WorldPublicationActionButton(
+    state: WorldPublicationUiState,
+    colors: IconButtonColors,
+    pageRefreshing: Boolean,
+    onClick: (WorldPublicationAction) -> Unit,
+) {
+    val action = state.action ?: return
+    val description = when (state.blockReason) {
+        WorldPublicationBlockReason.WeeklyLimit -> strings.worldPublishUnavailable
+        WorldPublicationBlockReason.CheckFailed -> strings.worldPublishAvailabilityCheckFailed
+        WorldPublicationBlockReason.RefreshRequired -> strings.worldPublicationRefreshRequired
+        null -> when (action) {
+            WorldPublicationAction.Publish -> strings.worldPublishAction
+            WorldPublicationAction.Unpublish -> strings.worldUnpublishAction
+        }
+    }
+
+    ATooltipBox(tooltip = { Text(description) }) {
+        IconButton(
+            enabled = state.canExecute && !state.isChecking && !state.isChanging &&
+                !pageRefreshing,
+            colors = colors,
+            onClick = { onClick(action) },
+        ) {
+            if (state.isChecking || state.isChanging) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(22.dp),
+                    color = LocalContentColor.current,
+                    strokeWidth = 2.dp,
+                )
+            } else {
+                Icon(
+                    imageVector = when (action) {
+                        WorldPublicationAction.Publish -> AppIcons.Publish
+                        WorldPublicationAction.Unpublish -> AppIcons.VisibilityOff
+                    },
+                    contentDescription = description,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun WorldPublicationConfirmationDialog(
+    action: WorldPublicationAction,
+    worldName: String,
+    enabled: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    val title = when (action) {
+        WorldPublicationAction.Publish -> strings.worldPublishConfirmationTitle
+        WorldPublicationAction.Unpublish -> strings.worldUnpublishConfirmationTitle
+    }
+    val message = when (action) {
+        WorldPublicationAction.Publish -> strings.worldPublishConfirmationMessage
+        WorldPublicationAction.Unpublish -> strings.worldUnpublishConfirmationMessage
+    }.replace("%s", worldName)
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Icon(
+                imageVector = when (action) {
+                    WorldPublicationAction.Publish -> AppIcons.Publish
+                    WorldPublicationAction.Unpublish -> AppIcons.VisibilityOff
+                },
+                contentDescription = null,
+            )
+        },
+        title = { Text(title) },
+        text = { Text(message) },
+        confirmButton = {
+            TextButton(onClick = onConfirm, enabled = enabled) {
+                Text(strings.confirm)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(strings.cancel)
+            }
+        },
+    )
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
@@ -200,22 +200,30 @@ class WorldProfileScreenModel internal constructor(
         }
     }
 
-    private fun applyPublicationWorld(worldData: WorldData) {
-        val current = _worldProfileState.value ?: return
-        if (current.worldId != worldData.id) return
+    private suspend fun applyPublicationWorld(worldData: WorldData): Result<Unit> {
+        val current = _worldProfileState.value
+            ?: return Result.failure(IllegalStateException("World profile is no longer active"))
+        if (current.worldId != worldData.id) {
+            return Result.failure(IllegalStateException("World profile target changed before cache sync"))
+        }
 
         _worldProfileState.value = WorldProfileVo(
             world = worldData,
             instancesList = current.instances,
             platformFileSizes = current.platformFileSizes,
         )
-        viewModelScope.launch(Dispatchers.IO) {
+        return try {
             worldProfileCacheStore.save(
                 WorldProfileCache(
                     world = worldData,
                     cachedAtEpochMilliseconds = Clock.System.now().toEpochMilliseconds(),
                 )
             )
+            Result.success(Unit)
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            Result.failure(error)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
@@ -13,6 +13,7 @@ import io.github.vrcmteam.vrcm.network.api.instances.InstancesApi
 import io.github.vrcmteam.vrcm.network.api.invite.InviteApi
 import io.github.vrcmteam.vrcm.network.api.users.UsersApi
 import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
+import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
 import io.github.vrcmteam.vrcm.presentation.compoments.ToastText
 import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntrySource
 import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntryState
@@ -63,6 +64,14 @@ class WorldProfileScreenModel internal constructor(
     )
     internal val favoriteEntryState: StateFlow<FavoriteEntryState> = favoriteEntry.state
 
+    private val publication = WorldPublicationStateModel(
+        source = NetworkWorldPublicationSource(worldsApi, authService),
+        scope = viewModelScope,
+        onWorldRefreshed = ::applyPublicationWorld,
+    )
+    internal val publicationState: StateFlow<WorldPublicationUiState> = publication.state
+    internal val publicationNotices: SharedFlow<WorldPublicationNotice> = publication.notices
+
     internal fun retryFavoriteEntryLoad() {
         favoriteEntry.retry()
     }
@@ -73,6 +82,7 @@ class WorldProfileScreenModel internal constructor(
     fun loadWorldData(worldProfileVO: WorldProfileVo) {
         _worldProfileState.value = worldProfileVO
         val worldId = worldProfileVO.worldId
+        publication.setTarget(worldId, worldProfileVO.authorID)
         favoriteEntry.load(worldId)
         if (worldId.isBlank()) return
         // 缓存读取改为挂起（Room），先出网络前的占位状态，缓存到达后再回填。
@@ -82,6 +92,7 @@ class WorldProfileScreenModel internal constructor(
     private suspend fun applyCachedWorld(worldId: String, worldProfileVO: WorldProfileVo) {
         val cached = worldProfileCacheStore.load(worldId)
         if (cached != null) {
+            publication.observeKnownWorld(cached.world)
             _worldProfileState.value = WorldProfileVo(
                 world = cached.world,
                 instancesList = worldProfileVO.instances,
@@ -96,6 +107,7 @@ class WorldProfileScreenModel internal constructor(
             refreshWorldData()
         } else {
             loadCachedInstances(cached.world.instances.orEmpty())
+            publication.refreshIfOwned()
         }
     }
 
@@ -138,9 +150,12 @@ class WorldProfileScreenModel internal constructor(
     }
 
     private suspend fun loadWorldInfo(worldId: String) {
-        authService.reTryAuthCatching {
+        val sessionToken = SharedFlowCentre.currentSession.value?.token ?: return
+        val response = authService.runSessionBoundCatching(sessionToken) {
             worldsApi.getWorldById(worldId)
-        }.onSuccess { worldData ->
+        } ?: return
+        response.result.onSuccess { worldData ->
+            if (!SharedFlowCentre.isCurrentSession(response.sessionToken)) return@onSuccess
             worldProfileCacheStore.save(
                 WorldProfileCache(
                     world = worldData,
@@ -158,6 +173,7 @@ class WorldProfileScreenModel internal constructor(
                     instancesList = _worldProfileState.value?.instances ?: mutableListOf(),
 //                    platformFileSizes = platformFileSizes,
                 )
+            publication.acceptVerifiedWorld(worldData, response.sessionToken)
 //            viewModelScope.launch(Dispatchers.IO) {
 //                // 获取平台文件大小信息
 //                runCatching {
@@ -176,8 +192,35 @@ class WorldProfileScreenModel internal constructor(
                 loadInstanceData(mergeInstanceIds)
             }
         }.onFailure {
-            SharedFlowCentre.toastText.emit(ToastText.Error(it.message ?: "Failed to load world data"))
+            if (SharedFlowCentre.isCurrentSession(response.sessionToken) &&
+                _worldProfileState.value?.worldId == worldId
+            ) {
+                SharedFlowCentre.toastText.emit(ToastText.Error(it.message ?: "Failed to load world data"))
+            }
         }
+    }
+
+    private fun applyPublicationWorld(worldData: WorldData) {
+        val current = _worldProfileState.value ?: return
+        if (current.worldId != worldData.id) return
+
+        _worldProfileState.value = WorldProfileVo(
+            world = worldData,
+            instancesList = current.instances,
+            platformFileSizes = current.platformFileSizes,
+        )
+        viewModelScope.launch(Dispatchers.IO) {
+            worldProfileCacheStore.save(
+                WorldProfileCache(
+                    world = worldData,
+                    cachedAtEpochMilliseconds = Clock.System.now().toEpochMilliseconds(),
+                )
+            )
+        }
+    }
+
+    internal fun changeWorldPublication(action: WorldPublicationAction) {
+        publication.changePublication(action)
     }
 
     private fun collectInstanceIds(

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldPublicationStateModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldPublicationStateModel.kt
@@ -30,7 +30,7 @@ internal enum class WorldPublicationAction {
 }
 
 internal enum class WorldPublicationBlockReason {
-    WeeklyLimit,
+    Unavailable,
     CheckFailed,
     RefreshRequired,
 }
@@ -410,7 +410,7 @@ internal class WorldPublicationStateModel(
                         blockReason = if (canPublish) {
                             null
                         } else {
-                            WorldPublicationBlockReason.WeeklyLimit
+                            WorldPublicationBlockReason.Unavailable
                         },
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldPublicationStateModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldPublicationStateModel.kt
@@ -10,6 +10,7 @@ import io.github.vrcmteam.vrcm.service.SessionBoundResponse
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
@@ -50,6 +51,8 @@ internal sealed interface WorldPublicationNotice {
     ) : WorldPublicationNotice
 
     data class RefreshFailed(val message: String?) : WorldPublicationNotice
+
+    data class CacheSyncFailed(val message: String?) : WorldPublicationNotice
 }
 
 internal fun worldPublicationAction(
@@ -130,7 +133,7 @@ internal class WorldPublicationStateModel(
     private val scope: CoroutineScope,
     private val requestDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val sessionFlow: StateFlow<AuthenticatedAccount?> = SharedFlowCentre.currentSession,
-    private val onWorldRefreshed: (WorldData) -> Unit = {},
+    private val onWorldRefreshed: suspend (WorldData) -> Result<Unit> = { Result.success(Unit) },
 ) {
     private data class Target(
         val worldId: String = "",
@@ -213,11 +216,13 @@ internal class WorldPublicationStateModel(
             if (!accepts(currentTarget.worldId, response.sessionToken, requestGeneration)) {
                 return@launch
             }
-            response.result.onSuccess { world ->
-                if (world.id != currentTarget.worldId) return@onSuccess
-                onWorldRefreshed(world)
-                applyVerifiedWorld(world, response.sessionToken, requestGeneration)
+            val world = response.result.getOrNull() ?: return@launch
+            if (world.id != currentTarget.worldId) return@launch
+            val cacheSync = syncWorld(world)
+            if (cacheSync.isFailure && accepts(world.id, response.sessionToken, requestGeneration)) {
+                _notices.emit(WorldPublicationNotice.CacheSyncFailed(cacheSync.exceptionOrNull()?.message))
             }
+            applyVerifiedWorld(world, response.sessionToken, requestGeneration)
         }
         return true
     }
@@ -300,7 +305,17 @@ internal class WorldPublicationStateModel(
                 WorldPublicationAction.Publish -> "public"
                 WorldPublicationAction.Unpublish -> "private"
             }
-            onWorldRefreshed(refreshedWorld)
+            val cacheSync = syncWorld(refreshedWorld)
+            if (cacheSync.isFailure) {
+                applyVerifiedWorld(
+                    world = refreshedWorld,
+                    sessionToken = refreshed.sessionToken,
+                    requestGeneration = requestGeneration,
+                    forcedBlockReason = WorldPublicationBlockReason.RefreshRequired,
+                )
+                _notices.emit(WorldPublicationNotice.CacheSyncFailed(cacheSync.exceptionOrNull()?.message))
+                return@launch
+            }
             if (refreshedWorld.releaseStatus != expectedStatus) {
                 applyVerifiedWorld(
                     world = refreshedWorld,
@@ -415,6 +430,14 @@ internal class WorldPublicationStateModel(
         mutationJob?.cancel()
         verifiedWorld = null
         _state.value = WorldPublicationUiState()
+    }
+
+    private suspend fun syncWorld(world: WorldData): Result<Unit> = try {
+        onWorldRefreshed(world)
+    } catch (error: CancellationException) {
+        throw error
+    } catch (error: Throwable) {
+        Result.failure(error)
     }
 
     private fun accepts(

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldPublicationStateModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldPublicationStateModel.kt
@@ -1,0 +1,427 @@
+package io.github.vrcmteam.vrcm.presentation.screens.world
+
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+import io.github.vrcmteam.vrcm.core.shared.AuthenticatedAccount
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
+import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
+import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
+import io.github.vrcmteam.vrcm.service.AuthService
+import io.github.vrcmteam.vrcm.service.SessionBoundResponse
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.updateAndGet
+import kotlinx.coroutines.launch
+
+internal enum class WorldPublicationAction {
+    Publish,
+    Unpublish,
+}
+
+internal enum class WorldPublicationBlockReason {
+    WeeklyLimit,
+    CheckFailed,
+    RefreshRequired,
+}
+
+internal data class WorldPublicationUiState(
+    val action: WorldPublicationAction? = null,
+    val canExecute: Boolean = false,
+    val isChecking: Boolean = false,
+    val isChanging: Boolean = false,
+    val blockReason: WorldPublicationBlockReason? = null,
+)
+
+internal sealed interface WorldPublicationNotice {
+    data class Changed(val action: WorldPublicationAction) : WorldPublicationNotice
+    data class ChangeFailed(
+        val action: WorldPublicationAction,
+        val message: String?,
+    ) : WorldPublicationNotice
+
+    data class RefreshFailed(val message: String?) : WorldPublicationNotice
+}
+
+internal fun worldPublicationAction(
+    authorId: String?,
+    releaseStatus: String?,
+    currentUserId: String?,
+): WorldPublicationAction? {
+    if (authorId.isNullOrBlank() || authorId != currentUserId) return null
+    return when (releaseStatus) {
+        "private" -> WorldPublicationAction.Publish
+        "public" -> WorldPublicationAction.Unpublish
+        else -> null
+    }
+}
+
+internal interface WorldPublicationSource {
+    suspend fun loadWorld(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+    ): SessionBoundResponse<WorldData>?
+
+    suspend fun canPublish(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+    ): SessionBoundResponse<Boolean>?
+
+    suspend fun changePublication(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+        action: WorldPublicationAction,
+    ): SessionBoundResponse<Unit>?
+}
+
+internal class NetworkWorldPublicationSource(
+    private val worldsApi: WorldsApi,
+    private val authService: AuthService,
+) : WorldPublicationSource {
+    override suspend fun loadWorld(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+    ): SessionBoundResponse<WorldData>? =
+        authService.runSessionBoundCatching(sessionToken) {
+            worldsApi.getWorldById(worldId)
+        }
+
+    override suspend fun canPublish(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+    ): SessionBoundResponse<Boolean>? {
+        val response = authService.runSessionBoundCatching(sessionToken) {
+            worldsApi.getWorldPublishStatus(worldId)
+        } ?: return null
+        return SessionBoundResponse(
+            result = response.result.map { it.canPublish },
+            sessionToken = response.sessionToken,
+        )
+    }
+
+    override suspend fun changePublication(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+        action: WorldPublicationAction,
+    ): SessionBoundResponse<Unit>? =
+        authService.runSessionBoundCatching(sessionToken) {
+            when (action) {
+                WorldPublicationAction.Publish -> worldsApi.publishWorld(worldId)
+                WorldPublicationAction.Unpublish -> worldsApi.unpublishWorld(worldId)
+            }
+        }
+}
+
+/**
+ * Coordinates owner-only publication mutations against a specific account session and world.
+ * Results from replaced sessions or targets are discarded before they can update UI state.
+ */
+internal class WorldPublicationStateModel(
+    private val source: WorldPublicationSource,
+    private val scope: CoroutineScope,
+    private val requestDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val sessionFlow: StateFlow<AuthenticatedAccount?> = SharedFlowCentre.currentSession,
+    private val onWorldRefreshed: (WorldData) -> Unit = {},
+) {
+    private data class Target(
+        val worldId: String = "",
+        val knownAuthorId: String? = null,
+    )
+
+    private data class VerifiedWorld(
+        val worldId: String,
+        val authorId: String,
+        val releaseStatus: String,
+        val sessionToken: AccountSessionToken,
+    )
+
+    private val target = MutableStateFlow(Target())
+    private val generation = MutableStateFlow(0L)
+    private var verifiedWorld: VerifiedWorld? = null
+    private var observedSessionToken = sessionFlow.value?.token
+    private var refreshJob: Job? = null
+    private var eligibilityJob: Job? = null
+    private var mutationJob: Job? = null
+
+    private val _state = MutableStateFlow(WorldPublicationUiState())
+    val state: StateFlow<WorldPublicationUiState> = _state.asStateFlow()
+
+    private val _notices = MutableSharedFlow<WorldPublicationNotice>(extraBufferCapacity = 1)
+    val notices: SharedFlow<WorldPublicationNotice> = _notices.asSharedFlow()
+
+    init {
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            sessionFlow.collect { session ->
+                val nextToken = session?.token
+                if (nextToken == observedSessionToken) return@collect
+                observedSessionToken = nextToken
+                invalidateRequests()
+                if (target.value.knownAuthorId == nextToken?.userId) {
+                    refreshIfOwned()
+                }
+            }
+        }
+    }
+
+    fun setTarget(worldId: String, knownAuthorId: String?) {
+        val current = target.value
+        if (current.worldId == worldId) {
+            if (!knownAuthorId.isNullOrBlank() && current.knownAuthorId != knownAuthorId) {
+                target.value = current.copy(knownAuthorId = knownAuthorId)
+            }
+            return
+        }
+
+        invalidateRequests()
+        target.value = Target(worldId = worldId, knownAuthorId = knownAuthorId)
+    }
+
+    fun observeKnownWorld(world: WorldData) {
+        val current = target.value
+        if (current.worldId != world.id) return
+        target.value = current.copy(knownAuthorId = world.authorId)
+    }
+
+    fun acceptVerifiedWorld(world: WorldData, sessionToken: AccountSessionToken) {
+        applyVerifiedWorld(
+            world = world,
+            sessionToken = sessionToken,
+            requestGeneration = generation.value,
+        )
+    }
+
+    fun refreshIfOwned(): Boolean {
+        val currentTarget = target.value
+        val sessionToken = sessionFlow.value?.token ?: return false
+        if (currentTarget.worldId.isBlank() || currentTarget.knownAuthorId != sessionToken.userId) {
+            return false
+        }
+
+        val requestGeneration = generation.value
+        refreshJob?.cancel()
+        refreshJob = scope.launch(requestDispatcher) {
+            val response = source.loadWorld(sessionToken, currentTarget.worldId) ?: return@launch
+            if (!accepts(currentTarget.worldId, response.sessionToken, requestGeneration)) {
+                return@launch
+            }
+            response.result.onSuccess { world ->
+                if (world.id != currentTarget.worldId) return@onSuccess
+                onWorldRefreshed(world)
+                applyVerifiedWorld(world, response.sessionToken, requestGeneration)
+            }
+        }
+        return true
+    }
+
+    fun changePublication(action: WorldPublicationAction) {
+        val readyState = _state.value
+        val verified = verifiedWorld ?: return
+        val sessionToken = sessionFlow.value?.token ?: return
+        val currentTarget = target.value
+        if (
+            readyState.action != action || !readyState.canExecute ||
+            readyState.isChecking || readyState.isChanging ||
+            verified.worldId != currentTarget.worldId ||
+            verified.authorId != sessionToken.userId ||
+            verified.sessionToken != sessionToken
+        ) {
+            return
+        }
+
+        val changingState = readyState.copy(canExecute = false, isChanging = true)
+        if (!_state.compareAndSet(readyState, changingState)) return
+
+        val requestGeneration = generation.value
+        mutationJob = scope.launch(requestDispatcher) {
+            val mutation = source.changePublication(
+                sessionToken = sessionToken,
+                worldId = verified.worldId,
+                action = action,
+            )
+            if (mutation == null) {
+                if (accepts(verified.worldId, sessionToken, requestGeneration)) {
+                    _state.value = readyState
+                }
+                return@launch
+            }
+            if (!accepts(verified.worldId, mutation.sessionToken, requestGeneration)) {
+                return@launch
+            }
+
+            val mutationError = mutation.result.exceptionOrNull()
+            if (mutationError != null) {
+                _state.value = readyState
+                _notices.emit(WorldPublicationNotice.ChangeFailed(action, mutationError.message))
+                return@launch
+            }
+
+            val refreshed = source.loadWorld(mutation.sessionToken, verified.worldId)
+            if (refreshed == null) {
+                if (accepts(verified.worldId, mutation.sessionToken, requestGeneration)) {
+                    _state.value = changingState.copy(
+                        isChanging = false,
+                        blockReason = WorldPublicationBlockReason.RefreshRequired,
+                    )
+                    _notices.emit(WorldPublicationNotice.RefreshFailed(null))
+                }
+                return@launch
+            }
+            if (!accepts(verified.worldId, refreshed.sessionToken, requestGeneration)) {
+                return@launch
+            }
+
+            val refreshedWorld = refreshed.result.getOrElse { error ->
+                _state.value = changingState.copy(
+                    isChanging = false,
+                    blockReason = WorldPublicationBlockReason.RefreshRequired,
+                )
+                _notices.emit(WorldPublicationNotice.RefreshFailed(error.message))
+                return@launch
+            }
+            if (refreshedWorld.id != verified.worldId) {
+                _state.value = changingState.copy(
+                    isChanging = false,
+                    blockReason = WorldPublicationBlockReason.RefreshRequired,
+                )
+                _notices.emit(WorldPublicationNotice.RefreshFailed(null))
+                return@launch
+            }
+
+            val expectedStatus = when (action) {
+                WorldPublicationAction.Publish -> "public"
+                WorldPublicationAction.Unpublish -> "private"
+            }
+            onWorldRefreshed(refreshedWorld)
+            if (refreshedWorld.releaseStatus != expectedStatus) {
+                applyVerifiedWorld(
+                    world = refreshedWorld,
+                    sessionToken = refreshed.sessionToken,
+                    requestGeneration = requestGeneration,
+                    forcedBlockReason = WorldPublicationBlockReason.RefreshRequired,
+                )
+                _notices.emit(WorldPublicationNotice.RefreshFailed(null))
+                return@launch
+            }
+
+            applyVerifiedWorld(refreshedWorld, refreshed.sessionToken, requestGeneration)
+            _notices.emit(WorldPublicationNotice.Changed(action))
+        }
+    }
+
+    private fun applyVerifiedWorld(
+        world: WorldData,
+        sessionToken: AccountSessionToken,
+        requestGeneration: Long,
+        forcedBlockReason: WorldPublicationBlockReason? = null,
+    ) {
+        if (!accepts(world.id, sessionToken, requestGeneration)) return
+
+        val currentTarget = target.value
+        target.value = currentTarget.copy(knownAuthorId = world.authorId)
+        verifiedWorld = VerifiedWorld(
+            worldId = world.id,
+            authorId = world.authorId,
+            releaseStatus = world.releaseStatus,
+            sessionToken = sessionToken,
+        )
+        eligibilityJob?.cancel()
+
+        when (val action = worldPublicationAction(
+            authorId = world.authorId,
+            releaseStatus = world.releaseStatus,
+            currentUserId = sessionToken.userId,
+        )) {
+            null -> _state.value = WorldPublicationUiState()
+            WorldPublicationAction.Unpublish -> {
+                _state.value = WorldPublicationUiState(
+                    action = action,
+                    canExecute = forcedBlockReason == null,
+                    blockReason = forcedBlockReason,
+                )
+            }
+            WorldPublicationAction.Publish -> {
+                if (forcedBlockReason == null) {
+                    _state.value = WorldPublicationUiState(
+                        action = action,
+                        isChecking = true,
+                    )
+                    checkPublishAvailability(world.id, sessionToken, requestGeneration)
+                } else {
+                    _state.value = WorldPublicationUiState(
+                        action = action,
+                        blockReason = forcedBlockReason,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun checkPublishAvailability(
+        worldId: String,
+        sessionToken: AccountSessionToken,
+        requestGeneration: Long,
+    ) {
+        eligibilityJob = scope.launch(requestDispatcher) {
+            val response = source.canPublish(sessionToken, worldId)
+            if (response == null) {
+                if (accepts(worldId, sessionToken, requestGeneration)) {
+                    _state.value = WorldPublicationUiState(
+                        action = WorldPublicationAction.Publish,
+                        blockReason = WorldPublicationBlockReason.CheckFailed,
+                    )
+                }
+                return@launch
+            }
+            if (!accepts(worldId, response.sessionToken, requestGeneration) ||
+                verifiedWorld?.releaseStatus != "private"
+            ) {
+                return@launch
+            }
+
+            response.result
+                .onSuccess { canPublish ->
+                    _state.value = WorldPublicationUiState(
+                        action = WorldPublicationAction.Publish,
+                        canExecute = canPublish,
+                        blockReason = if (canPublish) {
+                            null
+                        } else {
+                            WorldPublicationBlockReason.WeeklyLimit
+                        },
+                    )
+                }
+                .onFailure {
+                    _state.value = WorldPublicationUiState(
+                        action = WorldPublicationAction.Publish,
+                        blockReason = WorldPublicationBlockReason.CheckFailed,
+                    )
+                }
+        }
+    }
+
+    private fun invalidateRequests() {
+        generation.updateAndGet { it + 1 }
+        refreshJob?.cancel()
+        eligibilityJob?.cancel()
+        mutationJob?.cancel()
+        verifiedWorld = null
+        _state.value = WorldPublicationUiState()
+    }
+
+    private fun accepts(
+        worldId: String,
+        sessionToken: AccountSessionToken,
+        requestGeneration: Long,
+    ): Boolean = generation.value == requestGeneration &&
+        target.value.worldId == worldId &&
+        sessionFlow.value?.token == sessionToken
+}

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldPublicationStateModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldPublicationStateModel.kt
@@ -306,6 +306,9 @@ internal class WorldPublicationStateModel(
                 WorldPublicationAction.Unpublish -> "private"
             }
             val cacheSync = syncWorld(refreshedWorld)
+            if (!accepts(verified.worldId, refreshed.sessionToken, requestGeneration)) {
+                return@launch
+            }
             if (cacheSync.isFailure) {
                 applyVerifiedWorld(
                     world = refreshedWorld,

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
@@ -207,7 +207,8 @@ sealed class LocaleStrings {
     open val worldUnpublishSuccess: String = "World unpublished"
     open val worldPublishFailed: String = "Failed to publish world"
     open val worldUnpublishFailed: String = "Failed to unpublish world"
-    open val worldPublishUnavailable: String = "Publishing is not available yet"
+    open val worldPublishUnavailable: String =
+        "This world is not currently eligible for publishing. You can publish at most one world per week."
     open val worldPublishAvailabilityCheckFailed: String =
         "Could not check publishing availability. Refresh to try again."
     open val worldPublicationRefreshRequired: String =

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
@@ -212,6 +212,8 @@ sealed class LocaleStrings {
         "Could not check publishing availability. Refresh to try again."
     open val worldPublicationRefreshRequired: String =
         "The request completed, but the current status could not be confirmed. Refresh before trying again."
+    open val worldPublicationCacheSyncFailed: String =
+        "World status updated, but the cached data could not be saved. Refresh before trying again."
 
     // World Search
     open val worldSearchAdvancedOptions: String = "Advanced Search Options"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
@@ -196,6 +196,22 @@ sealed class LocaleStrings {
     open val instanceCreateSuccess: String = "Successfully created instance and sent invite"
     open val instanceCreateSuccessButInviteFailed: String = "Instance created successfully but invite failed"
     open val instanceCreateFailed: String = "Failed to create instance"
+    open val worldPublishAction: String = "Publish to Community Labs"
+    open val worldUnpublishAction: String = "Unpublish World"
+    open val worldPublishConfirmationTitle: String = "Publish World?"
+    open val worldUnpublishConfirmationTitle: String = "Unpublish World?"
+    open val worldPublishConfirmationMessage: String =
+        "Publish %s to Community Labs? Publishing is limited to one world per week."
+    open val worldUnpublishConfirmationMessage: String = "Unpublish %s and make it private?"
+    open val worldPublishSuccess: String = "World published"
+    open val worldUnpublishSuccess: String = "World unpublished"
+    open val worldPublishFailed: String = "Failed to publish world"
+    open val worldUnpublishFailed: String = "Failed to unpublish world"
+    open val worldPublishUnavailable: String = "Publishing is not available yet"
+    open val worldPublishAvailabilityCheckFailed: String =
+        "Could not check publishing availability. Refresh to try again."
+    open val worldPublicationRefreshRequired: String =
+        "The request completed, but the current status could not be confirmed. Refresh before trying again."
 
     // World Search
     open val worldSearchAdvancedOptions: String = "Advanced Search Options"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
@@ -192,7 +192,7 @@ internal object LocaleStringsJa : LocaleStrings() {
     override val worldUnpublishSuccess = "ワールドを非公開にしました"
     override val worldPublishFailed = "ワールドの公開に失敗しました"
     override val worldUnpublishFailed = "ワールドの非公開化に失敗しました"
-    override val worldPublishUnavailable = "現在はワールドを公開できません"
+    override val worldPublishUnavailable = "現在このワールドは公開資格を満たしていません。公開できるワールドは週に1つまでです。"
     override val worldPublishAvailabilityCheckFailed =
         "公開可能か確認できませんでした。更新してもう一度お試しください。"
     override val worldPublicationRefreshRequired =

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
@@ -181,6 +181,22 @@ internal object LocaleStringsJa : LocaleStrings() {
     override val instanceCreateSuccess = "インスタンスを作成し、招待を送信しました"
     override val instanceCreateSuccessButInviteFailed = "インスタンスは作成されましたが、招待に失敗しました"
     override val instanceCreateFailed = "インスタンス作成に失敗しました"
+    override val worldPublishAction = "コミュニティラボに公開"
+    override val worldUnpublishAction = "ワールドを非公開にする"
+    override val worldPublishConfirmationTitle = "ワールドを公開しますか？"
+    override val worldUnpublishConfirmationTitle = "ワールドを非公開にしますか？"
+    override val worldPublishConfirmationMessage =
+        "%sをコミュニティラボに公開しますか？公開できるワールドは週に1つまでです。"
+    override val worldUnpublishConfirmationMessage = "%sを非公開にしてプライベートに戻しますか？"
+    override val worldPublishSuccess = "ワールドを公開しました"
+    override val worldUnpublishSuccess = "ワールドを非公開にしました"
+    override val worldPublishFailed = "ワールドの公開に失敗しました"
+    override val worldUnpublishFailed = "ワールドの非公開化に失敗しました"
+    override val worldPublishUnavailable = "現在はワールドを公開できません"
+    override val worldPublishAvailabilityCheckFailed =
+        "公開可能か確認できませんでした。更新してもう一度お試しください。"
+    override val worldPublicationRefreshRequired =
+        "リクエストは完了しましたが、現在の状態を確認できませんでした。再実行する前に更新してください。"
 
     // World Search
     override val worldSearchAdvancedOptions = "詳細検索オプション"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
@@ -197,6 +197,8 @@ internal object LocaleStringsJa : LocaleStrings() {
         "公開可能か確認できませんでした。更新してもう一度お試しください。"
     override val worldPublicationRefreshRequired =
         "リクエストは完了しましたが、現在の状態を確認できませんでした。再実行する前に更新してください。"
+    override val worldPublicationCacheSyncFailed =
+        "ワールドの状態は更新されましたが、キャッシュを保存できませんでした。再実行する前に更新してください。"
 
     // World Search
     override val worldSearchAdvancedOptions = "詳細検索オプション"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
@@ -180,6 +180,20 @@ internal object LocaleStringsZhHans : LocaleStrings() {
     override val instanceCreateSuccess = "成功创建房间并发送邀请"
     override val instanceCreateSuccessButInviteFailed = "创建房间成功，但邀请失败"
     override val instanceCreateFailed = "创建房间失败"
+    override val worldPublishAction = "发布到社区实验室"
+    override val worldUnpublishAction = "取消发布世界"
+    override val worldPublishConfirmationTitle = "发布世界？"
+    override val worldUnpublishConfirmationTitle = "取消发布世界？"
+    override val worldPublishConfirmationMessage =
+        "将“%s”发布到社区实验室吗？每周最多只能发布一个世界。"
+    override val worldUnpublishConfirmationMessage = "取消发布“%s”并将其设为私有吗？"
+    override val worldPublishSuccess = "世界已发布"
+    override val worldUnpublishSuccess = "世界已取消发布"
+    override val worldPublishFailed = "发布世界失败"
+    override val worldUnpublishFailed = "取消发布世界失败"
+    override val worldPublishUnavailable = "当前暂时无法发布世界"
+    override val worldPublishAvailabilityCheckFailed = "无法检查发布资格，请刷新后重试。"
+    override val worldPublicationRefreshRequired = "请求已完成，但无法确认当前状态。再次操作前请先刷新。"
 
     // World Search
     override val worldSearchAdvancedOptions = "高级搜索选项"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
@@ -191,7 +191,7 @@ internal object LocaleStringsZhHans : LocaleStrings() {
     override val worldUnpublishSuccess = "世界已取消发布"
     override val worldPublishFailed = "发布世界失败"
     override val worldUnpublishFailed = "取消发布世界失败"
-    override val worldPublishUnavailable = "当前暂时无法发布世界"
+    override val worldPublishUnavailable = "当前不符合世界发布资格。每周最多只能发布一个世界。"
     override val worldPublishAvailabilityCheckFailed = "无法检查发布资格，请刷新后重试。"
     override val worldPublicationRefreshRequired = "请求已完成，但无法确认当前状态。再次操作前请先刷新。"
     override val worldPublicationCacheSyncFailed = "世界状态已更新，但缓存保存失败。再次操作前请先刷新。"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
@@ -194,6 +194,7 @@ internal object LocaleStringsZhHans : LocaleStrings() {
     override val worldPublishUnavailable = "当前暂时无法发布世界"
     override val worldPublishAvailabilityCheckFailed = "无法检查发布资格，请刷新后重试。"
     override val worldPublicationRefreshRequired = "请求已完成，但无法确认当前状态。再次操作前请先刷新。"
+    override val worldPublicationCacheSyncFailed = "世界状态已更新，但缓存保存失败。再次操作前请先刷新。"
 
     // World Search
     override val worldSearchAdvancedOptions = "高级搜索选项"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
@@ -194,6 +194,7 @@ internal object LocaleStringsZhHant : LocaleStrings() {
     override val worldPublishUnavailable = "目前暫時無法發布世界"
     override val worldPublishAvailabilityCheckFailed = "無法檢查發布資格，請重新整理後再試。"
     override val worldPublicationRefreshRequired = "請求已完成，但無法確認目前狀態。再次操作前請先重新整理。"
+    override val worldPublicationCacheSyncFailed = "世界狀態已更新，但快取保存失敗。再次操作前請先重新整理。"
 
     // World Search
     override val worldSearchAdvancedOptions = "高級搜索選項"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
@@ -191,7 +191,7 @@ internal object LocaleStringsZhHant : LocaleStrings() {
     override val worldUnpublishSuccess = "世界已取消發布"
     override val worldPublishFailed = "發布世界失敗"
     override val worldUnpublishFailed = "取消發布世界失敗"
-    override val worldPublishUnavailable = "目前暫時無法發布世界"
+    override val worldPublishUnavailable = "目前此世界不符合發布資格。每週最多只能發布一個世界。"
     override val worldPublishAvailabilityCheckFailed = "無法檢查發布資格，請重新整理後再試。"
     override val worldPublicationRefreshRequired = "請求已完成，但無法確認目前狀態。再次操作前請先重新整理。"
     override val worldPublicationCacheSyncFailed = "世界狀態已更新，但快取保存失敗。再次操作前請先重新整理。"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
@@ -180,6 +180,20 @@ internal object LocaleStringsZhHant : LocaleStrings() {
     override val instanceCreateSuccess = "成功創建房間並發送邀請"
     override val instanceCreateSuccessButInviteFailed = "創建房間成功，但邀請失敗"
     override val instanceCreateFailed = "創建房間失敗"
+    override val worldPublishAction = "發布到社群實驗室"
+    override val worldUnpublishAction = "取消發布世界"
+    override val worldPublishConfirmationTitle = "發布世界？"
+    override val worldUnpublishConfirmationTitle = "取消發布世界？"
+    override val worldPublishConfirmationMessage =
+        "將「%s」發布到社群實驗室嗎？每週最多只能發布一個世界。"
+    override val worldUnpublishConfirmationMessage = "取消發布「%s」並將其設為私人嗎？"
+    override val worldPublishSuccess = "世界已發布"
+    override val worldUnpublishSuccess = "世界已取消發布"
+    override val worldPublishFailed = "發布世界失敗"
+    override val worldUnpublishFailed = "取消發布世界失敗"
+    override val worldPublishUnavailable = "目前暫時無法發布世界"
+    override val worldPublishAvailabilityCheckFailed = "無法檢查發布資格，請重新整理後再試。"
+    override val worldPublicationRefreshRequired = "請求已完成，但無法確認目前狀態。再次操作前請先重新整理。"
 
     // World Search
     override val worldSearchAdvancedOptions = "高級搜索選項"

--- a/composeApp/src/commonTest/kotlin/network/api/worlds/WorldsApiTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/api/worlds/WorldsApiTest.kt
@@ -1,0 +1,60 @@
+package io.github.vrcmteam.vrcm.network.api.worlds
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class WorldsApiTest {
+    @Test
+    fun publicationEndpointsUseThePublishResourceAndExpectedMethods() = runBlocking {
+        val requests = mutableListOf<Pair<HttpMethod, String>>()
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    requests += request.method to request.url.encodedPath
+                    respond(
+                        content = if (request.method == HttpMethod.Get) {
+                            """{"canPublish":true}"""
+                        } else {
+                            ""
+                        },
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+            }
+            defaultRequest { url("https://api.vrchat.cloud/api/1/") }
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+        val api = WorldsApi(client)
+
+        val status = api.getWorldPublishStatus("wrld_owned")
+        api.publishWorld("wrld_owned")
+        api.unpublishWorld("wrld_owned")
+
+        assertTrue(status.canPublish)
+        assertEquals(
+            listOf(
+                HttpMethod.Get to "/api/1/worlds/wrld_owned/publish",
+                HttpMethod.Put to "/api/1/worlds/wrld_owned/publish",
+                HttpMethod.Delete to "/api/1/worlds/wrld_owned/publish",
+            ),
+            requests,
+        )
+        client.close()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldPublicationStateModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldPublicationStateModelTest.kt
@@ -38,7 +38,7 @@ class WorldPublicationStateModelTest {
     }
 
     @Test
-    fun weeklyLimitKeepsTheVerifiedPublishActionVisibleButDisabled() = runTest {
+    fun unavailablePublishingKeepsTheVerifiedPublishActionVisibleButDisabled() = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
         val token = AccountSessionToken("usr_author", 1)
         val session = MutableStateFlow(authenticated(token))
@@ -54,7 +54,7 @@ class WorldPublicationStateModelTest {
 
         assertEquals(WorldPublicationAction.Publish, model.state.value.action)
         assertFalse(model.state.value.canExecute)
-        assertEquals(WorldPublicationBlockReason.WeeklyLimit, model.state.value.blockReason)
+        assertEquals(WorldPublicationBlockReason.Unavailable, model.state.value.blockReason)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldPublicationStateModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldPublicationStateModelTest.kt
@@ -75,7 +75,10 @@ class WorldPublicationStateModelTest {
             scope = backgroundScope,
             requestDispatcher = dispatcher,
             sessionFlow = session,
-            onWorldRefreshed = refreshedWorlds::add,
+            onWorldRefreshed = { world ->
+                refreshedWorlds += world
+                Result.success(Unit)
+            },
         )
         val notices = mutableListOf<WorldPublicationNotice>()
         val noticeJob = launch(start = CoroutineStart.UNDISPATCHED) {
@@ -159,6 +162,43 @@ class WorldPublicationStateModelTest {
     }
 
     @Test
+    fun cacheSyncFailureBlocksSuccessUntilTheWorldCanBeRefreshed() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val token = AccountSessionToken("usr_author", 1)
+        val session = MutableStateFlow(authenticated(token))
+        val source = FakeWorldPublicationSource(
+            worlds = mutableMapOf("wrld_owned" to world(releaseStatus = "private")),
+        )
+        val model = WorldPublicationStateModel(
+            source = source,
+            scope = backgroundScope,
+            requestDispatcher = dispatcher,
+            sessionFlow = session,
+            onWorldRefreshed = {
+                Result.failure(IllegalStateException("cache unavailable"))
+            },
+        )
+        val notices = mutableListOf<WorldPublicationNotice>()
+        val noticeJob = launch(start = CoroutineStart.UNDISPATCHED) {
+            model.notices.collect(notices::add)
+        }
+
+        model.setTarget("wrld_owned", "usr_author")
+        model.acceptVerifiedWorld(source.worlds.getValue("wrld_owned"), token)
+        runCurrent()
+        model.changePublication(WorldPublicationAction.Publish)
+        runCurrent()
+
+        assertEquals(WorldPublicationBlockReason.RefreshRequired, model.state.value.blockReason)
+        assertFalse(model.state.value.canExecute)
+        assertEquals(
+            listOf<WorldPublicationNotice>(WorldPublicationNotice.CacheSyncFailed("cache unavailable")),
+            notices,
+        )
+        noticeJob.cancel()
+    }
+
+    @Test
     fun accountSwitchRejectsACompletedMutationFromThePreviousSession() = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
         val tokenA = AccountSessionToken("usr_author", 1)
@@ -175,7 +215,10 @@ class WorldPublicationStateModelTest {
             scope = backgroundScope,
             requestDispatcher = dispatcher,
             sessionFlow = session,
-            onWorldRefreshed = refreshedWorlds::add,
+            onWorldRefreshed = { world ->
+                refreshedWorlds += world
+                Result.success(Unit)
+            },
         )
 
         model.setTarget("wrld_owned", "usr_author")
@@ -213,7 +256,10 @@ class WorldPublicationStateModelTest {
             scope = backgroundScope,
             requestDispatcher = dispatcher,
             sessionFlow = session,
-            onWorldRefreshed = refreshedWorlds::add,
+            onWorldRefreshed = { world ->
+                refreshedWorlds += world
+                Result.success(Unit)
+            },
         )
 
         model.setTarget("wrld_old", "usr_author")

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldPublicationStateModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldPublicationStateModelTest.kt
@@ -8,9 +8,11 @@ import io.github.vrcmteam.vrcm.service.data.AccountDto
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -278,6 +280,50 @@ class WorldPublicationStateModelTest {
 
         model.acceptVerifiedWorld(source.worlds.getValue("wrld_new"), token)
         assertEquals(WorldPublicationAction.Unpublish, model.state.value.action)
+    }
+
+    @Test
+    fun accountSwitchDuringCacheSyncDoesNotPublishStaleNotice() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val tokenA = AccountSessionToken("usr_author", 1)
+        val tokenB = AccountSessionToken("usr_other", 2)
+        val session = MutableStateFlow(authenticated(tokenA))
+        val cacheStarted = CompletableDeferred<Unit>()
+        val releaseCache = CompletableDeferred<Unit>()
+        val source = FakeWorldPublicationSource(
+            worlds = mutableMapOf("wrld_owned" to world(releaseStatus = "private")),
+        )
+        val model = WorldPublicationStateModel(
+            source = source,
+            scope = backgroundScope,
+            requestDispatcher = dispatcher,
+            sessionFlow = session,
+            onWorldRefreshed = {
+                cacheStarted.complete(Unit)
+                withContext(NonCancellable) { releaseCache.await() }
+                Result.success(Unit)
+            },
+        )
+        val notices = mutableListOf<WorldPublicationNotice>()
+        val noticeJob = launch(start = CoroutineStart.UNDISPATCHED) {
+            model.notices.collect(notices::add)
+        }
+
+        model.setTarget("wrld_owned", "usr_author")
+        model.acceptVerifiedWorld(source.worlds.getValue("wrld_owned"), tokenA)
+        runCurrent()
+        model.changePublication(WorldPublicationAction.Publish)
+        runCurrent()
+        cacheStarted.await()
+
+        session.value = authenticated(tokenB)
+        runCurrent()
+        releaseCache.complete(Unit)
+        runCurrent()
+
+        assertTrue(notices.isEmpty())
+        assertNull(model.state.value.action)
+        noticeJob.cancel()
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldPublicationStateModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldPublicationStateModelTest.kt
@@ -1,0 +1,326 @@
+package io.github.vrcmteam.vrcm.presentation.screens.world
+
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+import io.github.vrcmteam.vrcm.core.shared.AuthenticatedAccount
+import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
+import io.github.vrcmteam.vrcm.service.SessionBoundResponse
+import io.github.vrcmteam.vrcm.service.data.AccountDto
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WorldPublicationStateModelTest {
+    @Test
+    fun actionsRequireTheCurrentOwnerAndSupportedReleaseStatus() {
+        assertNull(worldPublicationAction("usr_author", "public", "usr_other"))
+        assertNull(worldPublicationAction("usr_author", "hidden", "usr_author"))
+        assertNull(worldPublicationAction("usr_author", "all", "usr_author"))
+        assertEquals(
+            WorldPublicationAction.Publish,
+            worldPublicationAction("usr_author", "private", "usr_author"),
+        )
+        assertEquals(
+            WorldPublicationAction.Unpublish,
+            worldPublicationAction("usr_author", "public", "usr_author"),
+        )
+    }
+
+    @Test
+    fun weeklyLimitKeepsTheVerifiedPublishActionVisibleButDisabled() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val token = AccountSessionToken("usr_author", 1)
+        val session = MutableStateFlow(authenticated(token))
+        val source = FakeWorldPublicationSource(
+            worlds = mutableMapOf("wrld_owned" to world(releaseStatus = "private")),
+            canPublish = false,
+        )
+        val model = WorldPublicationStateModel(source, backgroundScope, dispatcher, session)
+
+        model.setTarget("wrld_owned", "usr_author")
+        model.acceptVerifiedWorld(source.worlds.getValue("wrld_owned"), token)
+        runCurrent()
+
+        assertEquals(WorldPublicationAction.Publish, model.state.value.action)
+        assertFalse(model.state.value.canExecute)
+        assertEquals(WorldPublicationBlockReason.WeeklyLimit, model.state.value.blockReason)
+    }
+
+    @Test
+    fun failedPublishRestoresTheActionAndRetryUsesTheRefreshedStatus() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val token = AccountSessionToken("usr_author", 1)
+        val session = MutableStateFlow(authenticated(token))
+        val source = FakeWorldPublicationSource(
+            worlds = mutableMapOf("wrld_owned" to world(releaseStatus = "private")),
+            publicationResults = mutableListOf(
+                Result.failure(IllegalStateException("offline")),
+                Result.success(Unit),
+            ),
+        )
+        val refreshedWorlds = mutableListOf<WorldData>()
+        val model = WorldPublicationStateModel(
+            source = source,
+            scope = backgroundScope,
+            requestDispatcher = dispatcher,
+            sessionFlow = session,
+            onWorldRefreshed = refreshedWorlds::add,
+        )
+        val notices = mutableListOf<WorldPublicationNotice>()
+        val noticeJob = launch(start = CoroutineStart.UNDISPATCHED) {
+            model.notices.collect(notices::add)
+        }
+
+        model.setTarget("wrld_owned", "usr_author")
+        model.acceptVerifiedWorld(source.worlds.getValue("wrld_owned"), token)
+        runCurrent()
+        assertTrue(model.state.value.canExecute)
+
+        model.changePublication(WorldPublicationAction.Publish)
+        model.changePublication(WorldPublicationAction.Publish)
+        runCurrent()
+
+        assertEquals(1, source.publicationCalls.size)
+        assertEquals(WorldPublicationAction.Publish, model.state.value.action)
+        assertTrue(model.state.value.canExecute)
+        assertEquals(
+            listOf<WorldPublicationNotice>(
+                WorldPublicationNotice.ChangeFailed(
+                    action = WorldPublicationAction.Publish,
+                    message = "offline",
+                )
+            ),
+            notices,
+        )
+
+        model.changePublication(WorldPublicationAction.Publish)
+        runCurrent()
+
+        assertEquals(2, source.publicationCalls.size)
+        assertEquals("public", refreshedWorlds.single().releaseStatus)
+        assertEquals(WorldPublicationAction.Unpublish, model.state.value.action)
+        assertTrue(model.state.value.canExecute)
+        assertEquals(
+            WorldPublicationNotice.Changed(WorldPublicationAction.Publish),
+            notices.last(),
+        )
+        noticeJob.cancel()
+    }
+
+    @Test
+    fun completedMutationWithUnconfirmedStatusRequiresARefreshBeforeRetry() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val token = AccountSessionToken("usr_author", 1)
+        val session = MutableStateFlow(authenticated(token))
+        val source = FakeWorldPublicationSource(
+            worlds = mutableMapOf("wrld_owned" to world(releaseStatus = "private")),
+            applyPublicationChange = false,
+        )
+        val model = WorldPublicationStateModel(source, backgroundScope, dispatcher, session)
+        val notices = mutableListOf<WorldPublicationNotice>()
+        val noticeJob = launch(start = CoroutineStart.UNDISPATCHED) {
+            model.notices.collect(notices::add)
+        }
+
+        model.setTarget("wrld_owned", "usr_author")
+        model.acceptVerifiedWorld(source.worlds.getValue("wrld_owned"), token)
+        runCurrent()
+        model.changePublication(WorldPublicationAction.Publish)
+        runCurrent()
+
+        assertEquals(WorldPublicationAction.Publish, model.state.value.action)
+        assertFalse(model.state.value.canExecute)
+        assertEquals(
+            WorldPublicationBlockReason.RefreshRequired,
+            model.state.value.blockReason,
+        )
+        assertEquals(
+            listOf<WorldPublicationNotice>(WorldPublicationNotice.RefreshFailed(null)),
+            notices,
+        )
+
+        model.acceptVerifiedWorld(source.worlds.getValue("wrld_owned"), token)
+        runCurrent()
+
+        assertTrue(model.state.value.canExecute)
+        assertNull(model.state.value.blockReason)
+        noticeJob.cancel()
+    }
+
+    @Test
+    fun accountSwitchRejectsACompletedMutationFromThePreviousSession() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val tokenA = AccountSessionToken("usr_author", 1)
+        val tokenB = AccountSessionToken("usr_other", 2)
+        val session = MutableStateFlow(authenticated(tokenA))
+        val pendingMutation = CompletableDeferred<Result<Unit>>()
+        val source = FakeWorldPublicationSource(
+            worlds = mutableMapOf("wrld_owned" to world(releaseStatus = "private")),
+            pendingPublication = pendingMutation,
+        )
+        val refreshedWorlds = mutableListOf<WorldData>()
+        val model = WorldPublicationStateModel(
+            source = source,
+            scope = backgroundScope,
+            requestDispatcher = dispatcher,
+            sessionFlow = session,
+            onWorldRefreshed = refreshedWorlds::add,
+        )
+
+        model.setTarget("wrld_owned", "usr_author")
+        model.acceptVerifiedWorld(source.worlds.getValue("wrld_owned"), tokenA)
+        runCurrent()
+        model.changePublication(WorldPublicationAction.Publish)
+        runCurrent()
+        assertTrue(model.state.value.isChanging)
+
+        session.value = authenticated(tokenB)
+        runCurrent()
+        pendingMutation.complete(Result.success(Unit))
+        runCurrent()
+
+        assertNull(model.state.value.action)
+        assertTrue(refreshedWorlds.isEmpty())
+    }
+
+    @Test
+    fun targetSwitchRejectsACompletedMutationForThePreviousWorld() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val token = AccountSessionToken("usr_author", 1)
+        val session = MutableStateFlow(authenticated(token))
+        val pendingMutation = CompletableDeferred<Result<Unit>>()
+        val source = FakeWorldPublicationSource(
+            worlds = mutableMapOf(
+                "wrld_old" to world(id = "wrld_old", releaseStatus = "private"),
+                "wrld_new" to world(id = "wrld_new", releaseStatus = "public"),
+            ),
+            pendingPublication = pendingMutation,
+        )
+        val refreshedWorlds = mutableListOf<WorldData>()
+        val model = WorldPublicationStateModel(
+            source = source,
+            scope = backgroundScope,
+            requestDispatcher = dispatcher,
+            sessionFlow = session,
+            onWorldRefreshed = refreshedWorlds::add,
+        )
+
+        model.setTarget("wrld_old", "usr_author")
+        model.acceptVerifiedWorld(source.worlds.getValue("wrld_old"), token)
+        runCurrent()
+        model.changePublication(WorldPublicationAction.Publish)
+        runCurrent()
+        assertTrue(model.state.value.isChanging)
+
+        model.setTarget("wrld_new", "usr_author")
+        pendingMutation.complete(Result.success(Unit))
+        runCurrent()
+
+        assertNull(model.state.value.action)
+        assertTrue(refreshedWorlds.isEmpty())
+
+        model.acceptVerifiedWorld(source.worlds.getValue("wrld_new"), token)
+        assertEquals(WorldPublicationAction.Unpublish, model.state.value.action)
+    }
+}
+
+private class FakeWorldPublicationSource(
+    val worlds: MutableMap<String, WorldData>,
+    private val canPublish: Boolean = true,
+    private val publicationResults: MutableList<Result<Unit>> = mutableListOf(),
+    private val pendingPublication: CompletableDeferred<Result<Unit>>? = null,
+    private val applyPublicationChange: Boolean = true,
+) : WorldPublicationSource {
+    val publicationCalls = mutableListOf<Pair<String, WorldPublicationAction>>()
+
+    override suspend fun loadWorld(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+    ): SessionBoundResponse<WorldData> {
+        val world = worlds[worldId]
+        return SessionBoundResponse(
+            result = if (world == null) {
+                Result.failure(IllegalStateException("missing world"))
+            } else {
+                Result.success(world)
+            },
+            sessionToken = sessionToken,
+        )
+    }
+
+    override suspend fun canPublish(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+    ): SessionBoundResponse<Boolean> = SessionBoundResponse(
+        result = Result.success(canPublish),
+        sessionToken = sessionToken,
+    )
+
+    override suspend fun changePublication(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+        action: WorldPublicationAction,
+    ): SessionBoundResponse<Unit> {
+        publicationCalls += worldId to action
+        val result = pendingPublication?.await()
+            ?: publicationResults.removeFirstOrNull()
+            ?: Result.success(Unit)
+        if (result.isSuccess && applyPublicationChange) {
+            worlds[worldId] = worlds.getValue(worldId).copy(
+                releaseStatus = when (action) {
+                    WorldPublicationAction.Publish -> "public"
+                    WorldPublicationAction.Unpublish -> "private"
+                }
+            )
+        }
+        return SessionBoundResponse(result, sessionToken)
+    }
+}
+
+private fun authenticated(token: AccountSessionToken) = AuthenticatedAccount(
+    account = AccountDto(userId = token.userId),
+    token = token,
+)
+
+private fun world(
+    id: String = "wrld_owned",
+    authorId: String = "usr_author",
+    releaseStatus: String,
+) = WorldData(
+    authorId = authorId,
+    authorName = "Author",
+    capacity = 16,
+    createdAt = "2026-01-01T00:00:00Z",
+    description = "Description",
+    favorites = 0,
+    featured = false,
+    heat = 0,
+    id = id,
+    imageUrl = "https://example.test/world.png",
+    labsPublicationDate = "none",
+    name = "World",
+    namespace = null,
+    organization = "vrchat",
+    popularity = 0,
+    publicationDate = "none",
+    recommendedCapacity = 8,
+    releaseStatus = releaseStatus,
+    tags = emptyList(),
+    thumbnailImageUrl = "https://example.test/world-thumbnail.png",
+    udonProducts = emptyList(),
+    unityPackages = emptyList(),
+    updatedAt = "2026-01-01T00:00:00Z",
+    version = 1,
+    visits = 0,
+)


### PR DESCRIPTION
## 改动说明

- 在世界详情页为当前登录用户本人拥有的世界提供发布与取消发布动作。
- 私有世界先检查发布资格；达到每周限制或资格检查失败时保留禁用动作并给出说明。
- 公开世界允许取消发布；其他发布状态和非本人世界不显示动作。
- 变更前显示确认弹窗，执行期间阻止重复点击；成功后重新拉取权威世界数据并同步页面与缓存。
- 账户切换、目标切换和权威状态无法确认时拒绝旧结果并禁用后续动作。
- 同步英语、日语、简体中文和繁体中文文案，并补充端点与状态转换测试。

## 实现假设清单

- 只有权威世界数据的 `authorId` 与当前会话用户 ID 一致时，用户才有权执行发布状态变更。
- `releaseStatus=private` 对应发布动作，`releaseStatus=public` 对应取消发布动作；其他值不提供动作。
- `GET /worlds/{worldId}/publish` 返回的 `canPublish` 是发布资格的权威结果，并包含每周发布限制的判定。
- 发布使用 `PUT /worlds/{worldId}/publish`，取消发布使用 `DELETE /worlds/{worldId}/publish`。
- 变更接口成功只代表请求已完成；页面以随后重新获取的世界详情作为最终状态来源。
- 若重新获取失败或状态未达到预期，必须先由用户手动刷新确认权威状态，不能直接重复提交。

## 代码逻辑图

```mermaid
flowchart TD
    A[打开世界详情] --> B[按当前会话拉取权威世界数据]
    B --> C{authorId 等于当前用户 ID}
    C -- 否 --> D[隐藏发布动作]
    C -- 是 --> E{releaseStatus}
    E -- private --> F[GET 发布资格]
    F --> G{canPublish}
    G -- 否 --> H[显示禁用的发布动作与资格说明]
    G -- 是 --> I[显示可用的发布动作]
    E -- public --> J[显示可用的取消发布动作]
    E -- 其他 --> D
    I --> K[确认弹窗]
    J --> K
    K --> L{选择的动作}
    L -- 发布 --> M[PUT 发布资源]
    L -- 取消发布 --> N[DELETE 发布资源]
    M --> O{变更请求成功}
    N --> O
    O -- 否 --> P[恢复动作并提示失败]
    O -- 是 --> Q[重新 GET 世界详情]
    Q --> R{权威状态符合预期}
    R -- 否或刷新失败 --> T[更新可确认数据并禁用动作]
    R -- 是 --> U[WorldPublicationStateModel 调用 WorldProfileScreenModel.applyPublicationWorld]
    U --> V{WorldProfileCacheStore.save}
    V --> C1{世界、会话和请求代次仍有效?}
    C1 -- 否 --> X[丢弃旧结果]
    C1 -- 是且保存成功 --> S[更新页面与缓存并提示成功]
    C1 -- 是但保存失败 --> W[阻止成功状态、禁用动作并提示缓存同步失败]
    T --> X2[等待用户手动刷新]
    W --> X2
```

## 本轮实现说明

- `WorldProfileScreenModel.applyPublicationWorld` 改为挂起结果回调，页面状态更新与 `WorldProfileCacheStore.save` 按顺序完成；取消异常继续传播，其他持久化异常转换为缓存同步失败通知，并要求刷新后再操作。
- 顶部标题按返回按钮和右侧动作的实际槽位布局，在窄窗口仍保留可用标题空间，不再固定预留过大的宽度。
- `canPublish=false` 仅表示当前不符合发布资格，提示明确说明每周最多发布一个世界，但不臆造接口未提供的具体原因或重置时间。
- 缓存同步返回后再次校验同一世界、会话令牌和请求代次；如果保存期间发生账户或目标切换，状态提交和通知都会被丢弃。

## 验证

- `./gradlew :composeApp:compileKotlinDesktop`：通过。
- 发布状态机、世界端点和语言结构定向测试：9 项全部通过。
- `./gradlew :composeApp:desktopTest --rerun-tasks`：809 项中 808 项通过；唯一失败来自既有测试间后台协程残留。失败测试单独运行及与相邻测试组合运行均通过，本次新增测试全部通过。
- `git diff --check`：通过。
- 上一轮评审修复：`~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests 'io.github.vrcmteam.vrcm.presentation.screens.world.WorldPublicationStateModelTest'`：通过（含缓存同步失败回归测试）。
- 本轮评审修复：`~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests 'io.github.vrcmteam.vrcm.presentation.screens.world.WorldPublicationStateModelTest'`：通过（含缓存同步期间切号回归测试）。
