### PR TITLE
feat(world): 支持删除自有世界

### DIFF
--- a/composeApp/src/commonMain/kotlin/network/api/worlds/WorldsApi.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/worlds/WorldsApi.kt
@@ -24,6 +24,10 @@ class WorldsApi(private val client: HttpClient)  {
     suspend fun getWorldById(worldId: String): WorldData =
         client.get("$WORLDS_API_PREFIX/$worldId").checkSuccess()
 
+    suspend fun deleteWorld(worldId: String) {
+        client.delete("$WORLDS_API_PREFIX/$worldId").checkSuccess { Unit }
+    }
+
     suspend fun getRecentWorlds(
         n: Int = 50,
         offset: Int = 0,

--- a/composeApp/src/commonMain/kotlin/presentation/compoments/TopMenuBar.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/compoments/TopMenuBar.kt
@@ -44,6 +44,7 @@ fun TopMenuBar(
     color: Color = MaterialTheme.colorScheme.onPrimary,
     onReturn: () -> Unit,
     onMenu: (() -> Unit)?,
+    centerContent: @Composable RowScope.() -> Unit = {},
     actions: @Composable RowScope.(IconButtonColors) -> Unit = {},
 ) {
     // image上滑反比例
@@ -65,6 +66,7 @@ fun TopMenuBar(
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically
         ) {
+            val rowScope = this
             val actionColors = topMenuActionColors(
                 ratio = ratio,
                 onPrimary = MaterialTheme.colorScheme.onPrimary,
@@ -89,7 +91,14 @@ fun TopMenuBar(
                     contentDescription = "ReturnIcon"
                 )
             }
-            Spacer(modifier = Modifier.weight(1f))
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight(),
+                contentAlignment = Alignment.Center,
+            ) {
+                with(rowScope) { centerContent() }
+            }
             Row(
                 modifier = Modifier.padding(end = if (onMenu == null) 10.dp else 0.dp),
                 verticalAlignment = Alignment.CenterVertically,

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldDeletionStateModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldDeletionStateModel.kt
@@ -1,0 +1,217 @@
+package io.github.vrcmteam.vrcm.presentation.screens.world
+
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+import io.github.vrcmteam.vrcm.core.shared.AuthenticatedAccount
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
+import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
+import io.github.vrcmteam.vrcm.service.AuthService
+import io.github.vrcmteam.vrcm.service.SessionBoundResponse
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.updateAndGet
+import kotlinx.coroutines.launch
+
+internal data class WorldDeletionUiState(
+    val isAvailable: Boolean = false,
+    val isDeleting: Boolean = false,
+    val isDeleted: Boolean = false,
+) {
+    val canDelete: Boolean
+        get() = isAvailable && !isDeleting && !isDeleted
+}
+
+internal sealed interface WorldDeletionNotice {
+    data class Deleted(val cacheCleanupFailed: Boolean = false) : WorldDeletionNotice
+    data object Failed : WorldDeletionNotice
+}
+
+internal fun canDeleteWorld(
+    worldId: String,
+    authorId: String?,
+    currentUserId: String?,
+): Boolean = worldId.isNotBlank() &&
+    !authorId.isNullOrBlank() &&
+    authorId == currentUserId
+
+internal fun interface WorldDeletionSource {
+    suspend fun delete(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+    ): SessionBoundResponse<Unit>?
+}
+
+internal class NetworkWorldDeletionSource(
+    private val worldsApi: WorldsApi,
+    private val authService: AuthService,
+) : WorldDeletionSource {
+    override suspend fun delete(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+    ): SessionBoundResponse<Unit>? = authService.runSessionBoundCatching(sessionToken) {
+        worldsApi.deleteWorld(worldId)
+    }
+}
+
+/**
+ * Coordinates one irreversible deletion against a specific world and account owner.
+ * Only the exact session token returned by the authenticated request may commit the result.
+ */
+internal class WorldDeletionStateModel(
+    private val source: WorldDeletionSource,
+    private val scope: CoroutineScope,
+    private val removeCachedWorld: suspend (String) -> Unit,
+    private val requestDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val sessionFlow: StateFlow<AuthenticatedAccount?> = SharedFlowCentre.currentSession,
+) {
+    private data class Target(
+        val worldId: String = "",
+        val authorId: String? = null,
+    )
+
+    private val target = MutableStateFlow(Target())
+    private val generation = MutableStateFlow(0L)
+    private var observedUserId = sessionFlow.value?.token?.userId
+    private var deletionJob: Job? = null
+
+    private val _state = MutableStateFlow(WorldDeletionUiState())
+    val state: StateFlow<WorldDeletionUiState> = _state.asStateFlow()
+
+    private val _notices = MutableSharedFlow<WorldDeletionNotice>(extraBufferCapacity = 1)
+    val notices: SharedFlow<WorldDeletionNotice> = _notices.asSharedFlow()
+
+    init {
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            sessionFlow.collect { session ->
+                val nextUserId = session?.token?.userId
+                if (nextUserId != observedUserId) {
+                    observedUserId = nextUserId
+                    invalidatePendingDeletion(preserveDeleted = true)
+                } else {
+                    refreshAvailability(preserveDeletion = true)
+                }
+            }
+        }
+    }
+
+    fun setTarget(worldId: String, authorId: String?) {
+        val next = Target(worldId, authorId)
+        if (target.value == next) return
+        target.value = next
+        invalidatePendingDeletion()
+    }
+
+    fun delete(): Boolean {
+        val ready = _state.value
+        val currentTarget = target.value
+        val sessionToken = sessionFlow.value?.token ?: return false
+        if (!ready.canDelete ||
+            currentTarget.authorId != sessionToken.userId ||
+            !canDeleteWorld(currentTarget.worldId, currentTarget.authorId, sessionToken.userId)
+        ) {
+            return false
+        }
+        if (!_state.compareAndSet(ready, ready.copy(isDeleting = true))) return false
+
+        val requestGeneration = generation.value
+        deletionJob = scope.launch(requestDispatcher) {
+            val response = source.delete(sessionToken, currentTarget.worldId)
+            if (!acceptsTarget(currentTarget, requestGeneration)) return@launch
+
+            val currentSessionToken = sessionFlow.value?.token
+            if (response == null || response.sessionToken != currentSessionToken) {
+                refreshAvailability()
+                return@launch
+            }
+
+            val error = response.result.exceptionOrNull()
+            if (error != null) {
+                refreshAvailability()
+                _notices.emit(WorldDeletionNotice.Failed)
+                return@launch
+            }
+
+            if (!acceptsResponse(currentTarget, requestGeneration, response.sessionToken)) return@launch
+            _state.value = WorldDeletionUiState(isDeleted = true)
+            val cacheCleanupFailed = try {
+                removeCachedWorld(currentTarget.worldId)
+                false
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (_: Throwable) {
+                true
+            }
+
+            val mayNotify = acceptsDeletedCommit(
+                expected = currentTarget,
+                requestGeneration = requestGeneration,
+                ownerUserId = response.sessionToken.userId,
+            )
+            if (!mayNotify) return@launch
+            _notices.emit(WorldDeletionNotice.Deleted(cacheCleanupFailed))
+        }
+        return true
+    }
+
+    private fun invalidatePendingDeletion(preserveDeleted: Boolean = false) {
+        val deletionCommitted = _state.value.isDeleted
+        val wasDeleted = preserveDeleted && deletionCommitted
+        generation.updateAndGet { it + 1L }
+        if (!deletionCommitted) deletionJob?.cancel()
+        deletionJob = null
+        _state.value = if (wasDeleted) {
+            WorldDeletionUiState(isDeleted = true)
+        } else {
+            availableState()
+        }
+    }
+
+    private fun refreshAvailability(preserveDeletion: Boolean = false) {
+        val current = _state.value
+        _state.value = if (current.isDeleted) {
+            WorldDeletionUiState(isDeleted = true)
+        } else {
+            availableState().copy(isDeleting = preserveDeletion && current.isDeleting)
+        }
+    }
+
+    private fun availableState(): WorldDeletionUiState {
+        val currentTarget = target.value
+        return WorldDeletionUiState(
+            isAvailable = canDeleteWorld(
+                worldId = currentTarget.worldId,
+                authorId = currentTarget.authorId,
+                currentUserId = sessionFlow.value?.token?.userId,
+            )
+        )
+    }
+
+    private fun acceptsTarget(expected: Target, requestGeneration: Long): Boolean =
+        target.value == expected && generation.value == requestGeneration
+
+    private fun acceptsResponse(
+        expected: Target,
+        requestGeneration: Long,
+        responseToken: AccountSessionToken,
+    ): Boolean = acceptsTarget(expected, requestGeneration) &&
+        sessionFlow.value?.token == responseToken
+
+    private fun acceptsDeletedCommit(
+        expected: Target,
+        requestGeneration: Long,
+        ownerUserId: String,
+    ): Boolean = acceptsTarget(expected, requestGeneration) &&
+        sessionFlow.value?.token?.userId == ownerUserId &&
+        _state.value.isDeleted
+}

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
@@ -796,8 +796,6 @@ private fun RenderTopBar(
             .zIndex(20f) // 确保在所有内容之上
     ) {
         val topBarRatio = (1 - blurProgress).coerceIn(0f, 1f)
-        val reservedWidth = if (showDelete) 256.dp else 208.dp
-        val titleMaxWidth = (maxWidth - reservedWidth).coerceIn(0.dp, 200.dp)
 
         // 添加TopMenuBar
         TopMenuBar(
@@ -808,6 +806,29 @@ private fun RenderTopBar(
             color = MaterialTheme.colorScheme.surface,
             onReturn = onReturn,
             onMenu = null,
+            centerContent = {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .fillMaxHeight()
+                        .alpha(blurProgress)
+                        .simpleClickable(onClick = onCollapse),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 8.dp),
+                        text = worldName,
+                        textAlign = TextAlign.Center,
+                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            },
             actions = { colors ->
                 if (showDelete) {
                     ATooltipBox(tooltip = { Text(strings.worldDeleteAction) }) {
@@ -853,36 +874,8 @@ private fun RenderTopBar(
                         )
                     }
                 }
-            },
-        )
-        // 标题显示
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(topBarHeight + sysTopPadding)
-                .alpha(blurProgress)
-                .padding(top = sysTopPadding)
-        ) {
-            Row(
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .simpleClickable(onClick = onCollapse),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Text(
-                    modifier = Modifier.widthIn(max = titleMaxWidth),
-                    text = worldName,
-                    textAlign = TextAlign.Center,
-                    fontWeight = FontWeight.Bold,
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-
-            }
-        }
+                },
+            )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -58,6 +59,7 @@ import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import io.github.vrcmteam.vrcm.core.extensions.toLocalDate
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
 import io.github.vrcmteam.vrcm.network.api.files.data.PlatformType.*
 import io.github.vrcmteam.vrcm.presentation.compoments.*
@@ -103,10 +105,33 @@ class WorldProfileScreen(
         // 收集ViewModel状态
         val profileVoState by screenModel.worldProfileState.collectAsState()
         val isLoading by screenModel.isLoading.collectAsState()
+        val deletionState by screenModel.deletionState.collectAsState()
         val currentNavigator = currentNavigator
+        val localeStrings = strings
         // 组件首次加载时自动刷新数据
         LaunchedEffect(Unit) {
             screenModel.loadWorldData(worldProfileVO)
+        }
+        LaunchedEffect(screenModel, localeStrings, currentNavigator) {
+            screenModel.deletionNotices.collect { notice ->
+                when (notice) {
+                    is WorldDeletionNotice.Deleted -> {
+                        SharedFlowCentre.toastText.emit(
+                            if (notice.cacheCleanupFailed) {
+                                ToastText.Info(localeStrings.worldDeleteSuccessCacheCleanupFailed)
+                            } else {
+                                ToastText.Success(localeStrings.worldDeleteSuccess)
+                            }
+                        )
+                        if (currentNavigator.lastItem == this@WorldProfileScreen) {
+                            currentNavigator.pop()
+                        }
+                    }
+                    WorldDeletionNotice.Failed -> SharedFlowCentre.toastText.emit(
+                        ToastText.Error(localeStrings.worldDeleteFailed)
+                    )
+                }
+            }
         }
 
         CompositionLocalProvider(
@@ -118,6 +143,10 @@ class WorldProfileScreen(
                 onMenu = { /* 打开菜单 */ },
                 isRefreshing = isLoading,
                 onRefresh = screenModel::refreshWorldData,
+                isDeleteAvailable = deletionState.isAvailable,
+                isDeleting = deletionState.isDeleting,
+                isDeleted = deletionState.isDeleted,
+                onDelete = { screenModel.deleteWorld() },
                 sharedKeyPrefix = sharedKeyPrefix,
                 sharedImageCacheKey = sharedImageCacheKey,
             )
@@ -132,11 +161,31 @@ class WorldProfileScreen(
         onMenu: () -> Unit = {},
         isRefreshing: Boolean = false,
         onRefresh: () -> Unit = {},
+        isDeleteAvailable: Boolean = false,
+        isDeleting: Boolean = false,
+        isDeleted: Boolean = false,
+        onDelete: () -> Unit = {},
         sharedKeyPrefix: String = "",
         sharedImageCacheKey: String? = null,
     ) {
         // 模糊效果状态
         val hazeState = remember { HazeState() }
+        var showDeleteConfirmation by rememberSaveable(worldProfileVo.worldId) {
+            mutableStateOf(false)
+        }
+        LaunchedEffect(isDeleteAvailable, isDeleted) {
+            if (!isDeleteAvailable || isDeleted) showDeleteConfirmation = false
+        }
+
+        if (showDeleteConfirmation) {
+            WorldDeletionConfirmationDialog(
+                worldName = worldProfileVo.worldName,
+                isDeleting = isDeleting,
+                enabled = isDeleteAvailable && !isDeleting && !isRefreshing && !isDeleted,
+                onDismiss = { showDeleteConfirmation = false },
+                onConfirm = onDelete,
+            )
+        }
 
         BoxWithConstraints(
             modifier = Modifier.fillMaxSize()
@@ -227,7 +276,12 @@ class WorldProfileScreen(
                 onMenu = onMenu,
                 onCollapse = { sheetState = SheetState.COLLAPSED },
                 isRefreshing = isRefreshing,
-                onRefresh = onRefresh
+                onRefresh = onRefresh,
+                showDelete = isDeleteAvailable && !isDeleted,
+                deleteEnabled = isDeleteAvailable && !isDeleting && !isRefreshing && !isDeleted,
+                isDeleting = isDeleting,
+                isDeleted = isDeleted,
+                onDelete = { showDeleteConfirmation = true },
             )
 
             // ========== BottomSheet ==========
@@ -717,6 +771,7 @@ private fun ColumnScope.InfoArea(
 /**
  * 渲染顶部菜单栏
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun RenderTopBar(
     worldId: String,
@@ -729,6 +784,11 @@ private fun RenderTopBar(
     onCollapse: () -> Unit,
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
+    showDelete: Boolean = false,
+    deleteEnabled: Boolean = false,
+    isDeleting: Boolean = false,
+    isDeleted: Boolean = false,
+    onDelete: () -> Unit = {},
 ) {
     BoxWithConstraints(
         modifier = Modifier
@@ -736,7 +796,8 @@ private fun RenderTopBar(
             .zIndex(20f) // 确保在所有内容之上
     ) {
         val topBarRatio = (1 - blurProgress).coerceIn(0f, 1f)
-        val titleMaxWidth = (maxWidth - 208.dp).coerceIn(40.dp, 200.dp)
+        val reservedWidth = if (showDelete) 256.dp else 208.dp
+        val titleMaxWidth = (maxWidth - reservedWidth).coerceIn(0.dp, 200.dp)
 
         // 添加TopMenuBar
         TopMenuBar(
@@ -748,12 +809,34 @@ private fun RenderTopBar(
             onReturn = onReturn,
             onMenu = null,
             actions = { colors ->
+                if (showDelete) {
+                    ATooltipBox(tooltip = { Text(strings.worldDeleteAction) }) {
+                        IconButton(
+                            enabled = deleteEnabled,
+                            colors = colors,
+                            onClick = onDelete,
+                        ) {
+                            if (isDeleting) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(22.dp),
+                                    color = LocalContentColor.current,
+                                    strokeWidth = 2.dp,
+                                )
+                            } else {
+                                Icon(
+                                    imageVector = Icons.Default.DeleteOutline,
+                                    contentDescription = strings.worldDeleteAction,
+                                )
+                            }
+                        }
+                    }
+                }
                 OfficialUrlShareButton(
                     url = "https://vrchat.com/home/world/$worldId",
                     colors = colors,
                 )
                 IconButton(
-                    enabled = !isRefreshing,
+                    enabled = !isRefreshing && !isDeleting && !isDeleted,
                     colors = colors,
                     onClick = onRefresh,
                 ) {
@@ -801,6 +884,69 @@ private fun RenderTopBar(
             }
         }
     }
+}
+
+@Composable
+private fun WorldDeletionConfirmationDialog(
+    worldName: String,
+    isDeleting: Boolean,
+    enabled: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = { if (!isDeleting) onDismiss() },
+        icon = {
+            Icon(
+                imageVector = Icons.Default.DeleteOutline,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+            )
+        },
+        title = { Text(strings.worldDeleteConfirmationTitle) },
+        text = {
+            Text(strings.worldDeleteConfirmationMessage.replace("%name%", worldName))
+        },
+        confirmButton = {
+            Button(
+                enabled = enabled,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error,
+                    contentColor = MaterialTheme.colorScheme.onError,
+                ),
+                onClick = onConfirm,
+            ) {
+                Box(
+                    modifier = Modifier.size(18.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    if (isDeleting) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.fillMaxSize(),
+                            color = LocalContentColor.current,
+                            strokeWidth = 2.dp,
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Default.DeleteOutline,
+                            contentDescription = null,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
+                }
+                Spacer(Modifier.width(8.dp))
+                Text(strings.worldDeleteAction)
+            }
+        },
+        dismissButton = {
+            TextButton(
+                enabled = !isDeleting,
+                onClick = onDismiss,
+            ) {
+                Text(strings.cancel)
+            }
+        },
+    )
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
@@ -151,7 +151,11 @@ class WorldProfileScreenModel internal constructor(
 
     fun refreshWorldData() {
         val worldId = _worldProfileState.value?.worldId ?: return
-        if (_isLoading.value || worldId.isBlank()) return
+        if (_isLoading.value ||
+            worldId.isBlank() ||
+            deletion.state.value.isDeleting ||
+            deletion.state.value.isDeleted
+        ) return
         worldLoadJob?.cancel()
         val loadGeneration = ++worldLoadGeneration
         _isLoading.value = true

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
@@ -28,8 +28,11 @@ import io.github.vrcmteam.vrcm.storage.data.WorldProfileCache
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
@@ -63,13 +66,20 @@ class WorldProfileScreenModel internal constructor(
     )
     internal val favoriteEntryState: StateFlow<FavoriteEntryState> = favoriteEntry.state
 
+    private val worldCacheMutex = Mutex()
+
     private val deletion = WorldDeletionStateModel(
         source = NetworkWorldDeletionSource(worldsApi, authService),
         scope = viewModelScope,
-        removeCachedWorld = worldProfileCacheStore::delete,
+        removeCachedWorld = { worldId ->
+            worldCacheMutex.withLock { worldProfileCacheStore.delete(worldId) }
+        },
     )
     internal val deletionState: StateFlow<WorldDeletionUiState> = deletion.state
     internal val deletionNotices: SharedFlow<WorldDeletionNotice> = deletion.notices
+
+    private var worldLoadJob: Job? = null
+    private var worldLoadGeneration = 0L
 
     internal fun retryFavoriteEntryLoad() {
         favoriteEntry.retry()
@@ -79,17 +89,43 @@ class WorldProfileScreenModel internal constructor(
      * 刷新世界数据
      */
     fun loadWorldData(worldProfileVO: WorldProfileVo) {
+        worldLoadJob?.cancel()
+        val loadGeneration = ++worldLoadGeneration
         _worldProfileState.value = worldProfileVO
         val worldId = worldProfileVO.worldId
-        deletion.setTarget(worldId, worldProfileVO.authorID)
+        // 路由快照可能来自列表、活动或房间事件，作者字段不作为删除权限依据。
+        deletion.setTarget("", null)
         favoriteEntry.load(worldId)
-        if (worldId.isBlank()) return
-        // 缓存读取改为挂起（Room），先出网络前的占位状态，缓存到达后再回填。
-        viewModelScope.launch { applyCachedWorld(worldId, worldProfileVO) }
+        if (worldId.isBlank()) {
+            _isLoading.value = false
+            return
+        }
+        _isLoading.value = true
+        // 缓存读取和后续详情刷新共享同一任务，删除开始后会取消并使其代次失效。
+        worldLoadJob = viewModelScope.launch(Dispatchers.IO) {
+            try {
+                applyCachedWorld(worldId, worldProfileVO, loadGeneration)
+            } catch (error: Throwable) {
+                if (error is CancellationException) throw error
+                SharedFlowCentre.toastText.emit(
+                    ToastText.Error(error.message ?: "Failed to load world data")
+                )
+            } finally {
+                if (isCurrentWorldLoad(loadGeneration, worldId)) {
+                    _isLoading.value = false
+                    worldLoadJob = null
+                }
+            }
+        }
     }
 
-    private suspend fun applyCachedWorld(worldId: String, worldProfileVO: WorldProfileVo) {
+    private suspend fun applyCachedWorld(
+        worldId: String,
+        worldProfileVO: WorldProfileVo,
+        loadGeneration: Long,
+    ) {
         val cached = worldProfileCacheStore.load(worldId)
+        if (!isCurrentWorldLoad(loadGeneration, worldId)) return
         if (cached != null) {
             deletion.setTarget(cached.world.id, cached.world.authorId)
             _worldProfileState.value = WorldProfileVo(
@@ -103,61 +139,53 @@ class WorldProfileScreenModel internal constructor(
             cached.isExpired(Clock.System.now().toEpochMilliseconds()) ||
             cached.world.instances == null
         if (shouldRefreshProfile) {
-            refreshWorldData()
+            loadWorldInfo(worldId, loadGeneration)
         } else {
-            loadCachedInstances(cached.world.instances.orEmpty())
-        }
-    }
-
-    private fun loadCachedInstances(worldInstances: List<List<String>>) {
-        val profile = _worldProfileState.value ?: return
-        val instanceIds = collectInstanceIds(profile, worldInstances)
-        if (instanceIds.isEmpty() || _isLoading.value) return
-
-        _isLoading.value = true
-        viewModelScope.launch(Dispatchers.IO) {
-            try {
-                loadInstanceData(instanceIds)
-            } catch (error: Throwable) {
-                if (error is CancellationException) throw error
-                SharedFlowCentre.toastText.emit(
-                    ToastText.Error(error.message ?: "Failed to load instance data")
-                )
-            } finally {
-                _isLoading.value = false
-            }
+            val profile = _worldProfileState.value ?: return
+            loadInstanceData(
+                collectInstanceIds(profile, cached.world.instances.orEmpty()),
+                loadGeneration,
+            )
         }
     }
 
     fun refreshWorldData() {
         val worldId = _worldProfileState.value?.worldId ?: return
         if (_isLoading.value || worldId.isBlank()) return
+        worldLoadJob?.cancel()
+        val loadGeneration = ++worldLoadGeneration
         _isLoading.value = true
-        viewModelScope.launch(Dispatchers.IO) {
+        worldLoadJob = viewModelScope.launch(Dispatchers.IO) {
             try {
-                loadWorldInfo(worldId)
+                loadWorldInfo(worldId, loadGeneration)
             } catch (error: Throwable) {
                 if (error is CancellationException) throw error
                 SharedFlowCentre.toastText.emit(
                     ToastText.Error(error.message ?: "Failed to load world data")
                 )
             } finally {
-                _isLoading.value = false
+                if (isCurrentWorldLoad(loadGeneration, worldId)) {
+                    _isLoading.value = false
+                    worldLoadJob = null
+                }
             }
         }
     }
 
-    private suspend fun loadWorldInfo(worldId: String) {
+    private suspend fun loadWorldInfo(worldId: String, loadGeneration: Long) {
         authService.reTryAuthCatching {
             worldsApi.getWorldById(worldId)
         }.onSuccess { worldData ->
-            worldProfileCacheStore.save(
-                WorldProfileCache(
-                    world = worldData,
-                    cachedAtEpochMilliseconds = Clock.System.now().toEpochMilliseconds(),
+            worldCacheMutex.withLock {
+                if (!isCurrentWorldLoad(loadGeneration, worldId)) return@withLock
+                worldProfileCacheStore.save(
+                    WorldProfileCache(
+                        world = worldData,
+                        cachedAtEpochMilliseconds = Clock.System.now().toEpochMilliseconds(),
+                    )
                 )
-            )
-            if (_worldProfileState.value?.worldId != worldId) return@onSuccess
+            }
+            if (!isCurrentWorldLoad(loadGeneration, worldId)) return@onSuccess
 
             // TODO
 //            val platformFileSizes = mutableStateListOf<PlatformFileSize>()
@@ -184,10 +212,12 @@ class WorldProfileScreenModel internal constructor(
             )
             // 如果有实例ID，则获取实例信息
             if (mergeInstanceIds.isNotEmpty()) {
-                loadInstanceData(mergeInstanceIds)
+                loadInstanceData(mergeInstanceIds, loadGeneration)
             }
         }.onFailure {
-            SharedFlowCentre.toastText.emit(ToastText.Error(it.message ?: "Failed to load world data"))
+            if (isCurrentWorldLoad(loadGeneration, worldId)) {
+                SharedFlowCentre.toastText.emit(ToastText.Error(it.message ?: "Failed to load world data"))
+            }
         }
     }
 
@@ -208,10 +238,16 @@ class WorldProfileScreenModel internal constructor(
     /**
      * 加载实例数据
      */
-    private suspend fun loadInstanceData(instanceIds: Map<String, Owner?>) {
+    private suspend fun loadInstanceData(
+        instanceIds: Map<String, Owner?>,
+        loadGeneration: Long? = null,
+    ) {
         val currentProfile = _worldProfileState.value ?: return
+        if (loadGeneration != null && !isCurrentWorldLoad(loadGeneration, currentProfile.worldId)) return
         val instanceVos = currentProfile.instances.toMutableList()
-        _worldProfileState.value = currentProfile.copy(instances = instanceVos)
+        if (loadGeneration == null || isCurrentWorldLoad(loadGeneration, currentProfile.worldId)) {
+            _worldProfileState.value = currentProfile.copy(instances = instanceVos)
+        }
         authService.reTryAuthCatching {
             // 获取所有实例数据
             instanceIds.keys.asFlow().mapNotNull { instanceId ->
@@ -231,16 +267,31 @@ class WorldProfileScreenModel internal constructor(
                 val instanceVo = InstanceVo(instanceData, owner)
                 instanceVos.removeFirst { it.id == instanceData.id }
                 instanceVos.add(instanceVo)
-                _worldProfileState.value = _worldProfileState.value?.copy(instances = instanceVos.toList())
+                if (loadGeneration == null || isCurrentWorldLoad(loadGeneration, currentProfile.worldId)) {
+                    _worldProfileState.value = _worldProfileState.value?.copy(instances = instanceVos.toList())
+                }
                 instanceData.ownerId to owner
             }.collect { (ownerId, owner) ->
                 // 如果实例是活跃的，则获取实例的拥有者名称
+                if (loadGeneration != null && !isCurrentWorldLoad(loadGeneration, currentProfile.worldId)) return@collect
                 fetchAndSetOwner(ownerId)
-                    .onSuccess { if (it != null) owner.value = it }
+                    .onSuccess {
+                        if (it != null &&
+                            (loadGeneration == null || isCurrentWorldLoad(loadGeneration, currentProfile.worldId))
+                        ) {
+                            owner.value = it
+                        }
+                    }
                     .onFailure { SharedFlowCentre.toastText.emit(ToastText.Error(it.message ?: "Failed to load instance Owner")) }
             }
         }
     }
+
+    private fun isCurrentWorldLoad(loadGeneration: Long, worldId: String): Boolean =
+        worldLoadGeneration == loadGeneration &&
+            _worldProfileState.value?.worldId == worldId &&
+            !deletion.state.value.isDeleting &&
+            !deletion.state.value.isDeleted
 
     /**
      * 获取房间实例的拥有者名称
@@ -345,5 +396,14 @@ class WorldProfileScreenModel internal constructor(
         }
     }
 
-    internal fun deleteWorld(): Boolean = deletion.delete()
+    internal fun deleteWorld(): Boolean {
+        if (!deletion.state.value.canDelete) return false
+
+        // 先取消缓存/详情加载并提升代次，再启动不可逆请求，迟到响应只能被丢弃。
+        worldLoadGeneration++
+        worldLoadJob?.cancel()
+        worldLoadJob = null
+        _isLoading.value = false
+        return deletion.delete()
+    }
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
@@ -63,6 +63,14 @@ class WorldProfileScreenModel internal constructor(
     )
     internal val favoriteEntryState: StateFlow<FavoriteEntryState> = favoriteEntry.state
 
+    private val deletion = WorldDeletionStateModel(
+        source = NetworkWorldDeletionSource(worldsApi, authService),
+        scope = viewModelScope,
+        removeCachedWorld = worldProfileCacheStore::delete,
+    )
+    internal val deletionState: StateFlow<WorldDeletionUiState> = deletion.state
+    internal val deletionNotices: SharedFlow<WorldDeletionNotice> = deletion.notices
+
     internal fun retryFavoriteEntryLoad() {
         favoriteEntry.retry()
     }
@@ -73,6 +81,7 @@ class WorldProfileScreenModel internal constructor(
     fun loadWorldData(worldProfileVO: WorldProfileVo) {
         _worldProfileState.value = worldProfileVO
         val worldId = worldProfileVO.worldId
+        deletion.setTarget(worldId, worldProfileVO.authorID)
         favoriteEntry.load(worldId)
         if (worldId.isBlank()) return
         // 缓存读取改为挂起（Room），先出网络前的占位状态，缓存到达后再回填。
@@ -82,6 +91,7 @@ class WorldProfileScreenModel internal constructor(
     private suspend fun applyCachedWorld(worldId: String, worldProfileVO: WorldProfileVo) {
         val cached = worldProfileCacheStore.load(worldId)
         if (cached != null) {
+            deletion.setTarget(cached.world.id, cached.world.authorId)
             _worldProfileState.value = WorldProfileVo(
                 world = cached.world,
                 instancesList = worldProfileVO.instances,
@@ -158,6 +168,7 @@ class WorldProfileScreenModel internal constructor(
                     instancesList = _worldProfileState.value?.instances ?: mutableListOf(),
 //                    platformFileSizes = platformFileSizes,
                 )
+            deletion.setTarget(worldData.id, worldData.authorId)
 //            viewModelScope.launch(Dispatchers.IO) {
 //                // 获取平台文件大小信息
 //                runCatching {
@@ -333,4 +344,6 @@ class WorldProfileScreenModel internal constructor(
             refreshWorldData()
         }
     }
-} 
+
+    internal fun deleteWorld(): Boolean = deletion.delete()
+}

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
@@ -251,6 +251,15 @@ sealed class LocaleStrings {
     open val worldProfilePublishDate: String = "Publish Date"
     open val worldProfileUpdateDate: String = "Update Date"
     open val worldProfileLabReleaseDate: String = "Lab Release Date"
+    open val worldDeleteAction: String = "Delete world"
+    open val worldDeleteConfirmationTitle: String = "Delete this world?"
+    open val worldDeleteConfirmationMessage: String =
+        "Delete \"%name%\"? The world will become hidden, and associated files will be " +
+            "permanently deleted and cannot be recovered. The world ID will remain permanently reserved."
+    open val worldDeleteSuccess: String = "World deleted"
+    open val worldDeleteSuccessCacheCleanupFailed: String =
+        "World deleted, but its local cached details couldn't be removed."
+    open val worldDeleteFailed: String = "Couldn't delete this world. Try again."
     open val unknown: String = "Unknown"
 
     // CreateInstanceDialog

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
@@ -236,6 +236,14 @@ internal object LocaleStringsJa : LocaleStrings() {
     override val worldProfilePublishDate = "公開日"
     override val worldProfileUpdateDate = "更新日"
     override val worldProfileLabReleaseDate = "ラボ公開日"
+    override val worldDeleteAction = "ワールドを削除"
+    override val worldDeleteConfirmationTitle = "このワールドを削除しますか？"
+    override val worldDeleteConfirmationMessage =
+        "「%name%」を削除しますか？ワールドは非表示になり、関連ファイルは完全に削除されて復元できません。ワールドIDは永久に予約されたままです。"
+    override val worldDeleteSuccess = "ワールドを削除しました"
+    override val worldDeleteSuccessCacheCleanupFailed =
+        "ワールドは削除されましたが、ローカルのキャッシュ情報を削除できませんでした。"
+    override val worldDeleteFailed = "ワールドを削除できませんでした。もう一度お試しください。"
     override val unknown = "不明"
 
     // CreateInstanceDialog

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
@@ -235,6 +235,13 @@ internal object LocaleStringsZhHans : LocaleStrings() {
     override val worldProfilePublishDate = "发布日期"
     override val worldProfileUpdateDate = "更新日期"
     override val worldProfileLabReleaseDate = "实验室发布日期"
+    override val worldDeleteAction = "删除世界"
+    override val worldDeleteConfirmationTitle = "确认删除这个世界？"
+    override val worldDeleteConfirmationMessage =
+        "确定要删除“%name%”吗？世界将转为隐藏状态，关联文件将被永久删除且无法恢复，世界 ID 将永久保留。"
+    override val worldDeleteSuccess = "世界已删除"
+    override val worldDeleteSuccessCacheCleanupFailed = "世界已删除，但未能清理本地缓存的详情。"
+    override val worldDeleteFailed = "删除世界失败，请重试。"
     override val unknown = "未知"
 
     // CreateInstanceDialog

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
@@ -235,6 +235,13 @@ internal object LocaleStringsZhHant : LocaleStrings() {
     override val worldProfilePublishDate = "發布日期"
     override val worldProfileUpdateDate = "更新日期"
     override val worldProfileLabReleaseDate = "實驗室發布日期"
+    override val worldDeleteAction = "刪除世界"
+    override val worldDeleteConfirmationTitle = "確認刪除這個世界？"
+    override val worldDeleteConfirmationMessage =
+        "確定要刪除「%name%」嗎？世界將轉為隱藏狀態，關聯檔案將被永久刪除且無法復原，世界 ID 將永久保留。"
+    override val worldDeleteSuccess = "世界已刪除"
+    override val worldDeleteSuccessCacheCleanupFailed = "世界已刪除，但未能清理本機快取的詳情。"
+    override val worldDeleteFailed = "刪除世界失敗，請重試。"
     override val unknown = "未知"
 
     // CreateInstanceDialog

--- a/composeApp/src/commonMain/kotlin/storage/CacheStores.kt
+++ b/composeApp/src/commonMain/kotlin/storage/CacheStores.kt
@@ -61,6 +61,8 @@ interface WorldProfileCacheStore {
 
     suspend fun save(cache: WorldProfileCache)
 
+    suspend fun delete(worldId: String)
+
     suspend fun clearAll()
 }
 
@@ -220,6 +222,8 @@ internal class RoomWorldProfileCacheStore(
     override suspend fun load(worldId: String): WorldProfileCache? = cache.load(worldId)
 
     override suspend fun save(cache: WorldProfileCache) = this.cache.save(cache.world.id, cache)
+
+    override suspend fun delete(worldId: String) = cache.delete(worldId)
 
     override suspend fun clearAll() = cache.clear()
 }

--- a/composeApp/src/commonTest/kotlin/network/api/worlds/WorldsApiDeletionTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/api/worlds/WorldsApiDeletionTest.kt
@@ -1,0 +1,56 @@
+package io.github.vrcmteam.vrcm.network.api.worlds
+
+import io.github.vrcmteam.vrcm.network.supports.VRCApiException
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class WorldsApiDeletionTest {
+    @Test
+    fun deletionUsesTheWorldResourceAndDeleteMethod() = runBlocking {
+        var recordedMethod: HttpMethod? = null
+        var recordedPath: String? = null
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    recordedMethod = request.method
+                    recordedPath = request.url.encodedPath
+                    respond("", HttpStatusCode.OK)
+                }
+            }
+            defaultRequest { url("https://api.vrchat.cloud/api/1/") }
+        }
+
+        WorldsApi(client).deleteWorld("wrld_owned")
+
+        assertEquals(HttpMethod.Delete, recordedMethod)
+        assertEquals("/api/1/worlds/wrld_owned", recordedPath)
+        client.close()
+    }
+
+    @Test
+    fun deletionRejectsNonSuccessResponses() = runBlocking {
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    respond("not allowed", HttpStatusCode.Forbidden)
+                }
+            }
+            defaultRequest { url("https://api.vrchat.cloud/api/1/") }
+        }
+
+        val error = assertFailsWith<VRCApiException> {
+            WorldsApi(client).deleteWorld("wrld_other")
+        }
+
+        assertEquals(HttpStatusCode.Forbidden.value, error.code)
+        client.close()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldDeletionStateModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldDeletionStateModelTest.kt
@@ -1,0 +1,487 @@
+package io.github.vrcmteam.vrcm.presentation.screens.world
+
+import com.russhwolf.settings.MapSettings
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+import io.github.vrcmteam.vrcm.core.shared.AuthenticatedAccount
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
+import io.github.vrcmteam.vrcm.di.supports.PersistentCookiesStorage
+import io.github.vrcmteam.vrcm.network.api.auth.AuthApi
+import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
+import io.github.vrcmteam.vrcm.service.AuthService
+import io.github.vrcmteam.vrcm.service.SessionBoundResponse
+import io.github.vrcmteam.vrcm.service.data.AccountDto
+import io.github.vrcmteam.vrcm.storage.AccountCacheManager
+import io.github.vrcmteam.vrcm.storage.AccountDao
+import io.github.vrcmteam.vrcm.storage.InMemoryFriendListCacheStore
+import io.github.vrcmteam.vrcm.storage.InMemorySecureStorage
+import io.github.vrcmteam.vrcm.storage.InMemoryUserProfileCacheStore
+import io.github.vrcmteam.vrcm.storage.NoOpFriendActivityCacheStore
+import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardAssetStore
+import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardConfigDao
+import io.github.vrcmteam.vrcm.testing.MainDispatcherTest
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.MockRequestHandler
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.koin.core.logger.EmptyLogger
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WorldDeletionStateModelTest : MainDispatcherTest() {
+    @AfterTest
+    fun clearSession() = runTest { SharedFlowCentre.emitLogout() }
+
+    @Test
+    fun onlyTheCurrentOwnerCanStartDeletion() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val token = AccountSessionToken("usr_owner", 1)
+        val session = MutableStateFlow(authenticated(token))
+        val source = RecordingDeletionSource()
+        val model = WorldDeletionStateModel(
+            source = source,
+            scope = backgroundScope,
+            removeCachedWorld = {},
+            requestDispatcher = dispatcher,
+            sessionFlow = session,
+        )
+
+        model.setTarget("wrld_owned", "usr_other")
+
+        assertFalse(model.state.value.isAvailable)
+        assertFalse(model.delete())
+        assertTrue(source.calls.isEmpty())
+
+        model.setTarget("wrld_owned", "usr_owner")
+
+        assertTrue(model.state.value.canDelete)
+    }
+
+    @Test
+    fun duplicateSubmissionIsRejectedAndRemoteFailureAllowsRetry() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val token = AccountSessionToken("usr_owner", 1)
+        val session = MutableStateFlow(authenticated(token))
+        val pending = CompletableDeferred<SessionBoundResponse<Unit>?>()
+        val source = RecordingDeletionSource { _, _ -> pending.await() }
+        val notices = mutableListOf<WorldDeletionNotice>()
+        val model = WorldDeletionStateModel(
+            source = source,
+            scope = backgroundScope,
+            removeCachedWorld = {},
+            requestDispatcher = dispatcher,
+            sessionFlow = session,
+        )
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            model.notices.collect(notices::add)
+        }
+        model.setTarget("wrld_owned", "usr_owner")
+
+        assertTrue(model.delete())
+        assertFalse(model.delete())
+        runCurrent()
+
+        assertEquals(listOf("wrld_owned"), source.calls.map { it.second })
+        assertTrue(model.state.value.isDeleting)
+
+        pending.complete(
+            SessionBoundResponse(
+                result = Result.failure(IllegalStateException("offline")),
+                sessionToken = token,
+            )
+        )
+        runCurrent()
+
+        assertTrue(model.state.value.canDelete)
+        assertEquals(listOf<WorldDeletionNotice>(WorldDeletionNotice.Failed), notices)
+    }
+
+    @Test
+    fun successfulDeletionRemovesOnlyTheTargetCacheAndCannotBeRepeated() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val token = AccountSessionToken("usr_owner", 1)
+        val session = MutableStateFlow(authenticated(token))
+        val source = RecordingDeletionSource()
+        val removedWorlds = mutableListOf<String>()
+        val notices = mutableListOf<WorldDeletionNotice>()
+        val model = WorldDeletionStateModel(
+            source = source,
+            scope = backgroundScope,
+            removeCachedWorld = removedWorlds::add,
+            requestDispatcher = dispatcher,
+            sessionFlow = session,
+        )
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            model.notices.collect(notices::add)
+        }
+        model.setTarget("wrld_owned", "usr_owner")
+
+        assertTrue(model.delete())
+        runCurrent()
+
+        assertEquals(listOf("wrld_owned"), removedWorlds)
+        assertEquals(listOf<WorldDeletionNotice>(WorldDeletionNotice.Deleted()), notices)
+        assertTrue(model.state.value.isDeleted)
+        assertFalse(model.state.value.canDelete)
+        assertFalse(model.delete())
+        assertEquals(1, source.calls.size)
+
+        session.value = authenticated(AccountSessionToken("usr_other", 2))
+        runCurrent()
+        session.value = authenticated(AccountSessionToken("usr_owner", 3))
+        runCurrent()
+
+        assertTrue(model.state.value.isDeleted)
+        assertFalse(model.delete())
+        assertEquals(1, source.calls.size)
+    }
+
+    @Test
+    fun cacheFailureAfterRemoteSuccessStillExitsAsDeletedAndPreventsAnotherRequest() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val token = AccountSessionToken("usr_owner", 1)
+        val session = MutableStateFlow(authenticated(token))
+        val source = RecordingDeletionSource()
+        val notices = mutableListOf<WorldDeletionNotice>()
+        val model = WorldDeletionStateModel(
+            source = source,
+            scope = backgroundScope,
+            removeCachedWorld = { error("cache unavailable") },
+            requestDispatcher = dispatcher,
+            sessionFlow = session,
+        )
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            model.notices.collect(notices::add)
+        }
+        model.setTarget("wrld_owned", "usr_owner")
+
+        assertTrue(model.delete())
+        runCurrent()
+
+        assertEquals(
+            listOf<WorldDeletionNotice>(
+                WorldDeletionNotice.Deleted(cacheCleanupFailed = true)
+            ),
+            notices,
+        )
+        assertTrue(model.state.value.isDeleted)
+        assertFalse(model.state.value.canDelete)
+        assertFalse(model.delete())
+        assertEquals(1, source.calls.size)
+    }
+
+    @Test
+    fun sameAccountRenewalAcceptsTheExactResponseToken() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val firstToken = AccountSessionToken("usr_owner", 1)
+        val renewedToken = AccountSessionToken("usr_owner", 2)
+        val session = MutableStateFlow(authenticated(firstToken))
+        val removedWorlds = mutableListOf<String>()
+        val source = RecordingDeletionSource { _, _ ->
+            session.value = authenticated(renewedToken)
+            SessionBoundResponse(Result.success(Unit), renewedToken)
+        }
+        val model = WorldDeletionStateModel(
+            source = source,
+            scope = backgroundScope,
+            removeCachedWorld = removedWorlds::add,
+            requestDispatcher = dispatcher,
+            sessionFlow = session,
+        )
+        model.setTarget("wrld_owned", "usr_owner")
+
+        assertTrue(model.delete())
+        runCurrent()
+
+        assertEquals(listOf("wrld_owned"), removedWorlds)
+        assertTrue(model.state.value.isDeleted)
+    }
+
+    @Test
+    fun externalSameAccountTokenChangeUnlocksWhenTheOldResponseReturns() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val firstToken = AccountSessionToken("usr_owner", 1)
+        val renewedToken = AccountSessionToken("usr_owner", 2)
+        val session = MutableStateFlow(authenticated(firstToken))
+        val pending = CompletableDeferred<SessionBoundResponse<Unit>?>()
+        val source = RecordingDeletionSource { _, _ -> pending.await() }
+        val removedWorlds = mutableListOf<String>()
+        val notices = mutableListOf<WorldDeletionNotice>()
+        val model = WorldDeletionStateModel(
+            source = source,
+            scope = backgroundScope,
+            removeCachedWorld = removedWorlds::add,
+            requestDispatcher = dispatcher,
+            sessionFlow = session,
+        )
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            model.notices.collect(notices::add)
+        }
+        model.setTarget("wrld_owned", "usr_owner")
+        assertTrue(model.delete())
+        runCurrent()
+
+        session.value = authenticated(renewedToken)
+        runCurrent()
+        assertTrue(model.state.value.isDeleting)
+
+        pending.complete(SessionBoundResponse(Result.success(Unit), firstToken))
+        runCurrent()
+
+        assertFalse(model.state.value.isDeleting)
+        assertTrue(model.state.value.canDelete)
+        assertTrue(removedWorlds.isEmpty())
+        assertTrue(notices.isEmpty())
+    }
+
+    @Test
+    fun sameAccountTokenChangeDuringCacheCleanupKeepsTheDeletedCommitAndFinishes() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val firstToken = AccountSessionToken("usr_owner", 1)
+        val renewedToken = AccountSessionToken("usr_owner", 2)
+        val session = MutableStateFlow(authenticated(firstToken))
+        val cacheCleanup = CompletableDeferred<Unit>()
+        val source = RecordingDeletionSource()
+        val notices = mutableListOf<WorldDeletionNotice>()
+        val model = WorldDeletionStateModel(
+            source = source,
+            scope = backgroundScope,
+            removeCachedWorld = { cacheCleanup.await() },
+            requestDispatcher = dispatcher,
+            sessionFlow = session,
+        )
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            model.notices.collect(notices::add)
+        }
+        model.setTarget("wrld_owned", "usr_owner")
+
+        assertTrue(model.delete())
+        runCurrent()
+        assertTrue(model.state.value.isDeleted)
+        assertFalse(model.state.value.isDeleting)
+
+        session.value = authenticated(renewedToken)
+        runCurrent()
+
+        assertTrue(model.state.value.isDeleted)
+        assertFalse(model.delete())
+        cacheCleanup.complete(Unit)
+        runCurrent()
+
+        assertEquals(listOf<WorldDeletionNotice>(WorldDeletionNotice.Deleted()), notices)
+        assertTrue(model.state.value.isDeleted)
+        assertEquals(1, source.calls.size)
+    }
+
+    @Test
+    fun accountSwitchDiscardsLateSuccessWithoutCacheOrNotice() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val ownerToken = AccountSessionToken("usr_owner", 1)
+        val otherToken = AccountSessionToken("usr_other", 2)
+        val session = MutableStateFlow(authenticated(ownerToken))
+        val pending = CompletableDeferred<SessionBoundResponse<Unit>?>()
+        val source = RecordingDeletionSource { _, _ ->
+            withContext(NonCancellable) { pending.await() }
+        }
+        val removedWorlds = mutableListOf<String>()
+        val notices = mutableListOf<WorldDeletionNotice>()
+        val model = WorldDeletionStateModel(
+            source = source,
+            scope = backgroundScope,
+            removeCachedWorld = removedWorlds::add,
+            requestDispatcher = dispatcher,
+            sessionFlow = session,
+        )
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            model.notices.collect(notices::add)
+        }
+        model.setTarget("wrld_owned", "usr_owner")
+        assertTrue(model.delete())
+        runCurrent()
+
+        session.value = authenticated(otherToken)
+        runCurrent()
+        pending.complete(SessionBoundResponse(Result.success(Unit), ownerToken))
+        runCurrent()
+
+        assertFalse(model.state.value.isAvailable)
+        assertFalse(model.state.value.isDeleting)
+        assertTrue(removedWorlds.isEmpty())
+        assertTrue(notices.isEmpty())
+    }
+
+    @Test
+    fun unauthorizedRequestRenewsTheSameAccountAndReturnsTheCurrentToken() = runTest {
+        var deletionAttempts = 0
+        val account = cachedAccount()
+        val fixture = authFixture(account) { request ->
+            when (request.url.encodedPath) {
+                "/api/1/auth/user" -> jsonResponse(currentUserJson(account))
+                "/api/1/worlds/wrld_owned" -> {
+                    deletionAttempts++
+                    if (deletionAttempts == 1) {
+                        respond("expired", HttpStatusCode.Unauthorized)
+                    } else {
+                        respond("", HttpStatusCode.OK)
+                    }
+                }
+                else -> error("Unexpected request: ${request.url}")
+            }
+        }
+        try {
+            fixture.service.restoreAuth()
+            val firstSession = assertNotNull(SharedFlowCentre.currentSession.value)
+            val response = assertNotNull(
+                NetworkWorldDeletionSource(
+                    worldsApi = WorldsApi(fixture.client),
+                    authService = fixture.service,
+                ).delete(firstSession.token, "wrld_owned")
+            )
+
+            val renewedSession = assertNotNull(SharedFlowCentre.currentSession.value)
+            assertEquals(2, deletionAttempts)
+            assertEquals(firstSession.account.userId, renewedSession.account.userId)
+            assertNotEquals(firstSession.token, renewedSession.token)
+            assertEquals(renewedSession.token, response.sessionToken)
+            assertTrue(response.result.isSuccess)
+        } finally {
+            fixture.client.close()
+        }
+    }
+}
+
+private class RecordingDeletionSource(
+    private val handler: suspend (
+        AccountSessionToken,
+        String,
+    ) -> SessionBoundResponse<Unit>? = { token, _ ->
+        SessionBoundResponse(Result.success(Unit), token)
+    },
+) : WorldDeletionSource {
+    val calls = mutableListOf<Pair<AccountSessionToken, String>>()
+
+    override suspend fun delete(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+    ): SessionBoundResponse<Unit>? {
+        calls += sessionToken to worldId
+        return handler(sessionToken, worldId)
+    }
+}
+
+private fun authenticated(token: AccountSessionToken) = AuthenticatedAccount(
+    account = AccountDto(userId = token.userId),
+    token = token,
+)
+
+private data class DeletionAuthFixture(
+    val service: AuthService,
+    val client: HttpClient,
+)
+
+private fun authFixture(
+    account: AccountDto,
+    handler: MockRequestHandler,
+): DeletionAuthFixture {
+    val cookies = PersistentCookiesStorage(EmptyLogger())
+    val client = HttpClient(MockEngine) {
+        engine { addHandler(handler) }
+        defaultRequest { url("https://api.vrchat.cloud/api/1/") }
+        install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        install(HttpCookies) { storage = cookies }
+    }
+    val accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also {
+        it.saveAccountInfo(account)
+    }
+    val service = AuthService(
+        authApi = AuthApi(client),
+        accountDao = accountDao,
+        cookiesStorage = cookies,
+        accountCacheManager = AccountCacheManager(
+            friendListCacheStore = InMemoryFriendListCacheStore(),
+            userProfileCacheStore = InMemoryUserProfileCacheStore(),
+            friendActivityStore = NoOpFriendActivityCacheStore,
+            meetupCardConfigDao = MeetupCardConfigDao(MapSettings()),
+            meetupCardAssetStore = MeetupCardAssetStore(
+                FakeFileSystem(),
+                "/meetup-assets".toPath(),
+            ),
+        ),
+    )
+    return DeletionAuthFixture(service, client)
+}
+
+private fun cachedAccount() = AccountDto(
+    userId = "usr_owner",
+    username = "owner",
+    password = "owner-password",
+    current = true,
+    authCookie = "cached-auth",
+    twoFactorAuthCookie = "cached-2fa",
+)
+
+private fun MockRequestHandleScope.jsonResponse(body: String) = respond(
+    content = body,
+    status = HttpStatusCode.OK,
+    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+)
+
+private fun currentUserJson(account: AccountDto): String = """
+    {
+      "requiresTwoFactorAuth":null,
+      "ageVerificationStatus":"verified","ageVerified":true,
+      "acceptedPrivacyVersion":0,"acceptedTOSVersion":0,
+      "accountDeletionDate":null,"accountDeletionLog":null,"activeFriends":[],
+      "allowAvatarCopying":true,"bio":null,"bioLinks":[],
+      "currentAvatar":"","currentAvatarAssetUrl":null,"currentAvatarImageUrl":"",
+      "currentAvatarTags":[],"currentAvatarThumbnailImageUrl":"","date_joined":"",
+      "developerType":"none","displayName":"${account.username}","emailVerified":true,
+      "fallbackAvatar":"","friendGroupNames":[],"friendKey":"","friends":[],
+      "googleId":"","hasBirthday":true,"hasEmail":true,
+      "hasLoggedInFromClient":true,"hasPendingEmail":false,
+      "hideContentFilterSettings":false,"homeLocation":"","id":"${account.userId}",
+      "isFriend":false,"last_activity":"","last_login":"",
+      "last_platform":"standalonewindows","obfuscatedEmail":"",
+      "obfuscatedPendingEmail":"","oculusId":"","offlineFriends":[],
+      "onlineFriends":[],"pastDisplayNames":[],"picoId":"",
+      "presence":{
+        "avatarThumbnail":null,"displayName":"${account.username}","groups":[],
+        "id":"${account.userId}","instance":"","instanceType":"",
+        "isRejoining":null,"platform":"standalonewindows","profilePicOverride":null,
+        "status":"active","travelingToInstance":"","travelingToWorld":"","world":""
+      },
+      "profilePicOverride":"","state":"online","status":"active",
+      "statusDescription":"","statusFirstTime":false,"statusHistory":[],
+      "steamDetails":{},"steamId":"","tags":[],"twoFactorAuthEnabled":false,
+      "twoFactorAuthEnabledDate":null,"unsubscribe":false,"updated_at":"",
+      "userIcon":"","userLanguage":null,"userLanguageCode":null,
+      "username":"${account.username}","viveId":"","pronouns":null
+    }
+""".trimIndent()

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldProfileScreenModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldProfileScreenModelTest.kt
@@ -65,6 +65,7 @@ class WorldProfileScreenModelTest : MainDispatcherTest() {
         val getStarted = CompletableDeferred<Unit>()
         val releaseGet = CompletableDeferred<Unit>()
         val updatedWorld = testWorld(name = "late response")
+        var worldGetCount = 0
         val fixture = worldProfileFixture { request ->
             when {
                 request.url.encodedPath == "/api/1/auth/user" ->
@@ -72,6 +73,7 @@ class WorldProfileScreenModelTest : MainDispatcherTest() {
 
                 request.method == HttpMethod.Get &&
                     request.url.encodedPath == "/api/1/worlds/wrld_owned" -> {
+                    worldGetCount++
                     getStarted.complete(Unit)
                     releaseGet.await()
                     jsonResponse(Json.encodeToString(WorldData.serializer(), updatedWorld))
@@ -111,12 +113,14 @@ class WorldProfileScreenModelTest : MainDispatcherTest() {
             assertTrue(model.isLoading.value)
 
             assertTrue(model.deleteWorld())
+            model.refreshWorldData()
             releaseGet.complete(Unit)
             cache.deleted.await()
 
             assertTrue(cache.saved.isEmpty())
             assertEquals(listOf("wrld_owned"), cache.deletedWorlds)
             assertEquals("cached", model.worldProfileState.value?.worldName)
+            assertEquals(1, worldGetCount)
         } finally {
             fixture.client.close()
         }

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldProfileScreenModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldProfileScreenModelTest.kt
@@ -1,0 +1,255 @@
+package io.github.vrcmteam.vrcm.presentation.screens.world
+
+import com.russhwolf.settings.MapSettings
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
+import io.github.vrcmteam.vrcm.di.supports.PersistentCookiesStorage
+import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
+import io.github.vrcmteam.vrcm.network.api.files.FileApi
+import io.github.vrcmteam.vrcm.network.api.groups.GroupsApi
+import io.github.vrcmteam.vrcm.network.api.instances.InstancesApi
+import io.github.vrcmteam.vrcm.network.api.invite.InviteApi
+import io.github.vrcmteam.vrcm.network.api.users.UsersApi
+import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
+import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
+import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntrySource
+import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
+import io.github.vrcmteam.vrcm.service.AuthService
+import io.github.vrcmteam.vrcm.service.data.AccountDto
+import io.github.vrcmteam.vrcm.service.WorldPlatformService
+import io.github.vrcmteam.vrcm.storage.AccountCacheManager
+import io.github.vrcmteam.vrcm.storage.AccountDao
+import io.github.vrcmteam.vrcm.storage.WorldProfileCacheStore
+import io.github.vrcmteam.vrcm.storage.data.WorldProfileCache
+import io.github.vrcmteam.vrcm.storage.InMemoryFriendListCacheStore
+import io.github.vrcmteam.vrcm.storage.InMemorySecureStorage
+import io.github.vrcmteam.vrcm.storage.InMemoryUserProfileCacheStore
+import io.github.vrcmteam.vrcm.storage.NoOpFriendActivityCacheStore
+import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardAssetStore
+import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardConfigDao
+import io.github.vrcmteam.vrcm.testing.MainDispatcherTest
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.MockRequestHandler
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.koin.core.logger.EmptyLogger
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WorldProfileScreenModelTest : MainDispatcherTest() {
+    @AfterTest
+    fun clearSession() = runTest { SharedFlowCentre.emitLogout() }
+
+    @Test
+    fun deletionInvalidatesLateWorldRefreshBeforeItWritesCache() = runTest {
+        val getStarted = CompletableDeferred<Unit>()
+        val releaseGet = CompletableDeferred<Unit>()
+        val updatedWorld = testWorld(name = "late response")
+        val fixture = worldProfileFixture { request ->
+            when {
+                request.url.encodedPath == "/api/1/auth/user" ->
+                    jsonResponse(currentUserJson(cachedAccount()))
+
+                request.method == HttpMethod.Get &&
+                    request.url.encodedPath == "/api/1/worlds/wrld_owned" -> {
+                    getStarted.complete(Unit)
+                    releaseGet.await()
+                    jsonResponse(Json.encodeToString(WorldData.serializer(), updatedWorld))
+                }
+
+                request.method == HttpMethod.Delete &&
+                    request.url.encodedPath == "/api/1/worlds/wrld_owned" ->
+                    respond("", HttpStatusCode.OK)
+
+                else -> error("Unexpected request: ${request.method} ${request.url}")
+            }
+        }
+        val cache = RecordingWorldProfileCache(
+            cached = WorldProfileCache(
+                world = testWorld(name = "cached", instances = null),
+                cachedAtEpochMilliseconds = 0L,
+            ),
+        )
+        try {
+            fixture.service.restoreAuth()
+            val model = WorldProfileScreenModel(
+                worldsApi = WorldsApi(fixture.client),
+                instancesApi = InstancesApi(fixture.client),
+                usersApi = UsersApi(fixture.client),
+                groupsApi = GroupsApi(fixture.client),
+                authService = fixture.service,
+                favoriteEntrySource = EmptyFavoriteEntrySource(),
+                inviteApi = InviteApi(fixture.client),
+                worldPlatformService = WorldPlatformService(FileApi(fixture.client)),
+                worldProfileCacheStore = cache,
+            )
+
+            model.loadWorldData(WorldProfileVo(worldId = "wrld_owned", authorID = "usr_owner"))
+            assertFalse(model.deletionState.value.isAvailable)
+            getStarted.await()
+            assertTrue(model.deletionState.value.canDelete)
+            assertTrue(model.isLoading.value)
+
+            assertTrue(model.deleteWorld())
+            releaseGet.complete(Unit)
+            cache.deleted.await()
+
+            assertTrue(cache.saved.isEmpty())
+            assertEquals(listOf("wrld_owned"), cache.deletedWorlds)
+            assertEquals("cached", model.worldProfileState.value?.worldName)
+        } finally {
+            fixture.client.close()
+        }
+    }
+}
+
+private class EmptyFavoriteEntrySource : FavoriteEntrySource {
+    private val groups = MutableStateFlow(emptyMap<io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteGroupData, List<io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteData>>())
+
+    override fun favoritesByGroup(type: FavoriteType): StateFlow<Map<io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteGroupData, List<io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteData>>> = groups
+
+    override suspend fun load(type: FavoriteType): Result<Unit> = Result.success(Unit)
+}
+
+private class RecordingWorldProfileCache(
+    private val cached: WorldProfileCache?,
+) : WorldProfileCacheStore {
+    val saved = mutableListOf<WorldProfileCache>()
+    val deletedWorlds = mutableListOf<String>()
+    val deleted = CompletableDeferred<Unit>()
+
+    override suspend fun load(worldId: String): WorldProfileCache? = cached
+
+    override suspend fun save(cache: WorldProfileCache) {
+        saved += cache
+    }
+
+    override suspend fun delete(worldId: String) {
+        deletedWorlds += worldId
+        deleted.complete(Unit)
+    }
+
+    override suspend fun clearAll() = Unit
+}
+
+private data class WorldProfileFixture(
+    val service: AuthService,
+    val client: HttpClient,
+)
+
+private fun worldProfileFixture(handler: MockRequestHandler): WorldProfileFixture {
+    val cookies = PersistentCookiesStorage(EmptyLogger())
+    val client = HttpClient(MockEngine) {
+        engine { addHandler(handler) }
+        defaultRequest { url("https://api.vrchat.cloud/api/1/") }
+        install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        install(HttpCookies) { storage = cookies }
+    }
+    val account = cachedAccount()
+    val accountDao = AccountDao(MapSettings(), InMemorySecureStorage()).also { it.saveAccountInfo(account) }
+    val service = AuthService(
+        authApi = io.github.vrcmteam.vrcm.network.api.auth.AuthApi(client),
+        accountDao = accountDao,
+        cookiesStorage = cookies,
+        accountCacheManager = AccountCacheManager(
+            friendListCacheStore = InMemoryFriendListCacheStore(),
+            userProfileCacheStore = InMemoryUserProfileCacheStore(),
+            friendActivityStore = NoOpFriendActivityCacheStore,
+            meetupCardConfigDao = MeetupCardConfigDao(MapSettings()),
+            meetupCardAssetStore = MeetupCardAssetStore(FakeFileSystem(), "/meetup-assets".toPath()),
+        ),
+    )
+    return WorldProfileFixture(service, client)
+}
+
+private fun testWorld(
+    name: String,
+    instances: List<List<String>>? = emptyList(),
+) = WorldData(
+    authorId = "usr_owner",
+    authorName = "owner",
+    capacity = 16,
+    createdAt = "2026-01-01T00:00:00.000Z",
+    description = name,
+    favorites = 0,
+    featured = false,
+    heat = 0,
+    id = "wrld_owned",
+    imageUrl = "",
+    labsPublicationDate = "2026-01-01T00:00:00.000Z",
+    name = name,
+    namespace = null,
+    organization = "vrchat",
+    popularity = 0,
+    publicationDate = "2026-01-01T00:00:00.000Z",
+    recommendedCapacity = 16,
+    releaseStatus = "public",
+    tags = emptyList(),
+    thumbnailImageUrl = null,
+    udonProducts = emptyList(),
+    unityPackages = emptyList(),
+    instances = instances,
+    updatedAt = "2026-01-01T00:00:00.000Z",
+    version = 1,
+    visits = 0,
+)
+
+private fun cachedAccount() = AccountDto(
+    userId = "usr_owner",
+    username = "owner",
+    password = "owner-password",
+    current = true,
+    authCookie = "cached-auth",
+    twoFactorAuthCookie = "cached-2fa",
+)
+
+private fun MockRequestHandleScope.jsonResponse(body: String) = respond(
+    content = body,
+    status = HttpStatusCode.OK,
+    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+)
+
+private fun currentUserJson(account: AccountDto): String = """
+    {
+      "requiresTwoFactorAuth":null,"ageVerificationStatus":"verified","ageVerified":true,
+      "acceptedPrivacyVersion":0,"acceptedTOSVersion":0,"accountDeletionDate":null,
+      "accountDeletionLog":null,"activeFriends":[],"allowAvatarCopying":true,"bio":null,
+      "bioLinks":[],"currentAvatar":"","currentAvatarAssetUrl":null,"currentAvatarImageUrl":"",
+      "currentAvatarTags":[],"currentAvatarThumbnailImageUrl":"","date_joined":"",
+      "developerType":"none","displayName":"${account.username}","emailVerified":true,
+      "fallbackAvatar":"","friendGroupNames":[],"friendKey":"","friends":[],"googleId":"",
+      "hasBirthday":true,"hasEmail":true,"hasLoggedInFromClient":true,"hasPendingEmail":false,
+      "hideContentFilterSettings":false,"homeLocation":"","id":"${account.userId}",
+      "isFriend":false,"last_activity":"","last_login":"","last_platform":"standalonewindows",
+      "obfuscatedEmail":"","obfuscatedPendingEmail":"","oculusId":"","offlineFriends":[],
+      "onlineFriends":[],"pastDisplayNames":[],"picoId":"","presence":{"avatarThumbnail":null,
+      "displayName":"${account.username}","groups":[],"id":"${account.userId}","instance":"",
+      "instanceType":"","isRejoining":null,"platform":"standalonewindows","profilePicOverride":null,
+      "status":"active","travelingToInstance":"","travelingToWorld":"","world":""},
+      "profilePicOverride":"","state":"online","status":"active","statusDescription":"",
+      "statusFirstTime":false,"statusHistory":[],"steamDetails":{},"steamId":"","tags":[],
+      "twoFactorAuthEnabled":false,"twoFactorAuthEnabledDate":null,"unsubscribe":false,"updated_at":"",
+      "userIcon":"","userLanguage":null,"userLanguageCode":null,"username":"${account.username}",
+      "viveId":"","pronouns":null
+    }
+""".trimIndent()

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldProfileScreenModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldProfileScreenModelTest.kt
@@ -1,5 +1,6 @@
 package io.github.vrcmteam.vrcm.presentation.screens.world
 
+import androidx.lifecycle.ViewModelStore
 import com.russhwolf.settings.MapSettings
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.di.supports.PersistentCookiesStorage
@@ -92,9 +93,10 @@ class WorldProfileScreenModelTest : MainDispatcherTest() {
                 cachedAtEpochMilliseconds = 0L,
             ),
         )
+        var model: WorldProfileScreenModel? = null
         try {
             fixture.service.restoreAuth()
-            val model = WorldProfileScreenModel(
+            model = WorldProfileScreenModel(
                 worldsApi = WorldsApi(fixture.client),
                 instancesApi = InstancesApi(fixture.client),
                 usersApi = UsersApi(fixture.client),
@@ -105,23 +107,30 @@ class WorldProfileScreenModelTest : MainDispatcherTest() {
                 worldPlatformService = WorldPlatformService(FileApi(fixture.client)),
                 worldProfileCacheStore = cache,
             )
+            val screenModel = requireNotNull(model)
 
-            model.loadWorldData(WorldProfileVo(worldId = "wrld_owned", authorID = "usr_owner"))
-            assertFalse(model.deletionState.value.isAvailable)
+            screenModel.loadWorldData(WorldProfileVo(worldId = "wrld_owned", authorID = "usr_owner"))
+            assertFalse(screenModel.deletionState.value.isAvailable)
             getStarted.await()
-            assertTrue(model.deletionState.value.canDelete)
-            assertTrue(model.isLoading.value)
+            assertTrue(screenModel.deletionState.value.canDelete)
+            assertTrue(screenModel.isLoading.value)
 
-            assertTrue(model.deleteWorld())
-            model.refreshWorldData()
+            assertTrue(screenModel.deleteWorld())
+            screenModel.refreshWorldData()
             releaseGet.complete(Unit)
             cache.deleted.await()
 
             assertTrue(cache.saved.isEmpty())
             assertEquals(listOf("wrld_owned"), cache.deletedWorlds)
-            assertEquals("cached", model.worldProfileState.value?.worldName)
+            assertEquals("cached", screenModel.worldProfileState.value?.worldName)
             assertEquals(1, worldGetCount)
         } finally {
+            model?.let {
+                ViewModelStore().apply {
+                    put("world-profile", it)
+                    clear()
+                }
+            }
             fixture.client.close()
         }
     }


### PR DESCRIPTION
## 功能说明

- 在世界详情页为当前作者提供删除入口，并用二次确认明确隐藏状态、关联文件不可恢复以及 ID 永久保留。
- 通过已认证会话调用世界删除接口；成功后清理对应世界详情缓存并安全返回上一页。
- 对重复提交、接口失败、缓存清理失败、令牌续期和账号切换提供确定的状态处理。
- 补齐英文、日文、简体中文和繁体中文文案，并增加接口契约与状态转换测试。

## 实现假设清单

- 世界详情返回的作者 ID 是所有权判断的可信字段，且必须与当前有效会话的用户 ID 完全一致。
- 删除接口成功后远端状态不可逆，因此在本地缓存清理前先提交“已删除”终态，避免重复请求。
- 同账号认证续期可以接受认证流程返回的新会话令牌；账号切换后迟到的响应不得触发缓存清理、提示或导航。
- 本地缓存清理失败不改变远端删除结果，应用应退出详情页并给出差异化提示。
- 删除入口仅依赖现有认证、网络、缓存和导航能力，不引入额外平台权限。
- 路由快照可能来自列表、活动记录或房间事件，只有世界详情缓存或 getWorldById 返回的作者 ID 才能用于所有权判断。
- 初始缓存读取和详情刷新共享一个可取消的加载任务；删除开始时提升加载代次并取消该任务，迟到结果不得更新页面或缓存。
- 世界详情缓存的保存与删除通过同一互斥锁串行化，删除完成后不会被并发的旧刷新重新写回。

## 代码逻辑图

```mermaid
flowchart TD
    A[路由快照进入 WorldProfileScreenModel] --> B[清空删除目标并启动世界加载代次]
    B --> C[挂起读取世界详情缓存]
    C --> D{加载代次仍有效且未开始删除}
    D -- 否 --> E[丢弃迟到缓存结果]
    D -- 是且缓存可信 --> F[回填详情并设置缓存作者为删除目标]
    D -- 是且缓存缺失/过期 --> G[getWorldById]
    F --> H{缓存是否需要详情刷新}
    H -- 否 --> I[加载缓存实例]
    H -- 是 --> G
    G --> J[在缓存互斥锁内再次校验代次]
    J -- 失效 --> K[不写缓存和页面状态]
    J -- 有效 --> L[保存详情缓存并更新页面与删除目标]
    L --> I
    M[用户确认删除] --> N[提升加载代次并取消加载任务]
    N --> O[锁定重复操作并调用 DELETE /worlds/{worldId}]
    O --> P{响应属于当前目标和有效会话}
    P -- 否 --> Q[丢弃迟到响应并恢复可用状态]
    P -- 是且失败 --> R[保留确认框并允许重试]
    P -- 是且成功 --> S[提交已删除终态]
    S --> T[在缓存互斥锁内删除详情缓存]
    T --> U{缓存清理成功}
    U -- 是 --> V[成功提示]
    U -- 否 --> W[远端成功但缓存清理失败提示]
    V --> X[仅当详情页仍在栈顶时返回]
    W --> X
```

## 验证

- `.\gradlew.bat :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.network.api.worlds.WorldsApiDeletionTest" --tests "io.github.vrcmteam.vrcm.presentation.screens.world.WorldDeletionStateModelTest" --tests "io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStringsStructureTest"`：通过。
- `.\gradlew.bat :composeApp:compileKotlinDesktop`：通过。
- `.\gradlew.bat :composeApp:desktopTest --rerun-tasks`：新增后共 813 项，1 项既有失败；未修改的 `upstream/newui` 同命令共 802 项，也在同一 `MeetupCardScreenModelTest.shortTextRejectsMoreThanEightyCodePointsWithoutPersisting` 失败。底层异常均为收藏限额响应 `[]` 无法反序列化为对象。
- `git diff --check`：通过。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:compileKotlinDesktop`：通过。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.network.api.worlds.WorldsApiDeletionTest" --tests "io.github.vrcmteam.vrcm.presentation.screens.world.WorldDeletionStateModelTest" --tests "io.github.vrcmteam.vrcm.presentation.screens.world.WorldProfileScreenModelTest" --tests "io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStringsStructureTest"`：通过。
