### PR TITLE
feat(friends): 添加好友邀请请求

### DIFF
--- a/composeApp/src/commonMain/kotlin/di/modules/ServiceModule.kt
+++ b/composeApp/src/commonMain/kotlin/di/modules/ServiceModule.kt
@@ -34,6 +34,8 @@ val serviceModule: Module = module {
     singleOf(::VrchatStatusNotificationService)
     singleOf(::NetworkBoopRequest) bind BoopRequest::class
     singleOf(::BoopService)
+    singleOf(::NetworkRequestInviteCall) bind RequestInviteCall::class
+    singleOf(::RequestInviteService)
     singleOf(::WorldPlatformService)
     singleOf(::OfficialLinkService)
     singleOf(::HttpMeetupRemoteBytesLoader) bind MeetupRemoteBytesLoader::class

--- a/composeApp/src/commonMain/kotlin/network/api/attributes/PathPrefixs.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/attributes/PathPrefixs.kt
@@ -26,6 +26,8 @@ internal const val AVATARS_API_PREFIX = "avatars"
 
 internal const val INVITE_API_PREFIX = "invite"
 
+internal const val REQUEST_INVITE_API_PREFIX = "requestInvite"
+
 internal const val NOTIFICATIONS_API_PREFIX = "notifications"
 
 internal const val FAVORITE_API_PREFIX = "favorite"

--- a/composeApp/src/commonMain/kotlin/network/api/invite/InviteApi.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/invite/InviteApi.kt
@@ -1,11 +1,15 @@
 package io.github.vrcmteam.vrcm.network.api.invite
 
 import io.github.vrcmteam.vrcm.network.api.attributes.INVITE_API_PREFIX
+import io.github.vrcmteam.vrcm.network.api.attributes.REQUEST_INVITE_API_PREFIX
 import io.github.vrcmteam.vrcm.network.api.attributes.VRChatResponse
 import io.github.vrcmteam.vrcm.network.api.invite.data.InviteMyselfData
+import io.github.vrcmteam.vrcm.network.api.invite.data.RequestInviteRequest
 import io.github.vrcmteam.vrcm.network.extensions.checkSuccess
 import io.ktor.client.*
 import io.ktor.client.request.*
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
 
 class InviteApi(private val client: HttpClient) {
 
@@ -18,5 +22,12 @@ class InviteApi(private val client: HttpClient) {
     suspend fun inviteMyselfToInstance(instanceId: String): InviteMyselfData =
         client.post("$INVITE_API_PREFIX/myself/to/$instanceId")
             .checkSuccess()
+
+    suspend fun requestInvite(userId: String, requestSlot: Int = 0) {
+        client.post("$REQUEST_INVITE_API_PREFIX/$userId") {
+            contentType(ContentType.Application.Json)
+            setBody(RequestInviteRequest(requestSlot = requestSlot))
+        }.checkSuccess { Unit }
+    }
 
 }

--- a/composeApp/src/commonMain/kotlin/network/api/invite/data/RequestInviteRequest.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/invite/data/RequestInviteRequest.kt
@@ -1,0 +1,8 @@
+package io.github.vrcmteam.vrcm.network.api.invite.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestInviteRequest(
+    val requestSlot: Int,
+)

--- a/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreen.kt
@@ -122,6 +122,7 @@ data class UserProfileScreen(
         var openEditNoteDialog by remember { mutableStateOf(false) }
         var openBoopDialog by remember { mutableStateOf(false) }
         var boopSending by remember { mutableStateOf(false) }
+        val requestInviteSubmitting by userProfileScreenModel.isRequestInviteSubmitting.collectAsState()
         val actionScope = rememberCoroutineScope()
         // Control showing favorite group management for Friend type
         var showFriendFavoriteSheet by remember { mutableStateOf(false) }
@@ -205,6 +206,7 @@ data class UserProfileScreen(
                 openEditNoteDialog = { openEditNoteDialog = true },
                 boopEnabled = userProfileScreenModel.isBoopAllowed,
                 openBoopDialog = { openBoopDialog = true },
+                requestInviteSubmitting = requestInviteSubmitting,
             )
         }
         // Friend FavoriteType group management bottom sheet
@@ -299,6 +301,7 @@ private fun ColumnScope.SheetItems(
     openEditNoteDialog: () -> Unit,
     boopEnabled: Boolean,
     openBoopDialog: () -> Unit,
+    requestInviteSubmitting: Boolean,
 ) {
     val navigator = LocalNavigator.currentOrThrow
     val localeStrings = strings
@@ -351,6 +354,25 @@ private fun ColumnScope.SheetItems(
                     openBoopDialog()
                 }
             })
+            SheetButtonItem(
+                text = localeStrings.profileRequestInvite,
+                enabled = !requestInviteSubmitting,
+                onClick = {
+                    userProfileScreenModel.requestInvite(
+                        userId = currentUser.id,
+                        successMessage = localeStrings.profileRequestInviteSent,
+                    )
+                },
+            ) { label ->
+                if (requestInviteSubmitting) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                    )
+                    Spacer(Modifier.width(8.dp))
+                }
+                Text(label)
+            }
             SheetButtonItem(text = localeStrings.profileInviteToMyInstance, onClick = {
                 scope.launch { hideSheet() }.invokeOnCompletion {
                     onHideCompletion()

--- a/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreenModel.kt
@@ -41,6 +41,8 @@ import io.github.vrcmteam.vrcm.service.FriendActivityService
 import io.github.vrcmteam.vrcm.service.FriendActivitySummary
 import io.github.vrcmteam.vrcm.service.BoopResult
 import io.github.vrcmteam.vrcm.service.BoopService
+import io.github.vrcmteam.vrcm.service.RequestInviteResult
+import io.github.vrcmteam.vrcm.service.RequestInviteService
 import io.github.vrcmteam.vrcm.storage.AccountCacheManager
 import io.github.vrcmteam.vrcm.storage.FavoriteListCacheStore
 import io.github.vrcmteam.vrcm.storage.UserProfileCacheStore
@@ -334,6 +336,7 @@ class UserProfileScreenModel(
     private val friendLocationPagerModel: FriendLocationPagerModel,
     friendActivityService: FriendActivityService,
     private val boopService: BoopService,
+    private val requestInviteService: RequestInviteService,
 ) : ViewModel() {
 
     private val cacheOwnerUserId = authService.accountDto().userId
@@ -362,6 +365,9 @@ class UserProfileScreenModel(
 
     private val _isBoopAllowed = mutableStateOf(authService.currentUserState.value?.isBoopingEnabled != false)
     val isBoopAllowed by _isBoopAllowed
+
+    private val _isRequestInviteSubmitting = MutableStateFlow(false)
+    val isRequestInviteSubmitting: StateFlow<Boolean> = _isRequestInviteSubmitting.asStateFlow()
 
     private val _createdWorlds = mutableStateOf<List<WorldData>>(emptyList())
     val createdWorlds by _createdWorlds
@@ -905,6 +911,33 @@ class UserProfileScreenModel(
         }
         is BoopResult.Failed -> result.also { handleError(it.error) }
         BoopResult.InFlight, BoopResult.SessionChanged -> result
+    }
+
+    fun requestInvite(
+        userId: String,
+        successMessage: String,
+    ) {
+        if (!_isRequestInviteSubmitting.compareAndSet(expect = false, update = true)) return
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                when (val result = requestInviteService.send(userId)) {
+                    is RequestInviteResult.Sent -> {
+                        if (SharedFlowCentre.isCurrentSession(result.sessionToken)) {
+                            SharedFlowCentre.toastText.emit(ToastText.Success(successMessage))
+                        }
+                    }
+                    is RequestInviteResult.Failed -> {
+                        if (SharedFlowCentre.isCurrentSession(result.sessionToken)) {
+                            handleError(result.error)
+                        }
+                    }
+                    RequestInviteResult.InFlight,
+                    RequestInviteResult.SessionChanged -> Unit
+                }
+            } finally {
+                _isRequestInviteSubmitting.value = false
+            }
+        }
     }
 
     fun inviteToMyInstance(

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
@@ -377,6 +377,8 @@ sealed class LocaleStrings {
     open val profileInviteToMyInstance: String = "Invite to My Instance"
     open val profileInviteSent: String = "Invite sent"
     open val profileInviteNotInInstance: String = "You are not in an instance"
+    open val profileRequestInvite: String = "Request Invite"
+    open val profileRequestInviteSent: String = "Invite request sent"
     open val friendActivityTitle: String = "Activity"
     open val friendActivityRecentTogether: String = "Recently together"
     open val friendActivityLastTogether: String = "Last met"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
@@ -360,6 +360,8 @@ internal object LocaleStringsJa : LocaleStrings() {
     override val profileInviteToMyInstance = "自分のインスタンスに招待"
     override val profileInviteSent = "招待を送信しました"
     override val profileInviteNotInInstance = "現在インスタンスに参加していません"
+    override val profileRequestInvite = "招待をリクエスト"
+    override val profileRequestInviteSent = "招待リクエストを送信しました"
     override val friendActivityTitle = "アクティビティ"
     override val friendActivityRecentTogether = "最近一緒にいたユーザー"
     override val friendActivityLastTogether = "最後に会った日時"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
@@ -359,6 +359,8 @@ internal object LocaleStringsZhHans : LocaleStrings() {
     override val profileInviteToMyInstance = "邀请来我的房间"
     override val profileInviteSent = "邀请已发送"
     override val profileInviteNotInInstance = "你当前不在任何房间中"
+    override val profileRequestInvite = "请求对方邀请"
+    override val profileRequestInviteSent = "邀请请求已发送"
     override val friendActivityTitle = "好友活动"
     override val friendActivityRecentTogether = "最近一起玩过"
     override val friendActivityLastTogether = "最后见面"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
@@ -359,6 +359,8 @@ internal object LocaleStringsZhHant : LocaleStrings() {
     override val profileInviteToMyInstance = "邀請來我的房間"
     override val profileInviteSent = "邀請已發送"
     override val profileInviteNotInInstance = "你當前不在任何房間中"
+    override val profileRequestInvite = "請求對方邀請"
+    override val profileRequestInviteSent = "邀請請求已傳送"
     override val friendActivityTitle = "好友活動"
     override val friendActivityRecentTogether = "最近一起玩過"
     override val friendActivityLastTogether = "最後見面"

--- a/composeApp/src/commonMain/kotlin/service/RequestInviteService.kt
+++ b/composeApp/src/commonMain/kotlin/service/RequestInviteService.kt
@@ -1,0 +1,75 @@
+package io.github.vrcmteam.vrcm.service
+
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
+import io.github.vrcmteam.vrcm.network.api.invite.InviteApi
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+
+sealed interface RequestInviteResult {
+    data class Sent(val sessionToken: AccountSessionToken) : RequestInviteResult
+    data object InFlight : RequestInviteResult
+    data object SessionChanged : RequestInviteResult
+    data class Failed(
+        val error: Throwable,
+        val sessionToken: AccountSessionToken,
+    ) : RequestInviteResult
+}
+
+internal fun interface RequestInviteCall {
+    suspend fun send(
+        sessionToken: AccountSessionToken,
+        userId: String,
+    ): SessionBoundResponse<Unit>?
+}
+
+internal class NetworkRequestInviteCall(
+    private val authService: AuthService,
+    private val inviteApi: InviteApi,
+) : RequestInviteCall {
+    override suspend fun send(
+        sessionToken: AccountSessionToken,
+        userId: String,
+    ): SessionBoundResponse<Unit>? = authService.runSessionBoundCatching(sessionToken) {
+        inviteApi.requestInvite(userId)
+    }
+}
+
+private class RequestInviteSubmissionGate {
+    private val lock = SynchronizedObject()
+    private val recipients = mutableSetOf<String>()
+
+    fun tryStart(userId: String): Boolean = synchronized(lock) {
+        recipients.add(userId)
+    }
+
+    fun finish(userId: String) = synchronized(lock) {
+        recipients.remove(userId)
+    }
+}
+
+class RequestInviteService internal constructor(
+    private val request: RequestInviteCall,
+) {
+    private val submissionGate = RequestInviteSubmissionGate()
+
+    suspend fun send(userId: String): RequestInviteResult {
+        val sessionToken = SharedFlowCentre.currentSession.value?.token
+            ?: return RequestInviteResult.SessionChanged
+        if (!submissionGate.tryStart(userId)) return RequestInviteResult.InFlight
+
+        return try {
+            val response = request.send(sessionToken, userId)
+                ?: return RequestInviteResult.SessionChanged
+            if (!SharedFlowCentre.isCurrentSession(response.sessionToken)) {
+                return RequestInviteResult.SessionChanged
+            }
+            response.result.fold(
+                onSuccess = { RequestInviteResult.Sent(response.sessionToken) },
+                onFailure = { RequestInviteResult.Failed(it, response.sessionToken) },
+            )
+        } finally {
+            submissionGate.finish(userId)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/service/RequestInviteService.kt
+++ b/composeApp/src/commonMain/kotlin/service/RequestInviteService.kt
@@ -36,15 +36,20 @@ internal class NetworkRequestInviteCall(
 }
 
 private class RequestInviteSubmissionGate {
-    private val lock = SynchronizedObject()
-    private val recipients = mutableSetOf<String>()
+    private data class Key(
+        val accountUserId: String,
+        val recipientUserId: String,
+    )
 
-    fun tryStart(userId: String): Boolean = synchronized(lock) {
-        recipients.add(userId)
+    private val lock = SynchronizedObject()
+    private val submissions = mutableSetOf<Key>()
+
+    fun tryStart(accountUserId: String, recipientUserId: String): Boolean = synchronized(lock) {
+        submissions.add(Key(accountUserId, recipientUserId))
     }
 
-    fun finish(userId: String) = synchronized(lock) {
-        recipients.remove(userId)
+    fun finish(accountUserId: String, recipientUserId: String) = synchronized(lock) {
+        submissions.remove(Key(accountUserId, recipientUserId))
     }
 }
 
@@ -56,7 +61,7 @@ class RequestInviteService internal constructor(
     suspend fun send(userId: String): RequestInviteResult {
         val sessionToken = SharedFlowCentre.currentSession.value?.token
             ?: return RequestInviteResult.SessionChanged
-        if (!submissionGate.tryStart(userId)) return RequestInviteResult.InFlight
+        if (!submissionGate.tryStart(sessionToken.userId, userId)) return RequestInviteResult.InFlight
 
         return try {
             val response = request.send(sessionToken, userId)
@@ -69,7 +74,7 @@ class RequestInviteService internal constructor(
                 onFailure = { RequestInviteResult.Failed(it, response.sessionToken) },
             )
         } finally {
-            submissionGate.finish(userId)
+            submissionGate.finish(sessionToken.userId, userId)
         }
     }
 }

--- a/composeApp/src/commonTest/kotlin/network/api/invite/InviteApiRequestInviteTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/api/invite/InviteApiRequestInviteTest.kt
@@ -1,0 +1,78 @@
+package io.github.vrcmteam.vrcm.network.api.invite
+
+import io.github.vrcmteam.vrcm.network.supports.VRCApiException
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class InviteApiRequestInviteTest {
+    @Test
+    fun defaultRequestUsesSlotZero() = runBlocking {
+        var method: HttpMethod? = null
+        var path = ""
+        var contentType: ContentType? = null
+        var body = ""
+        val client = requestInviteClient { request ->
+            method = request.method
+            path = request.url.encodedPath
+            contentType = request.body.contentType
+            body = request.bodyText()
+            HttpStatusCode.OK
+        }
+
+        InviteApi(client).requestInvite("usr_friend")
+
+        assertEquals(HttpMethod.Post, method)
+        assertEquals("/api/1/requestInvite/usr_friend", path)
+        assertEquals(ContentType.Application.Json, contentType?.withoutParameters())
+        assertEquals("{\"requestSlot\":0}", body)
+        client.close()
+    }
+
+    @Test
+    fun serverFailureIsReturnedToCaller() = runBlocking {
+        val client = requestInviteClient { HttpStatusCode.Forbidden }
+
+        val error = assertFailsWith<VRCApiException> {
+            InviteApi(client).requestInvite("usr_not_friend")
+        }
+
+        assertEquals(HttpStatusCode.Forbidden.value, error.code)
+        client.close()
+    }
+
+    private fun requestInviteClient(
+        status: (HttpRequestData) -> HttpStatusCode,
+    ) = HttpClient(MockEngine) {
+        engine {
+            addHandler { request ->
+                val responseStatus = status(request)
+                respond(
+                    content = if (responseStatus == HttpStatusCode.OK) "{}" else "forbidden",
+                    status = responseStatus,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+        }
+        defaultRequest { url("https://api.vrchat.cloud/api/1/") }
+        install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+    }
+
+    private fun HttpRequestData.bodyText(): String =
+        (body as OutgoingContent.ByteArrayContent).bytes().decodeToString()
+}

--- a/composeApp/src/commonTest/kotlin/service/RequestInviteServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/RequestInviteServiceTest.kt
@@ -1,0 +1,117 @@
+package io.github.vrcmteam.vrcm.service
+
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
+import io.github.vrcmteam.vrcm.network.supports.VRCApiException
+import io.github.vrcmteam.vrcm.service.data.AccountDto
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
+import kotlin.test.assertSame
+
+class RequestInviteServiceTest {
+    @Test
+    fun repeatedSubmissionWaitsForTheActiveRequest() = runTest {
+        val request = ControlledRequestInviteCall()
+        try {
+            SharedFlowCentre.emitAuthenticated(AccountDto(userId = "usr_a"))
+            val service = RequestInviteService(request)
+            val firstSend = async(start = CoroutineStart.UNDISPATCHED) {
+                service.send("usr_friend")
+            }
+            val sessionToken = request.started.await()
+
+            assertEquals(RequestInviteResult.InFlight, service.send("usr_friend"))
+
+            request.complete(Result.success(Unit), sessionToken)
+            val result = assertIs<RequestInviteResult.Sent>(firstSend.await())
+            assertEquals(sessionToken, result.sessionToken)
+        } finally {
+            SharedFlowCentre.emitLogout()
+        }
+    }
+
+    @Test
+    fun accountSwitchDiscardsTheCompletedRequest() = runTest {
+        val request = ControlledRequestInviteCall()
+        try {
+            SharedFlowCentre.emitAuthenticated(AccountDto(userId = "usr_a"))
+            val send = async(start = CoroutineStart.UNDISPATCHED) {
+                RequestInviteService(request).send("usr_friend")
+            }
+            val firstToken = request.started.await()
+
+            SharedFlowCentre.emitAuthenticated(AccountDto(userId = "usr_b"))
+            request.complete(Result.success(Unit), firstToken)
+
+            assertEquals(RequestInviteResult.SessionChanged, send.await())
+        } finally {
+            SharedFlowCentre.emitLogout()
+        }
+    }
+
+    @Test
+    fun renewedSessionForTheSameAccountCanComplete() = runTest {
+        val request = ControlledRequestInviteCall()
+        try {
+            SharedFlowCentre.emitAuthenticated(AccountDto(userId = "usr_a"))
+            val send = async(start = CoroutineStart.UNDISPATCHED) {
+                RequestInviteService(request).send("usr_friend")
+            }
+            val firstToken = request.started.await()
+
+            SharedFlowCentre.emitAuthenticated(AccountDto(userId = "usr_a"))
+            val renewedToken = requireNotNull(SharedFlowCentre.currentSession.value).token
+            assertNotEquals(firstToken, renewedToken)
+            request.complete(Result.success(Unit), renewedToken)
+
+            val result = assertIs<RequestInviteResult.Sent>(send.await())
+            assertEquals(renewedToken, result.sessionToken)
+        } finally {
+            SharedFlowCentre.emitLogout()
+        }
+    }
+
+    @Test
+    fun apiFailureRemainsAnActionableFailure() = runTest {
+        val request = ControlledRequestInviteCall()
+        val apiError = VRCApiException("Forbidden", 403, "not friends")
+        try {
+            SharedFlowCentre.emitAuthenticated(AccountDto(userId = "usr_a"))
+            val send = async(start = CoroutineStart.UNDISPATCHED) {
+                RequestInviteService(request).send("usr_friend")
+            }
+            val sessionToken = request.started.await()
+
+            request.complete(Result.failure(apiError), sessionToken)
+
+            val result = assertIs<RequestInviteResult.Failed>(send.await())
+            assertSame(apiError, result.error)
+            assertEquals(sessionToken, result.sessionToken)
+        } finally {
+            SharedFlowCentre.emitLogout()
+        }
+    }
+}
+
+private class ControlledRequestInviteCall : RequestInviteCall {
+    val started = CompletableDeferred<AccountSessionToken>()
+    private val completion = CompletableDeferred<SessionBoundResponse<Unit>?>()
+
+    override suspend fun send(
+        sessionToken: AccountSessionToken,
+        userId: String,
+    ): SessionBoundResponse<Unit>? {
+        started.complete(sessionToken)
+        return completion.await()
+    }
+
+    fun complete(result: Result<Unit>, sessionToken: AccountSessionToken) {
+        completion.complete(SessionBoundResponse(result, sessionToken))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/service/RequestInviteServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/RequestInviteServiceTest.kt
@@ -7,6 +7,7 @@ import io.github.vrcmteam.vrcm.service.data.AccountDto
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -24,7 +25,7 @@ class RequestInviteServiceTest {
             val firstSend = async(start = CoroutineStart.UNDISPATCHED) {
                 service.send("usr_friend")
             }
-            val sessionToken = request.started.await()
+            val sessionToken = request.nextStarted()
 
             assertEquals(RequestInviteResult.InFlight, service.send("usr_friend"))
 
@@ -44,12 +45,40 @@ class RequestInviteServiceTest {
             val send = async(start = CoroutineStart.UNDISPATCHED) {
                 RequestInviteService(request).send("usr_friend")
             }
-            val firstToken = request.started.await()
+            val firstToken = request.nextStarted()
 
             SharedFlowCentre.emitAuthenticated(AccountDto(userId = "usr_b"))
             request.complete(Result.success(Unit), firstToken)
 
             assertEquals(RequestInviteResult.SessionChanged, send.await())
+        } finally {
+            SharedFlowCentre.emitLogout()
+        }
+    }
+
+    @Test
+    fun accountSwitchAllowsTheNewAccountToSubmitTheSameRecipient() = runTest {
+        val request = ControlledRequestInviteCall()
+        try {
+            SharedFlowCentre.emitAuthenticated(AccountDto(userId = "usr_a"))
+            val service = RequestInviteService(request)
+            val firstSend = async(start = CoroutineStart.UNDISPATCHED) {
+                service.send("usr_friend")
+            }
+            val firstToken = request.nextStarted()
+
+            SharedFlowCentre.emitAuthenticated(AccountDto(userId = "usr_b"))
+            val secondSend = async(start = CoroutineStart.UNDISPATCHED) {
+                service.send("usr_friend")
+            }
+            val secondToken = request.nextStarted()
+
+            assertEquals("usr_b", secondToken.userId)
+            request.complete(Result.success(Unit), secondToken)
+            assertIs<RequestInviteResult.Sent>(secondSend.await())
+
+            request.complete(Result.success(Unit), firstToken)
+            assertEquals(RequestInviteResult.SessionChanged, firstSend.await())
         } finally {
             SharedFlowCentre.emitLogout()
         }
@@ -63,7 +92,7 @@ class RequestInviteServiceTest {
             val send = async(start = CoroutineStart.UNDISPATCHED) {
                 RequestInviteService(request).send("usr_friend")
             }
-            val firstToken = request.started.await()
+            val firstToken = request.nextStarted()
 
             SharedFlowCentre.emitAuthenticated(AccountDto(userId = "usr_a"))
             val renewedToken = requireNotNull(SharedFlowCentre.currentSession.value).token
@@ -86,7 +115,7 @@ class RequestInviteServiceTest {
             val send = async(start = CoroutineStart.UNDISPATCHED) {
                 RequestInviteService(request).send("usr_friend")
             }
-            val sessionToken = request.started.await()
+            val sessionToken = request.nextStarted()
 
             request.complete(Result.failure(apiError), sessionToken)
 
@@ -100,18 +129,31 @@ class RequestInviteServiceTest {
 }
 
 private class ControlledRequestInviteCall : RequestInviteCall {
-    val started = CompletableDeferred<AccountSessionToken>()
-    private val completion = CompletableDeferred<SessionBoundResponse<Unit>?>()
+    private val starts = Channel<AccountSessionToken>(Channel.UNLIMITED)
+    private val completions = mutableMapOf<AccountSessionToken, CompletableDeferred<SessionBoundResponse<Unit>?>>()
 
     override suspend fun send(
         sessionToken: AccountSessionToken,
         userId: String,
     ): SessionBoundResponse<Unit>? {
-        started.complete(sessionToken)
+        val completion = CompletableDeferred<SessionBoundResponse<Unit>?>()
+        completions[sessionToken] = completion
+        starts.send(sessionToken)
         return completion.await()
     }
 
+    suspend fun nextStarted(): AccountSessionToken = starts.receive()
+
     fun complete(result: Result<Unit>, sessionToken: AccountSessionToken) {
-        completion.complete(SessionBoundResponse(result, sessionToken))
+        val completion = completions.remove(sessionToken)
+            ?: if (completions.size == 1) {
+                completions.entries.single().let { (requestToken, pending) ->
+                    completions.remove(requestToken)
+                    pending
+                }
+            } else {
+                null
+            }
+        completion?.complete(SessionBoundResponse(result, sessionToken))
     }
 }


### PR DESCRIPTION
## 概要

- 新增默认消息槽位的好友邀请请求接口，使用结构化 JSON 请求体。
- 在其他好友的资料页操作面板提供请求邀请入口，提交期间禁用按钮并显示进度。
- 将请求绑定到发起时的认证会话，同账号续期后可正确完成，账号切换后的迟到结果会静默丢弃。
- 补充接口契约、重复提交、会话切换、同账号续期及错误传播测试，并同步英文、日文、简体中文和繁体中文文案。

## 验证

- `./gradlew :composeApp:desktopTest --tests "*InviteApiRequestInviteTest" --tests "*RequestInviteServiceTest" --tests "*LocaleStringsStructureTest"`：通过。
- `./gradlew :composeApp:compileKotlinDesktop`：通过。
- `./gradlew :composeApp:desktopTest`：809 项中 807 项通过；既有 `DesktopWindowTitleBarLocaleTest.windowControlLabelsUseTheLatestLanguage` 在无图形会话下因 `HeadlessException` 失败，`MeetupCardScreenModelTest.shortTextRejectsMoreThanEightyCodePointsWithoutPersisting` 因测试开始前的共享后台异常失败；后者单独运行通过。
- `git diff --check upstream/newui...HEAD`：通过。

## 实现假设清单

- 本次只实现普通好友邀请请求，不读取或编辑消息槽，不包含照片，也不调整现有普通邀请流程。
- 请求消息固定使用默认 `requestSlot = 0`，暂不提供槽位选择 UI。
- 请求入口仅在目标不是当前账号且目标为好友时显示；在线状态和房间权限由服务端最终校验。
- 只有接口返回 HTTP 200 且响应对应的认证会话仍为当前会话时才提示成功。
- 401 后只允许同一账号重新认证并使用返回的新会话令牌完成；账号已切换时不重试、不显示旧请求结果。
- 提交门控按发起账号 `sessionToken.userId` 与目标用户共同去重；同账号同目标的重复提交会被忽略，不同账号对同一目标可以并行提交。

## 代码逻辑图

```mermaid
flowchart TD
    A[打开用户资料操作面板] --> B{非本人且是好友}
    B -->|否| C[不显示请求入口]
    B -->|是| D[显示请求邀请按钮]
    D --> E{同账号同目标是否已有提交}
    E -->|是| F[忽略重复点击]
    E -->|否| G[记录提交中并捕获当前会话]
    G --> H[POST requestInvite userId with requestSlot 0]
    H --> I{需要重新认证}
    I -->|是且同账号| J[续期后重试并采用新令牌]
    I -->|否| K[处理接口结果]
    J --> K
    K --> L{结果会话仍为当前会话}
    L -->|否| M[静默丢弃迟到结果]
    L -->|是且失败| N[显示错误提示]
    L -->|是且成功| O[显示成功提示]
    F --> P[保持当前状态]
    M --> Q[清除提交中]
    N --> Q
    O --> Q
```
