### PR TITLE
feat(world): 添加实例关闭功能

### DIFF
--- a/composeApp/src/commonMain/kotlin/network/api/instances/InstancesApi.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/instances/InstancesApi.kt
@@ -23,6 +23,15 @@ class InstancesApi(private val client: HttpClient) {
     }
 
     /**
+     * 立即关闭实例。
+     */
+    suspend fun closeInstance(worldId: String, instanceId: String): InstanceData {
+        val location = "$worldId:$instanceId"
+        return client.delete { url { path(INSTANCES_API_SUFFIX, location) } }
+            .checkSuccess()
+    }
+
+    /**
      * 创建世界实例
      *
      * @param worldId 世界ID

--- a/composeApp/src/commonMain/kotlin/network/api/instances/InstancesApi.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/instances/InstancesApi.kt
@@ -6,6 +6,7 @@ import io.github.vrcmteam.vrcm.network.api.attributes.AccessType.*
 import io.github.vrcmteam.vrcm.network.api.attributes.INSTANCES_API_SUFFIX
 import io.github.vrcmteam.vrcm.network.api.attributes.RegionType
 import io.github.vrcmteam.vrcm.network.api.instances.data.CreateInstanceRequest
+import io.github.vrcmteam.vrcm.network.api.instances.data.InstanceCloseResponse
 import io.github.vrcmteam.vrcm.network.api.instances.data.InstanceData
 import io.github.vrcmteam.vrcm.network.extensions.checkSuccess
 import io.ktor.client.*
@@ -22,10 +23,17 @@ class InstancesApi(private val client: HttpClient) {
             .checkSuccess()
     }
 
+    /** 获取关闭流程使用的实例快照，保留协议中可选字段的缺失状态。 */
+    suspend fun closeStatus(worldId: String, instanceId: String): InstanceCloseResponse {
+        val location = "$worldId:$instanceId"
+        return client.get { url { path(INSTANCES_API_SUFFIX, location) } }
+            .checkSuccess()
+    }
+
     /**
      * 立即关闭实例。
      */
-    suspend fun closeInstance(worldId: String, instanceId: String): InstanceData {
+    suspend fun closeInstance(worldId: String, instanceId: String): InstanceCloseResponse {
         val location = "$worldId:$instanceId"
         return client.delete { url { path(INSTANCES_API_SUFFIX, location) } }
             .checkSuccess()

--- a/composeApp/src/commonMain/kotlin/network/api/instances/data/InstanceCloseResponse.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/instances/data/InstanceCloseResponse.kt
@@ -1,0 +1,44 @@
+package io.github.vrcmteam.vrcm.network.api.instances.data
+
+import io.github.vrcmteam.vrcm.network.api.attributes.RegionType
+import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** Instance snapshot returned by the close endpoint, including its contract-optional fields. */
+@Serializable
+data class InstanceCloseResponse(
+    val active: Boolean? = null,
+    val canRequestInvite: Boolean? = null,
+    val capacity: Int? = null,
+    val clientNumber: String,
+    val closedAt: String? = null,
+    val displayName: String? = null,
+    val full: Boolean,
+    val gameServerVersion: Int? = null,
+    val hardClose: Boolean? = null,
+    val hasCapacityForYou: Boolean? = null,
+    val hidden: String? = null,
+    val id: String,
+    val instanceId: String,
+    val location: String,
+    @SerialName("n_users")
+    val nUsers: Int,
+    val name: String,
+    val ownerId: String? = null,
+    val permanent: Boolean,
+    val photonRegion: String,
+    val platforms: Platforms,
+    val queueEnabled: Boolean,
+    val queueSize: Int,
+    val recommendedCapacity: Int,
+    val region: RegionType,
+    val secureName: String,
+    val shortName: String? = null,
+    val strict: Boolean,
+    val tags: List<String>,
+    val type: String,
+    val userCount: Int,
+    val world: WorldData,
+    val worldId: String,
+)

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/InstanceCloseCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/InstanceCloseCoordinator.kt
@@ -1,0 +1,319 @@
+package io.github.vrcmteam.vrcm.presentation.screens.world
+
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+import io.github.vrcmteam.vrcm.network.api.attributes.BlueprintType
+import io.github.vrcmteam.vrcm.network.api.instances.data.InstanceData
+import io.github.vrcmteam.vrcm.presentation.screens.world.data.InstanceVo
+import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal const val GROUP_INSTANCE_MANAGE_PERMISSION = "group-instance-manage"
+
+internal data class InstanceCloseTarget(
+    val worldId: String,
+    val instanceId: String,
+    val ownerId: String,
+) {
+    val location: String = "$worldId:$instanceId"
+}
+
+internal data class InstanceCloseRequest(
+    val target: InstanceCloseTarget,
+    val sessionToken: AccountSessionToken,
+)
+
+internal sealed interface InstanceCloseState {
+    data object Idle : InstanceCloseState
+    data class Authorizing(val request: InstanceCloseRequest) : InstanceCloseState
+    data class AwaitingConfirmation(val request: InstanceCloseRequest) : InstanceCloseState
+    data class Submitting(val request: InstanceCloseRequest) : InstanceCloseState
+}
+
+internal val InstanceCloseState.requestOrNull: InstanceCloseRequest?
+    get() = when (this) {
+        InstanceCloseState.Idle -> null
+        is InstanceCloseState.Authorizing -> request
+        is InstanceCloseState.AwaitingConfirmation -> request
+        is InstanceCloseState.Submitting -> request
+    }
+
+internal data class InstanceCloseSessionResult<T>(
+    val result: Result<T>,
+    val sessionToken: AccountSessionToken,
+)
+
+internal class InstanceCloseResponseMismatchException : IllegalStateException()
+
+internal sealed interface InstanceCloseAuthorizationResult {
+    data object Ready : InstanceCloseAuthorizationResult
+    data object Busy : InstanceCloseAuthorizationResult
+    data object Abandoned : InstanceCloseAuthorizationResult
+    data object NotAllowed : InstanceCloseAuthorizationResult
+    data class SessionChanged(val userId: String?) : InstanceCloseAuthorizationResult
+    data class Failed(val error: Throwable) : InstanceCloseAuthorizationResult
+}
+
+internal sealed interface InstanceCloseSubmissionResult {
+    data class Closed(
+        val request: InstanceCloseRequest,
+        val instance: InstanceData,
+    ) : InstanceCloseSubmissionResult
+    data object Busy : InstanceCloseSubmissionResult
+    data object Abandoned : InstanceCloseSubmissionResult
+    data class SessionChanged(val userId: String) : InstanceCloseSubmissionResult
+    data class Failed(val error: Throwable) : InstanceCloseSubmissionResult
+}
+
+/** Coordinates permission checks and submission without letting responses cross account sessions. */
+internal class InstanceCloseCoordinator(
+    private val currentSessionToken: () -> AccountSessionToken?,
+    private val isCurrentSession: (AccountSessionToken) -> Boolean,
+    private val fetchGroupPermissions: suspend (
+        AccountSessionToken,
+        String,
+    ) -> InstanceCloseSessionResult<List<String>>?,
+    private val closeInstance: suspend (
+        AccountSessionToken,
+        InstanceCloseTarget,
+    ) -> InstanceCloseSessionResult<InstanceData>?,
+) {
+    private val _state = MutableStateFlow<InstanceCloseState>(InstanceCloseState.Idle)
+    val state: StateFlow<InstanceCloseState> = _state.asStateFlow()
+
+    suspend fun authorize(target: InstanceCloseTarget): InstanceCloseAuthorizationResult {
+        val token = currentSessionToken()
+            ?: return InstanceCloseAuthorizationResult.SessionChanged(userId = null)
+        val request = InstanceCloseRequest(target, token)
+        val authorizing = InstanceCloseState.Authorizing(request)
+        if (!_state.compareAndSet(InstanceCloseState.Idle, authorizing)) {
+            return InstanceCloseAuthorizationResult.Busy
+        }
+
+        if (!isCurrentSession(token)) {
+            return finishAuthorization(
+                authorizing,
+                InstanceCloseState.Idle,
+                InstanceCloseAuthorizationResult.SessionChanged(token.userId),
+            )
+        }
+
+        return when (target.ownerId.blueprintTypeOrNull()) {
+            BlueprintType.User -> authorizePersonalInstance(authorizing)
+            BlueprintType.Group -> authorizeGroupInstance(authorizing)
+            else -> finishAuthorization(
+                authorizing,
+                InstanceCloseState.Idle,
+                InstanceCloseAuthorizationResult.NotAllowed,
+            )
+        }
+    }
+
+    private fun authorizePersonalInstance(
+        authorizing: InstanceCloseState.Authorizing,
+    ): InstanceCloseAuthorizationResult {
+        val request = authorizing.request
+        if (request.target.ownerId != request.sessionToken.userId) {
+            return finishAuthorization(
+                authorizing,
+                InstanceCloseState.Idle,
+                InstanceCloseAuthorizationResult.NotAllowed,
+            )
+        }
+        if (!isCurrentSession(request.sessionToken)) {
+            return finishAuthorization(
+                authorizing,
+                InstanceCloseState.Idle,
+                InstanceCloseAuthorizationResult.SessionChanged(request.sessionToken.userId),
+            )
+        }
+        return finishAuthorization(
+            authorizing,
+            InstanceCloseState.AwaitingConfirmation(request),
+            InstanceCloseAuthorizationResult.Ready,
+        )
+    }
+
+    private suspend fun authorizeGroupInstance(
+        authorizing: InstanceCloseState.Authorizing,
+    ): InstanceCloseAuthorizationResult {
+        val request = authorizing.request
+        val response = try {
+            fetchGroupPermissions(request.sessionToken, request.target.ownerId)
+        } catch (cancellation: CancellationException) {
+            _state.compareAndSet(authorizing, InstanceCloseState.Idle)
+            throw cancellation
+        } catch (error: Throwable) {
+            return finishAuthorization(
+                authorizing,
+                InstanceCloseState.Idle,
+                InstanceCloseAuthorizationResult.Failed(error),
+            )
+        } ?: return finishAuthorization(
+            authorizing,
+            InstanceCloseState.Idle,
+            InstanceCloseAuthorizationResult.SessionChanged(request.sessionToken.userId),
+        )
+
+        if (response.sessionToken.userId != request.sessionToken.userId ||
+            !isCurrentSession(response.sessionToken)
+        ) {
+            return finishAuthorization(
+                authorizing,
+                InstanceCloseState.Idle,
+                InstanceCloseAuthorizationResult.SessionChanged(request.sessionToken.userId),
+            )
+        }
+
+        val permissions = response.result.getOrElse { error ->
+            return finishAuthorization(
+                authorizing,
+                InstanceCloseState.Idle,
+                InstanceCloseAuthorizationResult.Failed(error),
+            )
+        }
+        if (GROUP_INSTANCE_MANAGE_PERMISSION !in permissions && "*" !in permissions) {
+            return finishAuthorization(
+                authorizing,
+                InstanceCloseState.Idle,
+                InstanceCloseAuthorizationResult.NotAllowed,
+            )
+        }
+
+        val refreshedRequest = request.copy(sessionToken = response.sessionToken)
+        return finishAuthorization(
+            authorizing,
+            InstanceCloseState.AwaitingConfirmation(refreshedRequest),
+            InstanceCloseAuthorizationResult.Ready,
+        )
+    }
+
+    suspend fun submit(): InstanceCloseSubmissionResult {
+        val awaiting = _state.value as? InstanceCloseState.AwaitingConfirmation
+            ?: return InstanceCloseSubmissionResult.Busy
+        val submitting = InstanceCloseState.Submitting(awaiting.request)
+        if (!_state.compareAndSet(awaiting, submitting)) return InstanceCloseSubmissionResult.Busy
+
+        val request = submitting.request
+        if (!isCurrentSession(request.sessionToken)) {
+            _state.compareAndSet(submitting, InstanceCloseState.Idle)
+            return InstanceCloseSubmissionResult.SessionChanged(request.sessionToken.userId)
+        }
+
+        val response = try {
+            closeInstance(request.sessionToken, request.target)
+        } catch (cancellation: CancellationException) {
+            _state.compareAndSet(submitting, InstanceCloseState.Idle)
+            throw cancellation
+        } catch (error: Throwable) {
+            _state.compareAndSet(submitting, InstanceCloseState.AwaitingConfirmation(request))
+            return InstanceCloseSubmissionResult.Failed(error)
+        } ?: run {
+            _state.compareAndSet(submitting, InstanceCloseState.Idle)
+            return InstanceCloseSubmissionResult.SessionChanged(request.sessionToken.userId)
+        }
+
+        if (response.sessionToken.userId != request.sessionToken.userId ||
+            !isCurrentSession(response.sessionToken)
+        ) {
+            _state.compareAndSet(submitting, InstanceCloseState.Idle)
+            return InstanceCloseSubmissionResult.SessionChanged(request.sessionToken.userId)
+        }
+
+        val refreshedRequest = request.copy(sessionToken = response.sessionToken)
+        val closedInstance = response.result.getOrElse { error ->
+            _state.compareAndSet(
+                submitting,
+                InstanceCloseState.AwaitingConfirmation(refreshedRequest),
+            )
+            return InstanceCloseSubmissionResult.Failed(error)
+        }
+        if (closedInstance.worldId != request.target.worldId ||
+            closedInstance.instanceId != request.target.instanceId ||
+            closedInstance.location != request.target.location
+        ) {
+            _state.compareAndSet(
+                submitting,
+                InstanceCloseState.AwaitingConfirmation(refreshedRequest),
+            )
+            return InstanceCloseSubmissionResult.Failed(
+                InstanceCloseResponseMismatchException(),
+            )
+        }
+
+        return if (_state.compareAndSet(submitting, InstanceCloseState.Idle)) {
+            InstanceCloseSubmissionResult.Closed(refreshedRequest, closedInstance)
+        } else {
+            InstanceCloseSubmissionResult.Abandoned
+        }
+    }
+
+    /** Only an idle confirmation can be invalidated immediately by an unrelated session change. */
+    fun onSessionChanged(sessionToken: AccountSessionToken?) {
+        while (true) {
+            val awaiting = _state.value as? InstanceCloseState.AwaitingConfirmation ?: return
+            if (awaiting.request.sessionToken == sessionToken) return
+            if (_state.compareAndSet(awaiting, InstanceCloseState.Idle)) return
+        }
+    }
+
+    fun abandon(location: String) {
+        while (true) {
+            val current = _state.value
+            val canAbandon = current is InstanceCloseState.Authorizing ||
+                current is InstanceCloseState.AwaitingConfirmation
+            if (!canAbandon || current.requestOrNull?.target?.location != location) return
+            if (_state.compareAndSet(current, InstanceCloseState.Idle)) return
+        }
+    }
+
+    private fun finishAuthorization(
+        expected: InstanceCloseState.Authorizing,
+        next: InstanceCloseState,
+        result: InstanceCloseAuthorizationResult,
+    ): InstanceCloseAuthorizationResult =
+        if (_state.compareAndSet(expected, next)) result else InstanceCloseAuthorizationResult.Abandoned
+}
+
+internal fun InstanceVo.closeTargetOrNull(): InstanceCloseTarget? {
+    if (worldId.isBlank() || instanceId.isBlank() || ownerId.isNullOrBlank()) return null
+    val target = InstanceCloseTarget(
+        worldId = worldId,
+        instanceId = instanceId,
+        ownerId = ownerId,
+    )
+    return target.takeIf { location == target.location }
+}
+
+internal fun InstanceVo.canOfferInstanceClose(sessionToken: AccountSessionToken?): Boolean {
+    val target = closeTargetOrNull() ?: return false
+    return when (target.ownerId.blueprintTypeOrNull()) {
+        BlueprintType.User -> target.ownerId == sessionToken?.userId
+        BlueprintType.Group -> sessionToken != null
+        else -> false
+    }
+}
+
+internal fun WorldProfileVo.applyInstanceCloseResponse(
+    target: InstanceCloseTarget,
+    response: InstanceData,
+): WorldProfileVo {
+    if (worldId != target.worldId) return this
+    val updatedInstances = if (!response.active || response.closedAt != null) {
+        instances.filterNot { it.location == target.location }
+    } else {
+        instances.map { current ->
+            if (current.location == target.location) {
+                InstanceVo(response, current.owner)
+            } else {
+                current
+            }
+        }
+    }
+    return copy(instances = updatedInstances)
+}
+
+private fun String.blueprintTypeOrNull(): BlueprintType? =
+    runCatching { BlueprintType.fromValue(this) }.getOrNull()

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/InstanceCloseCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/InstanceCloseCoordinator.kt
@@ -2,9 +2,9 @@ package io.github.vrcmteam.vrcm.presentation.screens.world
 
 import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
 import io.github.vrcmteam.vrcm.network.api.attributes.BlueprintType
-import io.github.vrcmteam.vrcm.network.api.instances.data.InstanceData
+import io.github.vrcmteam.vrcm.network.api.instances.data.InstanceCloseResponse
+import io.github.vrcmteam.vrcm.network.supports.VRCApiException
 import io.github.vrcmteam.vrcm.presentation.screens.world.data.InstanceVo
-import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -59,7 +59,7 @@ internal sealed interface InstanceCloseAuthorizationResult {
 internal sealed interface InstanceCloseSubmissionResult {
     data class Closed(
         val request: InstanceCloseRequest,
-        val instance: InstanceData,
+        val instance: InstanceCloseResponse,
     ) : InstanceCloseSubmissionResult
     data object Busy : InstanceCloseSubmissionResult
     data object Abandoned : InstanceCloseSubmissionResult
@@ -75,10 +75,14 @@ internal class InstanceCloseCoordinator(
         AccountSessionToken,
         String,
     ) -> InstanceCloseSessionResult<List<String>>?,
+    private val fetchInstance: suspend (
+        AccountSessionToken,
+        InstanceCloseTarget,
+    ) -> InstanceCloseSessionResult<InstanceCloseResponse>?,
     private val closeInstance: suspend (
         AccountSessionToken,
         InstanceCloseTarget,
-    ) -> InstanceCloseSessionResult<InstanceData>?,
+    ) -> InstanceCloseSessionResult<InstanceCloseResponse>?,
 ) {
     private val _state = MutableStateFlow<InstanceCloseState>(InstanceCloseState.Idle)
     val state: StateFlow<InstanceCloseState> = _state.asStateFlow()
@@ -224,31 +228,85 @@ internal class InstanceCloseCoordinator(
 
         val refreshedRequest = request.copy(sessionToken = response.sessionToken)
         val closedInstance = response.result.getOrElse { error ->
-            _state.compareAndSet(
-                submitting,
-                InstanceCloseState.AwaitingConfirmation(refreshedRequest),
-            )
-            return InstanceCloseSubmissionResult.Failed(error)
+            if (error is VRCApiException && error.code == 403) {
+                return verifyForbiddenClose(submitting, refreshedRequest, error)
+            }
+            return failSubmission(submitting, refreshedRequest, error)
         }
-        if (closedInstance.worldId != request.target.worldId ||
-            closedInstance.instanceId != request.target.instanceId ||
-            closedInstance.location != request.target.location
-        ) {
-            _state.compareAndSet(
+        if (!closedInstance.matches(request.target)) {
+            return failSubmission(
                 submitting,
-                InstanceCloseState.AwaitingConfirmation(refreshedRequest),
-            )
-            return InstanceCloseSubmissionResult.Failed(
+                refreshedRequest,
                 InstanceCloseResponseMismatchException(),
             )
         }
 
-        return if (_state.compareAndSet(submitting, InstanceCloseState.Idle)) {
-            InstanceCloseSubmissionResult.Closed(refreshedRequest, closedInstance)
+        return completeSubmission(submitting, refreshedRequest, closedInstance)
+    }
+
+    private suspend fun verifyForbiddenClose(
+        submitting: InstanceCloseState.Submitting,
+        request: InstanceCloseRequest,
+        originalError: VRCApiException,
+    ): InstanceCloseSubmissionResult {
+        val response = try {
+            fetchInstance(request.sessionToken, request.target)
+        } catch (cancellation: CancellationException) {
+            _state.compareAndSet(submitting, InstanceCloseState.Idle)
+            throw cancellation
+        } catch (_: Throwable) {
+            return failSubmission(submitting, request, originalError)
+        } ?: run {
+            _state.compareAndSet(submitting, InstanceCloseState.Idle)
+            return InstanceCloseSubmissionResult.SessionChanged(request.sessionToken.userId)
+        }
+
+        if (response.sessionToken.userId != request.sessionToken.userId ||
+            !isCurrentSession(response.sessionToken)
+        ) {
+            _state.compareAndSet(submitting, InstanceCloseState.Idle)
+            return InstanceCloseSubmissionResult.SessionChanged(request.sessionToken.userId)
+        }
+
+        val refreshedRequest = request.copy(sessionToken = response.sessionToken)
+        val instance = response.result.getOrElse {
+            return failSubmission(submitting, refreshedRequest, originalError)
+        }
+        if (!instance.matches(request.target)) {
+            return failSubmission(
+                submitting,
+                refreshedRequest,
+                InstanceCloseResponseMismatchException(),
+            )
+        }
+        if (!instance.isClosed) {
+            return failSubmission(submitting, refreshedRequest, originalError)
+        }
+        return completeSubmission(submitting, refreshedRequest, instance)
+    }
+
+    private fun failSubmission(
+        submitting: InstanceCloseState.Submitting,
+        request: InstanceCloseRequest,
+        error: Throwable,
+    ): InstanceCloseSubmissionResult {
+        _state.compareAndSet(
+            submitting,
+            InstanceCloseState.AwaitingConfirmation(request),
+        )
+        return InstanceCloseSubmissionResult.Failed(error)
+    }
+
+    private fun completeSubmission(
+        submitting: InstanceCloseState.Submitting,
+        request: InstanceCloseRequest,
+        response: InstanceCloseResponse,
+    ): InstanceCloseSubmissionResult =
+        if (_state.compareAndSet(submitting, InstanceCloseState.Idle)) {
+            InstanceCloseSubmissionResult.Closed(request, response)
         } else {
             InstanceCloseSubmissionResult.Abandoned
         }
-    }
 
     /** Only an idle confirmation can be invalidated immediately by an unrelated session change. */
     fun onSessionChanged(sessionToken: AccountSessionToken?) {
@@ -296,24 +354,8 @@ internal fun InstanceVo.canOfferInstanceClose(sessionToken: AccountSessionToken?
     }
 }
 
-internal fun WorldProfileVo.applyInstanceCloseResponse(
-    target: InstanceCloseTarget,
-    response: InstanceData,
-): WorldProfileVo {
-    if (worldId != target.worldId) return this
-    val updatedInstances = if (!response.active || response.closedAt != null) {
-        instances.filterNot { it.location == target.location }
-    } else {
-        instances.map { current ->
-            if (current.location == target.location) {
-                InstanceVo(response, current.owner)
-            } else {
-                current
-            }
-        }
-    }
-    return copy(instances = updatedInstances)
-}
-
 private fun String.blueprintTypeOrNull(): BlueprintType? =
     runCatching { BlueprintType.fromValue(this) }.getOrNull()
+
+private fun InstanceCloseResponse.matches(target: InstanceCloseTarget): Boolean =
+    worldId == target.worldId && instanceId == target.instanceId && location == target.location

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldInstanceStateStore.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldInstanceStateStore.kt
@@ -1,0 +1,174 @@
+package io.github.vrcmteam.vrcm.presentation.screens.world
+
+import io.github.vrcmteam.vrcm.network.api.attributes.AccessType
+import io.github.vrcmteam.vrcm.network.api.instances.data.InstanceCloseResponse
+import io.github.vrcmteam.vrcm.network.api.instances.data.InstanceData
+import io.github.vrcmteam.vrcm.presentation.screens.world.data.InstanceVo
+import io.github.vrcmteam.vrcm.presentation.screens.world.data.InstanceVo.Owner
+import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal data class LoadedInstanceOwner(
+    val ownerId: String?,
+    val owner: MutableStateFlow<Owner?>,
+)
+
+/** Serializes instance refresh commits with authoritative close results. */
+internal class WorldInstanceStateStore(
+    private val profileState: MutableStateFlow<WorldProfileVo?>,
+) {
+    private val commitMutex = Mutex()
+    private val locationRevisions = mutableMapOf<String, Long>()
+    private val closedLocations = mutableSetOf<String>()
+
+    suspend fun refreshInstance(
+        worldId: String,
+        instanceId: String,
+        initialOwner: Owner?,
+        fetch: suspend () -> InstanceData,
+    ): LoadedInstanceOwner? {
+        val location = "$worldId:$instanceId"
+        val expectedRevision = commitMutex.withLock { locationRevisions[location] ?: 0L }
+        val response = fetch()
+
+        return commitMutex.withLock {
+            if ((locationRevisions[location] ?: 0L) != expectedRevision ||
+                location in closedLocations
+            ) {
+                return@withLock null
+            }
+            if (response.worldId != worldId || response.instanceId != instanceId ||
+                response.location != location
+            ) {
+                return@withLock null
+            }
+            val profile = profileState.value?.takeIf { it.worldId == worldId }
+                ?: return@withLock null
+            if (!response.active || response.closedAt != null) {
+                closedLocations += location
+                profileState.value = profile.copy(
+                    instances = profile.instances.filterNot { it.location == location },
+                )
+                return@withLock null
+            }
+
+            val owner = MutableStateFlow(initialOwner)
+            val updated = profile.instances
+                .filterNot { it.id == response.id || it.location == location }
+                .plus(InstanceVo(response, owner))
+            profileState.value = profile.copy(instances = updated)
+            LoadedInstanceOwner(response.ownerId, owner)
+        }
+    }
+
+    suspend fun applyClose(
+        target: InstanceCloseTarget,
+        response: InstanceCloseResponse,
+        canCommit: () -> Boolean = { true },
+    ): Boolean = commitMutex.withLock {
+        if (!canCommit()) return@withLock false
+        val profile = profileState.value?.takeIf { it.worldId == target.worldId }
+            ?: return@withLock false
+        locationRevisions[target.location] = (locationRevisions[target.location] ?: 0L) + 1L
+        if (response.isClosed) {
+            closedLocations += target.location
+        }
+        profileState.value = profile.applyInstanceCloseResponse(target, response)
+        true
+    }
+}
+
+internal val InstanceCloseResponse.isClosed: Boolean
+    get() = active == false || closedAt != null
+
+internal fun WorldProfileVo.applyInstanceCloseResponse(
+    target: InstanceCloseTarget,
+    response: InstanceCloseResponse,
+): WorldProfileVo {
+    if (worldId != target.worldId) return this
+    val updatedInstances = if (response.isClosed) {
+        instances.filterNot { it.location == target.location }
+    } else {
+        instances.map { current ->
+            if (current.location == target.location) response.mergeWith(current) else current
+        }
+    }
+    return copy(instances = updatedInstances)
+}
+
+internal fun InstanceData.asInstanceCloseResponse() = InstanceCloseResponse(
+    active = active,
+    canRequestInvite = canRequestInvite,
+    capacity = capacity,
+    clientNumber = clientNumber,
+    closedAt = closedAt,
+    displayName = displayName,
+    full = full,
+    gameServerVersion = gameServerVersion,
+    hardClose = hardClose,
+    hasCapacityForYou = hasCapacityForYou,
+    hidden = hidden,
+    id = id,
+    instanceId = instanceId,
+    location = location,
+    nUsers = nUsers,
+    name = name,
+    ownerId = ownerId,
+    permanent = permanent,
+    photonRegion = photonRegion,
+    platforms = platforms,
+    queueEnabled = queueEnabled,
+    queueSize = queueSize,
+    recommendedCapacity = recommendedCapacity,
+    region = region,
+    secureName = secureName,
+    shortName = shortName,
+    strict = strict,
+    tags = tags,
+    type = type,
+    userCount = userCount,
+    world = world,
+    worldId = worldId,
+)
+
+private fun InstanceCloseResponse.mergeWith(current: InstanceVo): InstanceVo = current.copy(
+    id = id,
+    instanceId = instanceId,
+    worldId = worldId,
+    location = location,
+    ownerId = ownerId ?: current.ownerId,
+    instanceName = name,
+    currentUsers = nUsers,
+    pcUsers = platforms.standaloneWindows,
+    androidUsers = platforms.android,
+    iosUsers = platforms.ios,
+    queueEnabled = queueEnabled,
+    queueSize = queueSize,
+    isActive = active ?: current.isActive,
+    isFull = full,
+    hasCapacity = hasCapacityForYou ?: current.hasCapacity,
+    regionType = region,
+    regionName = region.name,
+    accessType = mergedAccessType(current.accessType),
+)
+
+private fun InstanceCloseResponse.mergedAccessType(current: AccessType): AccessType = when (type) {
+    AccessType.Group.value -> when (instanceId.substringAfter("groupAccessType(").substringBefore(")")) {
+        AccessType.GroupPublic.value -> AccessType.GroupPublic
+        AccessType.GroupPlus.value -> AccessType.GroupPlus
+        AccessType.GroupMembers.value -> AccessType.GroupMembers
+        else -> AccessType.Group
+    }
+
+    AccessType.Private.value -> when (canRequestInvite) {
+        true -> AccessType.InvitePlus
+        false -> AccessType.Invite
+        null -> current
+    }
+
+    AccessType.FriendPlus.value -> AccessType.FriendPlus
+    AccessType.Friend.value -> AccessType.Friend
+    else -> AccessType.Public
+}

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldInstanceStateStore.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldInstanceStateStore.kt
@@ -1,6 +1,5 @@
 package io.github.vrcmteam.vrcm.presentation.screens.world
 
-import io.github.vrcmteam.vrcm.network.api.attributes.AccessType
 import io.github.vrcmteam.vrcm.network.api.instances.data.InstanceCloseResponse
 import io.github.vrcmteam.vrcm.network.api.instances.data.InstanceData
 import io.github.vrcmteam.vrcm.presentation.screens.world.data.InstanceVo
@@ -71,10 +70,15 @@ internal class WorldInstanceStateStore(
         if (!canCommit()) return@withLock false
         val profile = profileState.value?.takeIf { it.worldId == target.worldId }
             ?: return@withLock false
-        locationRevisions[target.location] = (locationRevisions[target.location] ?: 0L) + 1L
-        if (response.isClosed) {
-            closedLocations += target.location
+        if (response.worldId != target.worldId ||
+            response.instanceId != target.instanceId ||
+            response.location != target.location
+        ) {
+            return@withLock false
         }
+        locationRevisions[target.location] = (locationRevisions[target.location] ?: 0L) + 1L
+        // A successful DELETE is authoritative even when active/closedAt are omitted.
+        closedLocations += target.location
         profileState.value = profile.applyInstanceCloseResponse(target, response)
         true
     }
@@ -88,14 +92,7 @@ internal fun WorldProfileVo.applyInstanceCloseResponse(
     response: InstanceCloseResponse,
 ): WorldProfileVo {
     if (worldId != target.worldId) return this
-    val updatedInstances = if (response.isClosed) {
-        instances.filterNot { it.location == target.location }
-    } else {
-        instances.map { current ->
-            if (current.location == target.location) response.mergeWith(current) else current
-        }
-    }
-    return copy(instances = updatedInstances)
+    return copy(instances = instances.filterNot { it.location == target.location })
 }
 
 internal fun InstanceData.asInstanceCloseResponse() = InstanceCloseResponse(
@@ -132,43 +129,3 @@ internal fun InstanceData.asInstanceCloseResponse() = InstanceCloseResponse(
     world = world,
     worldId = worldId,
 )
-
-private fun InstanceCloseResponse.mergeWith(current: InstanceVo): InstanceVo = current.copy(
-    id = id,
-    instanceId = instanceId,
-    worldId = worldId,
-    location = location,
-    ownerId = ownerId ?: current.ownerId,
-    instanceName = name,
-    currentUsers = nUsers,
-    pcUsers = platforms.standaloneWindows,
-    androidUsers = platforms.android,
-    iosUsers = platforms.ios,
-    queueEnabled = queueEnabled,
-    queueSize = queueSize,
-    isActive = active ?: current.isActive,
-    isFull = full,
-    hasCapacity = hasCapacityForYou ?: current.hasCapacity,
-    regionType = region,
-    regionName = region.name,
-    accessType = mergedAccessType(current.accessType),
-)
-
-private fun InstanceCloseResponse.mergedAccessType(current: AccessType): AccessType = when (type) {
-    AccessType.Group.value -> when (instanceId.substringAfter("groupAccessType(").substringBefore(")")) {
-        AccessType.GroupPublic.value -> AccessType.GroupPublic
-        AccessType.GroupPlus.value -> AccessType.GroupPlus
-        AccessType.GroupMembers.value -> AccessType.GroupMembers
-        else -> AccessType.Group
-    }
-
-    AccessType.Private.value -> when (canRequestInvite) {
-        true -> AccessType.InvitePlus
-        false -> AccessType.Invite
-        null -> current
-    }
-
-    AccessType.FriendPlus.value -> AccessType.FriendPlus
-    AccessType.Friend.value -> AccessType.Friend
-    else -> AccessType.Public
-}

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
@@ -113,6 +113,7 @@ class WorldProfileScreen(
             LocalSharedSuffixKey provides sharedSuffixKey,
         ) {
             WorldProfileContent(
+                screenModel = screenModel,
                 worldProfileVo = profileVoState ?: worldProfileVO,
                 onReturn = { currentNavigator.pop() },
                 onMenu = { /* 打开菜单 */ },
@@ -127,6 +128,7 @@ class WorldProfileScreen(
     // 主要内容组件
     @Composable
     fun WorldProfileContent(
+        screenModel: WorldProfileScreenModel,
         worldProfileVo: WorldProfileVo,
         onReturn: () -> Unit = {},
         onMenu: () -> Unit = {},
@@ -232,6 +234,7 @@ class WorldProfileScreen(
 
             // ========== BottomSheet ==========
             RenderBottomSheet(
+                screenModel = screenModel,
                 worldProfileVo = worldProfileVo,
                 bottomSheetState = bottomSheetState,
                 sizes = sizes,
@@ -808,6 +811,7 @@ private fun RenderTopBar(
  */
 @Composable
 private fun AppRoute.RenderBottomSheet(
+    screenModel: WorldProfileScreenModel,
     worldProfileVo: WorldProfileVo,
     bottomSheetState: BottomSheetUIState,
     sizes: WorldDetailSizesState,
@@ -821,7 +825,9 @@ private fun AppRoute.RenderBottomSheet(
         if (currentDialog == null) {
             currentDialog = InstancesDialog(
                 instance = it,
-                sharedSuffixKey = sharedSuffixKey
+                sharedSuffixKey = sharedSuffixKey,
+                screenModel = screenModel,
+                onClose = { currentDialog = null },
             )
         }
     }
@@ -855,6 +861,7 @@ private fun AppRoute.RenderBottomSheet(
 
                 // 主要信息内容
                 RenderBottomSheetContent(
+                    screenModel = screenModel,
                     worldProfileVo = worldProfileVo,
                     bottomSheetState = bottomSheetState,
                     onShrinkCardClick = onShrinkCardClick,
@@ -871,12 +878,12 @@ private fun AppRoute.RenderBottomSheet(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun AppRoute.RenderBottomSheetContent(
+    screenModel: WorldProfileScreenModel,
     worldProfileVo: WorldProfileVo,
     bottomSheetState: BottomSheetUIState,
     onShrinkCardClick: (InstanceVo) -> Unit,
     onExpanded: () -> Unit,
 ) {
-    val screenModel = koinViewModel<WorldProfileScreenModel>()
     val favoriteEntryState by screenModel.favoriteEntryState.collectAsState()
 
     // 对话框状态管理

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
@@ -13,6 +13,7 @@ import io.github.vrcmteam.vrcm.network.api.instances.InstancesApi
 import io.github.vrcmteam.vrcm.network.api.invite.InviteApi
 import io.github.vrcmteam.vrcm.network.api.users.UsersApi
 import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
+import io.github.vrcmteam.vrcm.network.supports.VRCApiException
 import io.github.vrcmteam.vrcm.presentation.compoments.ToastText
 import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntrySource
 import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntryState
@@ -55,6 +56,37 @@ class WorldProfileScreenModel internal constructor(
     // 加载状态
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val instanceCloseCoordinator = InstanceCloseCoordinator(
+        currentSessionToken = { SharedFlowCentre.currentSession.value?.token },
+        isCurrentSession = SharedFlowCentre::isCurrentSession,
+        fetchGroupPermissions = { sessionToken, groupId ->
+            authService.runSessionBoundCatching(sessionToken) {
+                groupsApi.fetchGroup(groupId).myMember?.permissions.orEmpty()
+            }?.let { response ->
+                InstanceCloseSessionResult(response.result, response.sessionToken)
+            }
+        },
+        closeInstance = { sessionToken, target ->
+            authService.runSessionBoundCatching(sessionToken) {
+                instancesApi.closeInstance(target.worldId, target.instanceId)
+            }?.let { response ->
+                InstanceCloseSessionResult(response.result, response.sessionToken)
+            }
+        },
+    )
+    internal val instanceCloseState: StateFlow<InstanceCloseState> = instanceCloseCoordinator.state
+
+    private val _closedInstanceLocations = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    internal val closedInstanceLocations: SharedFlow<String> = _closedInstanceLocations.asSharedFlow()
+
+    init {
+        viewModelScope.launch {
+            SharedFlowCentre.currentSession.collect { session ->
+                instanceCloseCoordinator.onSessionChanged(session?.token)
+            }
+        }
+    }
 
     private val favoriteEntry = FavoriteEntryStateModel(
         favoriteType = FavoriteType.World,
@@ -135,6 +167,80 @@ class WorldProfileScreenModel internal constructor(
                 _isLoading.value = false
             }
         }
+    }
+
+    internal fun requestInstanceClose(instance: InstanceVo, strings: LocaleStrings) {
+        val target = instance.closeTargetOrNull() ?: return
+        viewModelScope.launch {
+            when (val result = instanceCloseCoordinator.authorize(target)) {
+                InstanceCloseAuthorizationResult.NotAllowed ->
+                    emitInstanceCloseError(strings.instanceClosePermissionDenied)
+
+                is InstanceCloseAuthorizationResult.Failed ->
+                    emitInstanceCloseFailure(result.error, strings)
+
+                is InstanceCloseAuthorizationResult.SessionChanged ->
+                    emitInstanceCloseSessionChanged(result.userId, strings)
+
+                InstanceCloseAuthorizationResult.Abandoned,
+                InstanceCloseAuthorizationResult.Busy,
+                InstanceCloseAuthorizationResult.Ready -> Unit
+            }
+        }
+    }
+
+    internal fun confirmInstanceClose(strings: LocaleStrings) {
+        viewModelScope.launch {
+            when (val result = instanceCloseCoordinator.submit()) {
+                is InstanceCloseSubmissionResult.Closed -> onInstanceClosed(result, strings)
+                is InstanceCloseSubmissionResult.Failed -> emitInstanceCloseFailure(result.error, strings)
+                is InstanceCloseSubmissionResult.SessionChanged ->
+                    emitInstanceCloseSessionChanged(result.userId, strings)
+
+                InstanceCloseSubmissionResult.Abandoned,
+                InstanceCloseSubmissionResult.Busy -> Unit
+            }
+        }
+    }
+
+    internal fun abandonInstanceClose(location: String) {
+        instanceCloseCoordinator.abandon(location)
+    }
+
+    private suspend fun onInstanceClosed(
+        result: InstanceCloseSubmissionResult.Closed,
+        strings: LocaleStrings,
+    ) {
+        val request = result.request
+        if (!SharedFlowCentre.isCurrentSession(request.sessionToken)) return
+        val target = request.target
+        _worldProfileState.update { profile ->
+            profile?.applyInstanceCloseResponse(target, result.instance)
+        }
+        _closedInstanceLocations.tryEmit(target.location)
+        SharedFlowCentre.toastText.emit(ToastText.Success(strings.instanceCloseSuccess))
+    }
+
+    private suspend fun emitInstanceCloseFailure(error: Throwable, strings: LocaleStrings) {
+        val message = if (error is VRCApiException && error.code == 403) {
+            strings.instanceClosePermissionDenied
+        } else {
+            error.message
+                ?.takeIf { it.isNotBlank() }
+                ?.let { "${strings.instanceCloseFailed}: $it" }
+                ?: strings.instanceCloseFailed
+        }
+        emitInstanceCloseError(message)
+    }
+
+    private suspend fun emitInstanceCloseSessionChanged(userId: String?, strings: LocaleStrings) {
+        if (userId != null && SharedFlowCentre.currentSession.value?.token?.userId == userId) {
+            emitInstanceCloseError(strings.instanceCloseSessionChanged)
+        }
+    }
+
+    private suspend fun emitInstanceCloseError(message: String) {
+        SharedFlowCentre.toastText.emit(ToastText.Error(message))
     }
 
     private suspend fun loadWorldInfo(worldId: String) {

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
@@ -2,7 +2,6 @@ package io.github.vrcmteam.vrcm.presentation.screens.world
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import io.github.vrcmteam.vrcm.core.extensions.removeFirst
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.attributes.AccessType
 import io.github.vrcmteam.vrcm.network.api.attributes.BlueprintType
@@ -13,7 +12,6 @@ import io.github.vrcmteam.vrcm.network.api.instances.InstancesApi
 import io.github.vrcmteam.vrcm.network.api.invite.InviteApi
 import io.github.vrcmteam.vrcm.network.api.users.UsersApi
 import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
-import io.github.vrcmteam.vrcm.network.supports.VRCApiException
 import io.github.vrcmteam.vrcm.presentation.compoments.ToastText
 import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntrySource
 import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntryState
@@ -52,6 +50,7 @@ class WorldProfileScreenModel internal constructor(
     // 世界数据状态
     private val _worldProfileState = MutableStateFlow<WorldProfileVo?>(null)
     val worldProfileState: StateFlow<WorldProfileVo?> = _worldProfileState.asStateFlow()
+    private val worldInstanceStateStore = WorldInstanceStateStore(_worldProfileState)
 
     // 加载状态
     private val _isLoading = MutableStateFlow(false)
@@ -63,6 +62,13 @@ class WorldProfileScreenModel internal constructor(
         fetchGroupPermissions = { sessionToken, groupId ->
             authService.runSessionBoundCatching(sessionToken) {
                 groupsApi.fetchGroup(groupId).myMember?.permissions.orEmpty()
+            }?.let { response ->
+                InstanceCloseSessionResult(response.result, response.sessionToken)
+            }
+        },
+        fetchInstance = { sessionToken, target ->
+            authService.runSessionBoundCatching(sessionToken) {
+                instancesApi.closeStatus(target.worldId, target.instanceId)
             }?.let { response ->
                 InstanceCloseSessionResult(response.result, response.sessionToken)
             }
@@ -214,22 +220,19 @@ class WorldProfileScreenModel internal constructor(
         val request = result.request
         if (!SharedFlowCentre.isCurrentSession(request.sessionToken)) return
         val target = request.target
-        _worldProfileState.update { profile ->
-            profile?.applyInstanceCloseResponse(target, result.instance)
+        val applied = worldInstanceStateStore.applyClose(target, result.instance) {
+            SharedFlowCentre.isCurrentSession(request.sessionToken)
         }
+        if (!applied) return
         _closedInstanceLocations.tryEmit(target.location)
         SharedFlowCentre.toastText.emit(ToastText.Success(strings.instanceCloseSuccess))
     }
 
     private suspend fun emitInstanceCloseFailure(error: Throwable, strings: LocaleStrings) {
-        val message = if (error is VRCApiException && error.code == 403) {
-            strings.instanceClosePermissionDenied
-        } else {
-            error.message
-                ?.takeIf { it.isNotBlank() }
-                ?.let { "${strings.instanceCloseFailed}: $it" }
-                ?: strings.instanceCloseFailed
-        }
+        val message = error.message
+            ?.takeIf { it.isNotBlank() }
+            ?.let { "${strings.instanceCloseFailed}: $it" }
+            ?: strings.instanceCloseFailed
         emitInstanceCloseError(message)
     }
 
@@ -305,13 +308,17 @@ class WorldProfileScreenModel internal constructor(
      */
     private suspend fun loadInstanceData(instanceIds: Map<String, Owner?>) {
         val currentProfile = _worldProfileState.value ?: return
-        val instanceVos = currentProfile.instances.toMutableList()
-        _worldProfileState.value = currentProfile.copy(instances = instanceVos)
         authService.reTryAuthCatching {
             // 获取所有实例数据
-            instanceIds.keys.asFlow().mapNotNull { instanceId ->
+            instanceIds.entries.asFlow().mapNotNull { (instanceId, initialOwner) ->
                 try {
-                    worldsApi.getWorldInstanceById(currentProfile.worldId, instanceId)
+                    worldInstanceStateStore.refreshInstance(
+                        worldId = currentProfile.worldId,
+                        instanceId = instanceId,
+                        initialOwner = initialOwner,
+                    ) {
+                        worldsApi.getWorldInstanceById(currentProfile.worldId, instanceId)
+                    }
                 } catch (error: Throwable) {
                     if (error is CancellationException) throw error
                     SharedFlowCentre.toastText.emit(
@@ -321,13 +328,6 @@ class WorldProfileScreenModel internal constructor(
                 }
             }.catch {
                 SharedFlowCentre.toastText.emit(ToastText.Error(it.message ?: "Failed to load instance data"))
-            }.map { instanceData ->
-                val owner: MutableStateFlow<Owner?> = MutableStateFlow(instanceIds[instanceData.instanceId])
-                val instanceVo = InstanceVo(instanceData, owner)
-                instanceVos.removeFirst { it.id == instanceData.id }
-                instanceVos.add(instanceVo)
-                _worldProfileState.value = _worldProfileState.value?.copy(instances = instanceVos.toList())
-                instanceData.ownerId to owner
             }.collect { (ownerId, owner) ->
                 // 如果实例是活跃的，则获取实例的拥有者名称
                 fetchAndSetOwner(ownerId)

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/components/InstancesDialog.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/components/InstancesDialog.kt
@@ -15,13 +15,20 @@ import androidx.compose.ui.unit.dp
 import io.github.vrcmteam.vrcm.network.api.attributes.BlueprintType
 import io.github.vrcmteam.vrcm.network.api.attributes.IUser
 import io.github.vrcmteam.vrcm.network.api.invite.InviteApi
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.presentation.compoments.*
 import io.github.vrcmteam.vrcm.presentation.extensions.currentNavigator
 import io.github.vrcmteam.vrcm.presentation.extensions.glideBack
 import io.github.vrcmteam.vrcm.presentation.screens.user.UserProfileScreen
 import io.github.vrcmteam.vrcm.presentation.screens.user.data.UserProfileVo
+import io.github.vrcmteam.vrcm.presentation.screens.world.InstanceCloseState
+import io.github.vrcmteam.vrcm.presentation.screens.world.WorldProfileScreenModel
+import io.github.vrcmteam.vrcm.presentation.screens.world.canOfferInstanceClose
+import io.github.vrcmteam.vrcm.presentation.screens.world.closeTargetOrNull
 import io.github.vrcmteam.vrcm.presentation.screens.world.data.InstanceVo
+import io.github.vrcmteam.vrcm.presentation.screens.world.requestOrNull
 import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
+import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
 import io.github.vrcmteam.vrcm.service.AuthService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -31,9 +38,10 @@ import org.koin.compose.koinInject
 class InstancesDialog(
     private val instance: InstanceVo,
     private val sharedSuffixKey: String,
+    private val screenModel: WorldProfileScreenModel,
     private val onClose: () -> Unit = {},
 ) : SharedDialog {
-    @OptIn(ExperimentalSharedTransitionApi::class)
+    @OptIn(ExperimentalLayoutApi::class, ExperimentalSharedTransitionApi::class)
     @Composable
     override fun Content(animatedVisibilityScope: AnimatedVisibilityScope) {
         val currentNavigator = currentNavigator
@@ -48,6 +56,25 @@ class InstancesDialog(
         var isInvited by remember { mutableStateOf(false) }
         val scope = rememberCoroutineScope()
         val localeStrings = strings
+        val currentSession by SharedFlowCentre.currentSession.collectAsState()
+        val instanceCloseState by screenModel.instanceCloseState.collectAsState()
+        val closeTarget = instance.closeTargetOrNull()
+        val closeLocation = closeTarget?.location
+        val isCurrentClose = closeLocation != null &&
+            instanceCloseState.requestOrNull?.target?.location == closeLocation
+        val isAuthorizingClose = isCurrentClose && instanceCloseState is InstanceCloseState.Authorizing
+        val isAwaitingCloseConfirmation = isCurrentClose &&
+            instanceCloseState is InstanceCloseState.AwaitingConfirmation
+        val isSubmittingClose = isCurrentClose && instanceCloseState is InstanceCloseState.Submitting
+        val canOfferClose = instance.canOfferInstanceClose(currentSession?.token)
+
+        LaunchedEffect(closeLocation) {
+            if (closeLocation == null) return@LaunchedEffect
+            screenModel.closedInstanceLocations.collect { closedLocation ->
+                if (closedLocation == closeLocation) close()
+            }
+        }
+
         val onClickInvite = {
             scope.launch(Dispatchers.IO) {
                 authService.reTryAuthCatching { inviteApi.inviteMyselfToInstance(instance.id) }.onSuccess {
@@ -119,6 +146,7 @@ class InstancesDialog(
 //                                onClickUserIcon(it)
 //                            }
                             Row(
+                                modifier = Modifier.fillMaxWidth(),
                                 horizontalArrangement = Arrangement.spacedBy(4.dp),
                                 verticalAlignment = Alignment.CenterVertically,
                             ) {
@@ -134,6 +162,46 @@ class InstancesDialog(
                                 TextLabel(
                                     text = "${instance.currentUsers ?: "0"}",
                                 )
+                            }
+                            FlowRow(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+                                verticalArrangement = Arrangement.spacedBy(4.dp),
+                                itemVerticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                if (canOfferClose) {
+                                    OutlinedButton(
+                                        enabled = instanceCloseState is InstanceCloseState.Idle,
+                                        onClick = {
+                                            screenModel.requestInstanceClose(instance, localeStrings)
+                                        },
+                                        colors = ButtonDefaults.outlinedButtonColors(
+                                            contentColor = MaterialTheme.colorScheme.error,
+                                        ),
+                                    ) {
+                                        if (isAuthorizingClose) {
+                                            CircularProgressIndicator(
+                                                modifier = Modifier.size(18.dp),
+                                                color = LocalContentColor.current,
+                                                strokeWidth = 2.dp,
+                                            )
+                                            Spacer(modifier = Modifier.width(8.dp))
+                                        } else {
+                                            Icon(
+                                                imageVector = AppIcons.Close,
+                                                contentDescription = null,
+                                            )
+                                            Spacer(modifier = Modifier.width(8.dp))
+                                        }
+                                        Text(
+                                            if (isAuthorizingClose) {
+                                                localeStrings.instanceCloseCheckingPermission
+                                            } else {
+                                                localeStrings.instanceCloseAction
+                                            }
+                                        )
+                                    }
+                                }
                                 Button(
                                     modifier = Modifier.animateContentSize(),
                                     enabled = !isInvited,
@@ -147,7 +215,57 @@ class InstancesDialog(
                 }
             }
         }
+
+        if (isAwaitingCloseConfirmation || isSubmittingClose) {
+            AlertDialog(
+                onDismissRequest = {
+                    if (!isSubmittingClose) {
+                        closeLocation?.let(screenModel::abandonInstanceClose)
+                    }
+                },
+                title = { Text(localeStrings.instanceCloseConfirmTitle) },
+                text = { Text(localeStrings.instanceCloseConfirmMessage) },
+                confirmButton = {
+                    TextButton(
+                        enabled = !isSubmittingClose,
+                        onClick = { screenModel.confirmInstanceClose(localeStrings) },
+                        colors = ButtonDefaults.textButtonColors(
+                            contentColor = MaterialTheme.colorScheme.error,
+                        ),
+                    ) {
+                        if (isSubmittingClose) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(18.dp),
+                                color = LocalContentColor.current,
+                                strokeWidth = 2.dp,
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                        }
+                        Text(
+                            if (isSubmittingClose) {
+                                localeStrings.instanceCloseInProgress
+                            } else {
+                                localeStrings.instanceCloseAction
+                            }
+                        )
+                    }
+                },
+                dismissButton = {
+                    TextButton(
+                        enabled = !isSubmittingClose,
+                        onClick = {
+                            closeLocation?.let(screenModel::abandonInstanceClose)
+                        },
+                    ) {
+                        Text(localeStrings.cancel)
+                    }
+                },
+            )
+        }
     }
 
-    override fun close() = onClose()
+    override fun close() {
+        instance.closeTargetOrNull()?.location?.let(screenModel::abandonInstanceClose)
+        onClose()
+    }
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/data/InstanceVo.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/data/InstanceVo.kt
@@ -16,6 +16,9 @@ import kotlinx.coroutines.flow.StateFlow
 data class InstanceVo(
     val id: String ,
     val instanceId: String = "",
+    val worldId: String = "",
+    val location: String = "",
+    val ownerId: String? = null,
     val instanceName: String = "unknown",
     val currentUsers: Int? = null,
     val pcUsers: Int? = null,
@@ -34,6 +37,9 @@ data class InstanceVo(
     constructor(instance: InstanceData, owner: StateFlow<Owner?> = MutableStateFlow(null)) : this(
         id = instance.id,
         instanceId = instance.instanceId,
+        worldId = instance.worldId,
+        location = instance.location,
+        ownerId = instance.ownerId,
         instanceName = instance.name,
         currentUsers = instance.nUsers,
         pcUsers = instance.platforms.standaloneWindows,
@@ -53,6 +59,9 @@ data class InstanceVo(
     constructor(instants: HomeInstanceVo) : this(
         id = instants.id,
         instanceId = instants.instanceId,
+        worldId = instants.worldId,
+        location = instants.id,
+        ownerId = instants.owner?.id,
         instanceName = instants.name,
         currentUsers = instants.userCount.substringBefore("/").toIntOrNull(),
         regionType = instants.region,
@@ -75,4 +84,4 @@ data class InstanceVo(
     ) {
         val iconVector: ImageVector get() = if (type == BlueprintType.User) AppIcons.Person else AppIcons.Groups
     }
-} 
+}

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
@@ -196,6 +196,15 @@ sealed class LocaleStrings {
     open val instanceCreateSuccess: String = "Successfully created instance and sent invite"
     open val instanceCreateSuccessButInviteFailed: String = "Instance created successfully but invite failed"
     open val instanceCreateFailed: String = "Failed to create instance"
+    open val instanceCloseAction: String = "Close instance"
+    open val instanceCloseCheckingPermission: String = "Checking permission"
+    open val instanceCloseConfirmTitle: String = "Close this instance?"
+    open val instanceCloseConfirmMessage: String = "This instance will immediately stop accepting new users. This action cannot be undone."
+    open val instanceCloseInProgress: String = "Closing instance"
+    open val instanceCloseSuccess: String = "Instance closed"
+    open val instanceCloseFailed: String = "Failed to close instance"
+    open val instanceClosePermissionDenied: String = "You do not have permission to close this instance"
+    open val instanceCloseSessionChanged: String = "The account session changed. Open the instance and try again."
 
     // World Search
     open val worldSearchAdvancedOptions: String = "Advanced Search Options"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
@@ -181,6 +181,15 @@ internal object LocaleStringsJa : LocaleStrings() {
     override val instanceCreateSuccess = "インスタンスを作成し、招待を送信しました"
     override val instanceCreateSuccessButInviteFailed = "インスタンスは作成されましたが、招待に失敗しました"
     override val instanceCreateFailed = "インスタンス作成に失敗しました"
+    override val instanceCloseAction = "インスタンスを閉じる"
+    override val instanceCloseCheckingPermission = "権限を確認中"
+    override val instanceCloseConfirmTitle = "このインスタンスを閉じますか？"
+    override val instanceCloseConfirmMessage = "このインスタンスへの新しいユーザーの参加を直ちに停止します。この操作は元に戻せません。"
+    override val instanceCloseInProgress = "インスタンスを閉じています"
+    override val instanceCloseSuccess = "インスタンスを閉じました"
+    override val instanceCloseFailed = "インスタンスを閉じられませんでした"
+    override val instanceClosePermissionDenied = "このインスタンスを閉じる権限がありません"
+    override val instanceCloseSessionChanged = "アカウントのセッションが変更されました。インスタンスを開き直して再試行してください。"
 
     // World Search
     override val worldSearchAdvancedOptions = "詳細検索オプション"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
@@ -180,6 +180,15 @@ internal object LocaleStringsZhHans : LocaleStrings() {
     override val instanceCreateSuccess = "成功创建房间并发送邀请"
     override val instanceCreateSuccessButInviteFailed = "创建房间成功，但邀请失败"
     override val instanceCreateFailed = "创建房间失败"
+    override val instanceCloseAction = "关闭实例"
+    override val instanceCloseCheckingPermission = "正在检查权限"
+    override val instanceCloseConfirmTitle = "关闭此实例？"
+    override val instanceCloseConfirmMessage = "此实例将立即禁止新用户加入，此操作无法撤销。"
+    override val instanceCloseInProgress = "正在关闭实例"
+    override val instanceCloseSuccess = "实例已关闭"
+    override val instanceCloseFailed = "实例关闭失败"
+    override val instanceClosePermissionDenied = "你没有关闭此实例的权限"
+    override val instanceCloseSessionChanged = "账号会话已变更，请重新打开实例后再试。"
 
     // World Search
     override val worldSearchAdvancedOptions = "高级搜索选项"

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
@@ -180,6 +180,15 @@ internal object LocaleStringsZhHant : LocaleStrings() {
     override val instanceCreateSuccess = "成功創建房間並發送邀請"
     override val instanceCreateSuccessButInviteFailed = "創建房間成功，但邀請失敗"
     override val instanceCreateFailed = "創建房間失敗"
+    override val instanceCloseAction = "關閉實例"
+    override val instanceCloseCheckingPermission = "正在檢查權限"
+    override val instanceCloseConfirmTitle = "關閉此實例？"
+    override val instanceCloseConfirmMessage = "此實例將立即禁止新使用者加入，此操作無法復原。"
+    override val instanceCloseInProgress = "正在關閉實例"
+    override val instanceCloseSuccess = "實例已關閉"
+    override val instanceCloseFailed = "實例關閉失敗"
+    override val instanceClosePermissionDenied = "你沒有關閉此實例的權限"
+    override val instanceCloseSessionChanged = "帳號工作階段已變更，請重新開啟實例後再試。"
 
     // World Search
     override val worldSearchAdvancedOptions = "高級搜索選項"

--- a/composeApp/src/commonTest/kotlin/network/api/instances/InstancesApiTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/api/instances/InstancesApiTest.kt
@@ -1,0 +1,140 @@
+package io.github.vrcmteam.vrcm.network.api.instances
+
+import io.github.vrcmteam.vrcm.network.supports.VRCApiException
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class InstancesApiTest {
+    @Test
+    fun closeInstanceUsesOnlyTheCanonicalDeletePath() = runBlocking {
+        var capturedRequest: HttpRequestData? = null
+        val client = closeInstanceClient { request ->
+            capturedRequest = request
+            HttpStatusCode.OK
+        }
+
+        val closed = InstancesApi(client).closeInstance(WORLD_ID, INSTANCE_ID)
+
+        val request = checkNotNull(capturedRequest)
+        assertEquals(HttpMethod.Delete, request.method)
+        assertEquals("/instances/$LOCATION", request.url.encodedPath)
+        assertTrue(request.url.encodedQuery.isEmpty())
+        assertEquals(LOCATION, closed.location)
+        assertEquals("2026-08-31T08:00:00.000Z", closed.closedAt)
+        client.close()
+    }
+
+    @Test
+    fun closeInstancePreservesPermissionFailure() = runBlocking {
+        val client = closeInstanceClient { HttpStatusCode.Forbidden }
+
+        val error = assertFailsWith<VRCApiException> {
+            InstancesApi(client).closeInstance(WORLD_ID, INSTANCE_ID)
+        }
+
+        assertEquals(403, error.code)
+        client.close()
+    }
+
+    private fun closeInstanceClient(
+        status: (HttpRequestData) -> HttpStatusCode,
+    ) = HttpClient(MockEngine) {
+        engine {
+            addHandler { request ->
+                val responseStatus = status(request)
+                respond(
+                    content = if (responseStatus == HttpStatusCode.OK) {
+                        closedInstanceJson()
+                    } else {
+                        "permission denied"
+                    },
+                    status = responseStatus,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+        }
+        install(ContentNegotiation) {
+            json(Json { ignoreUnknownKeys = true })
+        }
+    }
+
+    private fun closedInstanceJson(): String =
+        """
+        {
+          "active":false,
+          "canRequestInvite":false,
+          "capacity":16,
+          "clientNumber":"1",
+          "closedAt":"2026-08-31T08:00:00.000Z",
+          "full":false,
+          "hidden":null,
+          "id":"$LOCATION",
+          "instanceId":"$INSTANCE_ID",
+          "location":"$LOCATION",
+          "n_users":0,
+          "name":"12345",
+          "ownerId":"$USER_ID",
+          "permanent":false,
+          "photonRegion":"us",
+          "platforms":{"android":0,"ios":0,"standalonewindows":0},
+          "queueEnabled":false,
+          "queueSize":0,
+          "recommendedCapacity":16,
+          "region":"us",
+          "secureName":"secure",
+          "strict":false,
+          "tags":[],
+          "type":"private",
+          "userCount":0,
+          "world":{
+            "authorId":"$USER_ID",
+            "authorName":"Author",
+            "capacity":16,
+            "created_at":null,
+            "description":null,
+            "favorites":0,
+            "featured":false,
+            "heat":0,
+            "id":"$WORLD_ID",
+            "imageUrl":"",
+            "labsPublicationDate":"",
+            "name":"World",
+            "namespace":null,
+            "organization":"",
+            "popularity":0,
+            "publicationDate":"",
+            "recommendedCapacity":16,
+            "releaseStatus":"public",
+            "tags":[],
+            "thumbnailImageUrl":null,
+            "udonProducts":[],
+            "unityPackages":[],
+            "updated_at":null,
+            "version":1,
+            "visits":0
+          },
+          "worldId":"$WORLD_ID"
+        }
+        """.trimIndent()
+
+    private companion object {
+        const val WORLD_ID = "wrld_00000000-0000-0000-0000-000000000001"
+        const val USER_ID = "usr_00000000-0000-0000-0000-000000000002"
+        const val INSTANCE_ID = "12345~region(us)"
+        const val LOCATION = "$WORLD_ID:$INSTANCE_ID"
+    }
+}

--- a/composeApp/src/commonTest/kotlin/network/api/instances/InstancesApiTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/api/instances/InstancesApiTest.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class InstancesApiTest {
@@ -50,7 +51,23 @@ class InstancesApiTest {
         client.close()
     }
 
+    @Test
+    fun closeInstanceAcceptsResponseWithoutOptionalInstanceFields() = runBlocking {
+        val client = closeInstanceClient(
+            status = { HttpStatusCode.OK },
+            successContent = closedInstanceJson(includeOptionalFields = false),
+        )
+
+        val closed = InstancesApi(client).closeInstance(WORLD_ID, INSTANCE_ID)
+
+        assertEquals(LOCATION, closed.location)
+        assertNull(closed.active)
+        assertNull(closed.ownerId)
+        client.close()
+    }
+
     private fun closeInstanceClient(
+        successContent: String = closedInstanceJson(),
         status: (HttpRequestData) -> HttpStatusCode,
     ) = HttpClient(MockEngine) {
         engine {
@@ -58,7 +75,7 @@ class InstancesApiTest {
                 val responseStatus = status(request)
                 respond(
                     content = if (responseStatus == HttpStatusCode.OK) {
-                        closedInstanceJson()
+                        successContent
                     } else {
                         "permission denied"
                     },
@@ -72,22 +89,29 @@ class InstancesApiTest {
         }
     }
 
-    private fun closedInstanceJson(): String =
-        """
+    private fun closedInstanceJson(includeOptionalFields: Boolean = true): String {
+        val optionalFields = if (includeOptionalFields) {
+            """
+              "active":false,
+              "canRequestInvite":false,
+              "capacity":16,
+              "hidden":null,
+              "ownerId":"$USER_ID",
+            """.trimIndent()
+        } else {
+            ""
+        }
+        return """
         {
-          "active":false,
-          "canRequestInvite":false,
-          "capacity":16,
+          $optionalFields
           "clientNumber":"1",
           "closedAt":"2026-08-31T08:00:00.000Z",
           "full":false,
-          "hidden":null,
           "id":"$LOCATION",
           "instanceId":"$INSTANCE_ID",
           "location":"$LOCATION",
           "n_users":0,
           "name":"12345",
-          "ownerId":"$USER_ID",
           "permanent":false,
           "photonRegion":"us",
           "platforms":{"android":0,"ios":0,"standalonewindows":0},
@@ -130,6 +154,7 @@ class InstancesApiTest {
           "worldId":"$WORLD_ID"
         }
         """.trimIndent()
+    }
 
     private companion object {
         const val WORLD_ID = "wrld_00000000-0000-0000-0000-000000000001"

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/InstanceCloseCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/InstanceCloseCoordinatorTest.kt
@@ -129,6 +129,56 @@ class InstanceCloseCoordinatorTest {
     }
 
     @Test
+    fun forbiddenCloseConvergesToSuccessWhenRecheckShowsClosed() = runTest {
+        var currentToken: AccountSessionToken? = OWNER_TOKEN
+        var recheckCount = 0
+        val coordinator = coordinator(
+            currentSession = { currentToken },
+            fetchInstance = { token, _ ->
+                recheckCount++
+                InstanceCloseSessionResult(Result.success(closedInstance()), token)
+            },
+            closeInstance = { token, _ ->
+                InstanceCloseSessionResult(
+                    Result.failure(VRCApiException("Forbidden", 403, "already closed")),
+                    token,
+                )
+            },
+        )
+        coordinator.authorize(personalTarget())
+
+        assertIs<InstanceCloseSubmissionResult.Closed>(coordinator.submit())
+        assertEquals(1, recheckCount)
+        assertIs<InstanceCloseState.Idle>(coordinator.state.value)
+    }
+
+    @Test
+    fun forbiddenCloseRemainsRetryableWhenRecheckShowsActive() = runTest {
+        var currentToken: AccountSessionToken? = OWNER_TOKEN
+        val coordinator = coordinator(
+            currentSession = { currentToken },
+            fetchInstance = { token, _ ->
+                InstanceCloseSessionResult(
+                    Result.success(closedInstance(active = true, closedAt = null)),
+                    token,
+                )
+            },
+            closeInstance = { token, _ ->
+                InstanceCloseSessionResult(
+                    Result.failure(VRCApiException("Forbidden", 403, "permission denied")),
+                    token,
+                )
+            },
+        )
+        coordinator.authorize(personalTarget())
+
+        val failed = assertIs<InstanceCloseSubmissionResult.Failed>(coordinator.submit())
+
+        assertEquals(403, assertIs<VRCApiException>(failed.error).code)
+        assertIs<InstanceCloseState.AwaitingConfirmation>(coordinator.state.value)
+    }
+
+    @Test
     fun authenticationRenewalCanCompleteTheOriginalRequest() = runTest {
         var currentToken: AccountSessionToken? = OWNER_TOKEN
         val renewedToken = AccountSessionToken(OWNER_ID, generation = 2)
@@ -290,14 +340,17 @@ class InstanceCloseCoordinatorTest {
 
         val stillActive = profile.applyInstanceCloseResponse(
             target,
-            originalData.copy(nUsers = 2),
+            originalData.copy(nUsers = 2).asInstanceCloseResponse(),
         )
         assertEquals(2, stillActive.instances.single().currentUsers)
         assertTrue(stillActive.instances.single().owner === original.owner)
 
         val closed = stillActive.applyInstanceCloseResponse(
             target,
-            originalData.copy(active = false, closedAt = "2026-08-31T08:00:00.000Z"),
+            originalData.copy(
+                active = false,
+                closedAt = "2026-08-31T08:00:00.000Z",
+            ).asInstanceCloseResponse(),
         )
         assertTrue(closed.instances.isEmpty())
     }
@@ -310,6 +363,15 @@ class InstanceCloseCoordinatorTest {
         ) -> InstanceCloseSessionResult<List<String>>? = { token, _ ->
             InstanceCloseSessionResult(Result.success(emptyList()), token)
         },
+        fetchInstance: suspend (
+            AccountSessionToken,
+            InstanceCloseTarget,
+        ) -> InstanceCloseSessionResult<InstanceData>? = { token, _ ->
+            InstanceCloseSessionResult(
+                Result.success(closedInstance(active = true, closedAt = null)),
+                token,
+            )
+        },
         closeInstance: suspend (
             AccountSessionToken,
             InstanceCloseTarget,
@@ -320,7 +382,22 @@ class InstanceCloseCoordinatorTest {
         currentSessionToken = currentSession,
         isCurrentSession = { it == currentSession() },
         fetchGroupPermissions = groupPermissions,
-        closeInstance = closeInstance,
+        fetchInstance = { token, target ->
+            fetchInstance(token, target)?.let { response ->
+                InstanceCloseSessionResult(
+                    result = response.result.map { it.asInstanceCloseResponse() },
+                    sessionToken = response.sessionToken,
+                )
+            }
+        },
+        closeInstance = { token, target ->
+            closeInstance(token, target)?.let { response ->
+                InstanceCloseSessionResult(
+                    result = response.result.map { it.asInstanceCloseResponse() },
+                    sessionToken = response.sessionToken,
+                )
+            }
+        },
     )
 
     private fun personalTarget(ownerId: String = OWNER_ID) = InstanceCloseTarget(

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/InstanceCloseCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/InstanceCloseCoordinatorTest.kt
@@ -1,0 +1,408 @@
+package io.github.vrcmteam.vrcm.presentation.screens.world
+
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+import io.github.vrcmteam.vrcm.network.api.attributes.RegionType
+import io.github.vrcmteam.vrcm.network.api.instances.data.InstanceData
+import io.github.vrcmteam.vrcm.network.api.instances.data.Platforms
+import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
+import io.github.vrcmteam.vrcm.network.supports.VRCApiException
+import io.github.vrcmteam.vrcm.presentation.screens.world.data.InstanceVo
+import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class InstanceCloseCoordinatorTest {
+    @Test
+    fun personalInstanceRequiresTheCurrentOwner() = runTest {
+        var currentToken: AccountSessionToken? = OWNER_TOKEN
+        val coordinator = coordinator(currentSession = { currentToken })
+
+        assertIs<InstanceCloseAuthorizationResult.NotAllowed>(
+            coordinator.authorize(personalTarget(ownerId = OTHER_USER_ID))
+        )
+        assertIs<InstanceCloseState.Idle>(coordinator.state.value)
+
+        assertIs<InstanceCloseAuthorizationResult.Ready>(
+            coordinator.authorize(personalTarget(ownerId = OWNER_ID))
+        )
+        assertEquals(
+            OWNER_TOKEN,
+            assertIs<InstanceCloseState.AwaitingConfirmation>(coordinator.state.value)
+                .request.sessionToken,
+        )
+    }
+
+    @Test
+    fun groupPermissionAndWildcardAllowConfirmation() = runTest {
+        listOf(listOf(GROUP_INSTANCE_MANAGE_PERMISSION), listOf("*")).forEach { permissions ->
+            var currentToken: AccountSessionToken? = OWNER_TOKEN
+            val coordinator = coordinator(
+                currentSession = { currentToken },
+                groupPermissions = { token, _ ->
+                    InstanceCloseSessionResult(Result.success(permissions), token)
+                },
+            )
+
+            assertIs<InstanceCloseAuthorizationResult.Ready>(
+                coordinator.authorize(groupTarget())
+            )
+            assertIs<InstanceCloseState.AwaitingConfirmation>(coordinator.state.value)
+        }
+    }
+
+    @Test
+    fun missingGroupPermissionDoesNotOpenConfirmation() = runTest {
+        var currentToken: AccountSessionToken? = OWNER_TOKEN
+        val coordinator = coordinator(
+            currentSession = { currentToken },
+            groupPermissions = { token, _ ->
+                InstanceCloseSessionResult(Result.success(listOf("group-instance-view")), token)
+            },
+        )
+
+        assertIs<InstanceCloseAuthorizationResult.NotAllowed>(
+            coordinator.authorize(groupTarget())
+        )
+        assertIs<InstanceCloseState.Idle>(coordinator.state.value)
+    }
+
+    @Test
+    fun repeatedConfirmationOnlySubmitsOnce() = runTest {
+        var currentToken: AccountSessionToken? = OWNER_TOKEN
+        val closeStarted = CompletableDeferred<Unit>()
+        val finishClose = CompletableDeferred<Unit>()
+        var closeCount = 0
+        val coordinator = coordinator(
+            currentSession = { currentToken },
+            closeInstance = { token, _ ->
+                closeCount++
+                closeStarted.complete(Unit)
+                finishClose.await()
+                InstanceCloseSessionResult(Result.success(closedInstance()), token)
+            },
+        )
+        coordinator.authorize(personalTarget())
+
+        val first = async(start = CoroutineStart.UNDISPATCHED) { coordinator.submit() }
+        closeStarted.await()
+
+        assertIs<InstanceCloseSubmissionResult.Busy>(coordinator.submit())
+        assertEquals(1, closeCount)
+
+        finishClose.complete(Unit)
+        assertIs<InstanceCloseSubmissionResult.Closed>(first.await())
+        assertIs<InstanceCloseState.Idle>(coordinator.state.value)
+    }
+
+    @Test
+    fun permissionFailureKeepsConfirmationRetryable() = runTest {
+        var currentToken: AccountSessionToken? = OWNER_TOKEN
+        var reject = true
+        val coordinator = coordinator(
+            currentSession = { currentToken },
+            closeInstance = { token, _ ->
+                val result = if (reject) {
+                    Result.failure(VRCApiException("Forbidden", 403, "permission denied"))
+                } else {
+                    Result.success(closedInstance())
+                }
+                InstanceCloseSessionResult(result, token)
+            },
+        )
+        coordinator.authorize(personalTarget())
+
+        val failed = assertIs<InstanceCloseSubmissionResult.Failed>(coordinator.submit())
+        assertEquals(403, assertIs<VRCApiException>(failed.error).code)
+        assertIs<InstanceCloseState.AwaitingConfirmation>(coordinator.state.value)
+
+        reject = false
+        assertIs<InstanceCloseSubmissionResult.Closed>(coordinator.submit())
+        assertIs<InstanceCloseState.Idle>(coordinator.state.value)
+    }
+
+    @Test
+    fun authenticationRenewalCanCompleteTheOriginalRequest() = runTest {
+        var currentToken: AccountSessionToken? = OWNER_TOKEN
+        val renewedToken = AccountSessionToken(OWNER_ID, generation = 2)
+        lateinit var coordinator: InstanceCloseCoordinator
+        coordinator = coordinator(
+            currentSession = { currentToken },
+            closeInstance = { token, _ ->
+                assertEquals(OWNER_TOKEN, token)
+                currentToken = renewedToken
+                coordinator.onSessionChanged(renewedToken)
+                InstanceCloseSessionResult(Result.success(closedInstance()), renewedToken)
+            },
+        )
+        coordinator.authorize(personalTarget())
+
+        val closed = assertIs<InstanceCloseSubmissionResult.Closed>(coordinator.submit())
+
+        assertEquals(renewedToken, closed.request.sessionToken)
+        assertIs<InstanceCloseState.Idle>(coordinator.state.value)
+    }
+
+    @Test
+    fun authenticationRenewalDuringAuthorizationCanOpenConfirmation() = runTest {
+        var currentToken: AccountSessionToken? = OWNER_TOKEN
+        val renewedToken = AccountSessionToken(OWNER_ID, generation = 2)
+        lateinit var coordinator: InstanceCloseCoordinator
+        coordinator = coordinator(
+            currentSession = { currentToken },
+            groupPermissions = { token, _ ->
+                assertEquals(OWNER_TOKEN, token)
+                currentToken = renewedToken
+                coordinator.onSessionChanged(renewedToken)
+                InstanceCloseSessionResult(
+                    Result.success(listOf(GROUP_INSTANCE_MANAGE_PERMISSION)),
+                    renewedToken,
+                )
+            },
+        )
+
+        assertIs<InstanceCloseAuthorizationResult.Ready>(coordinator.authorize(groupTarget()))
+        assertEquals(
+            renewedToken,
+            assertIs<InstanceCloseState.AwaitingConfirmation>(coordinator.state.value)
+                .request.sessionToken,
+        )
+    }
+
+    @Test
+    fun unrelatedSessionChangeDismissesIdleConfirmationImmediately() = runTest {
+        var currentToken: AccountSessionToken? = OWNER_TOKEN
+        val coordinator = coordinator(currentSession = { currentToken })
+        coordinator.authorize(personalTarget())
+
+        currentToken = AccountSessionToken(OWNER_ID, generation = 7)
+        coordinator.onSessionChanged(currentToken)
+
+        assertIs<InstanceCloseState.Idle>(coordinator.state.value)
+    }
+
+    @Test
+    fun unrelatedSameAccountTokenReplacementPreventsSubmission() = runTest {
+        var currentToken: AccountSessionToken? = OWNER_TOKEN
+        var closeCalled = false
+        val coordinator = coordinator(
+            currentSession = { currentToken },
+            closeInstance = { token, _ ->
+                closeCalled = true
+                InstanceCloseSessionResult(Result.success(closedInstance()), token)
+            },
+        )
+        coordinator.authorize(personalTarget())
+        currentToken = AccountSessionToken(OWNER_ID, generation = 99)
+
+        assertIs<InstanceCloseSubmissionResult.SessionChanged>(coordinator.submit())
+        assertFalse(closeCalled)
+        assertIs<InstanceCloseState.Idle>(coordinator.state.value)
+    }
+
+    @Test
+    fun logoutAndNullResponseClearPendingState() = runTest {
+        var currentToken: AccountSessionToken? = OWNER_TOKEN
+        val logoutCoordinator = coordinator(currentSession = { currentToken })
+        logoutCoordinator.authorize(personalTarget())
+        currentToken = null
+
+        assertIs<InstanceCloseSubmissionResult.SessionChanged>(logoutCoordinator.submit())
+        assertIs<InstanceCloseState.Idle>(logoutCoordinator.state.value)
+
+        currentToken = OWNER_TOKEN
+        val nullResponseCoordinator = coordinator(
+            currentSession = { currentToken },
+            closeInstance = { _, _ -> null },
+        )
+        nullResponseCoordinator.authorize(personalTarget())
+
+        assertIs<InstanceCloseSubmissionResult.SessionChanged>(nullResponseCoordinator.submit())
+        assertIs<InstanceCloseState.Idle>(nullResponseCoordinator.state.value)
+    }
+
+    @Test
+    fun responseFromAnOldSessionCannotReportSuccess() = runTest {
+        var currentToken: AccountSessionToken? = OWNER_TOKEN
+        val otherToken = AccountSessionToken(OTHER_USER_ID, generation = 2)
+        val coordinator = coordinator(
+            currentSession = { currentToken },
+            closeInstance = { token, _ ->
+                currentToken = otherToken
+                InstanceCloseSessionResult(Result.success(closedInstance()), token)
+            },
+        )
+        coordinator.authorize(personalTarget())
+
+        assertIs<InstanceCloseSubmissionResult.SessionChanged>(coordinator.submit())
+        assertIs<InstanceCloseState.Idle>(coordinator.state.value)
+    }
+
+    @Test
+    fun responseForAnotherLocationCannotReportSuccess() = runTest {
+        var currentToken: AccountSessionToken? = OWNER_TOKEN
+        val coordinator = coordinator(
+            currentSession = { currentToken },
+            closeInstance = { token, _ ->
+                InstanceCloseSessionResult(
+                    Result.success(closedInstance(location = "$WORLD_ID:other")),
+                    token,
+                )
+            },
+        )
+        coordinator.authorize(personalTarget())
+
+        val failed = assertIs<InstanceCloseSubmissionResult.Failed>(coordinator.submit())
+
+        assertIs<InstanceCloseResponseMismatchException>(failed.error)
+        assertIs<InstanceCloseState.AwaitingConfirmation>(coordinator.state.value)
+    }
+
+    @Test
+    fun mismatchedRawLocationCannotBecomeARequestTarget() {
+        val instance = InstanceVo(
+            id = "unexpected",
+            instanceId = INSTANCE_ID,
+            worldId = WORLD_ID,
+            location = "$WORLD_ID:other",
+            ownerId = OWNER_ID,
+        )
+
+        assertNull(instance.closeTargetOrNull())
+    }
+
+    @Test
+    fun serverResponseControlsWhetherTheInstanceIsUpdatedOrRemoved() {
+        val target = personalTarget()
+        val originalData = closedInstance(active = true, closedAt = null).copy(nUsers = 3)
+        val original = InstanceVo(originalData)
+        val profile = WorldProfileVo(
+            worldId = WORLD_ID,
+            instances = listOf(original),
+        )
+
+        val stillActive = profile.applyInstanceCloseResponse(
+            target,
+            originalData.copy(nUsers = 2),
+        )
+        assertEquals(2, stillActive.instances.single().currentUsers)
+        assertTrue(stillActive.instances.single().owner === original.owner)
+
+        val closed = stillActive.applyInstanceCloseResponse(
+            target,
+            originalData.copy(active = false, closedAt = "2026-08-31T08:00:00.000Z"),
+        )
+        assertTrue(closed.instances.isEmpty())
+    }
+
+    private fun coordinator(
+        currentSession: () -> AccountSessionToken?,
+        groupPermissions: suspend (
+            AccountSessionToken,
+            String,
+        ) -> InstanceCloseSessionResult<List<String>>? = { token, _ ->
+            InstanceCloseSessionResult(Result.success(emptyList()), token)
+        },
+        closeInstance: suspend (
+            AccountSessionToken,
+            InstanceCloseTarget,
+        ) -> InstanceCloseSessionResult<InstanceData>? = { token, _ ->
+            InstanceCloseSessionResult(Result.success(closedInstance()), token)
+        },
+    ) = InstanceCloseCoordinator(
+        currentSessionToken = currentSession,
+        isCurrentSession = { it == currentSession() },
+        fetchGroupPermissions = groupPermissions,
+        closeInstance = closeInstance,
+    )
+
+    private fun personalTarget(ownerId: String = OWNER_ID) = InstanceCloseTarget(
+        worldId = WORLD_ID,
+        instanceId = INSTANCE_ID,
+        ownerId = ownerId,
+    )
+
+    private fun groupTarget() = InstanceCloseTarget(
+        worldId = WORLD_ID,
+        instanceId = INSTANCE_ID,
+        ownerId = GROUP_ID,
+    )
+
+    private fun closedInstance(
+        worldId: String = WORLD_ID,
+        instanceId: String = INSTANCE_ID,
+        location: String = "$worldId:$instanceId",
+        active: Boolean = false,
+        closedAt: String? = "2026-08-31T08:00:00.000Z",
+    ) = InstanceData(
+        active = active,
+        canRequestInvite = false,
+        capacity = 16,
+        clientNumber = "1",
+        closedAt = closedAt,
+        full = false,
+        hidden = null,
+        id = location,
+        instanceId = instanceId,
+        location = location,
+        nUsers = 0,
+        name = "12345",
+        ownerId = OWNER_ID,
+        permanent = false,
+        photonRegion = "us",
+        platforms = Platforms(),
+        queueEnabled = false,
+        queueSize = 0,
+        recommendedCapacity = 16,
+        region = RegionType.Us,
+        secureName = "secure",
+        strict = false,
+        tags = emptyList(),
+        type = "private",
+        userCount = 0,
+        world = WorldData(
+            authorId = OWNER_ID,
+            authorName = "Author",
+            capacity = 16,
+            createdAt = null,
+            description = null,
+            favorites = 0,
+            featured = false,
+            heat = 0,
+            id = worldId,
+            imageUrl = "",
+            labsPublicationDate = "",
+            name = "World",
+            namespace = null,
+            organization = "",
+            popularity = 0,
+            publicationDate = "",
+            recommendedCapacity = 16,
+            releaseStatus = "public",
+            tags = emptyList(),
+            thumbnailImageUrl = null,
+            udonProducts = emptyList(),
+            unityPackages = emptyList(),
+            updatedAt = null,
+            version = 1,
+            visits = 0,
+        ),
+        worldId = worldId,
+    )
+
+    private companion object {
+        const val OWNER_ID = "usr_00000000-0000-0000-0000-000000000001"
+        const val OTHER_USER_ID = "usr_00000000-0000-0000-0000-000000000002"
+        const val GROUP_ID = "grp_00000000-0000-0000-0000-000000000003"
+        const val WORLD_ID = "wrld_00000000-0000-0000-0000-000000000004"
+        const val INSTANCE_ID = "12345~region(us)"
+        val OWNER_TOKEN = AccountSessionToken(OWNER_ID, generation = 1)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/InstanceCloseCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/InstanceCloseCoordinatorTest.kt
@@ -2,6 +2,7 @@ package io.github.vrcmteam.vrcm.presentation.screens.world
 
 import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
 import io.github.vrcmteam.vrcm.network.api.attributes.RegionType
+import io.github.vrcmteam.vrcm.network.api.instances.data.InstanceCloseResponse
 import io.github.vrcmteam.vrcm.network.api.instances.data.InstanceData
 import io.github.vrcmteam.vrcm.network.api.instances.data.Platforms
 import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
@@ -11,6 +12,7 @@ import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -160,6 +162,36 @@ class InstanceCloseCoordinatorTest {
             fetchInstance = { token, _ ->
                 InstanceCloseSessionResult(
                     Result.success(closedInstance(active = true, closedAt = null)),
+                    token,
+                )
+            },
+            closeInstance = { token, _ ->
+                InstanceCloseSessionResult(
+                    Result.failure(VRCApiException("Forbidden", 403, "permission denied")),
+                    token,
+                )
+            },
+        )
+        coordinator.authorize(personalTarget())
+
+        val failed = assertIs<InstanceCloseSubmissionResult.Failed>(coordinator.submit())
+
+        assertEquals(403, assertIs<VRCApiException>(failed.error).code)
+        assertIs<InstanceCloseState.AwaitingConfirmation>(coordinator.state.value)
+    }
+
+    @Test
+    fun forbiddenCloseRemainsRetryableWhenRecheckOmitsCloseState() = runTest {
+        var currentToken: AccountSessionToken? = OWNER_TOKEN
+        val coordinator = coordinator(
+            currentSession = { currentToken },
+            fetchInstanceResponse = { token, _ ->
+                InstanceCloseSessionResult(
+                    Result.success(
+                        closedInstance(active = true, closedAt = null)
+                            .asInstanceCloseResponse()
+                            .copy(active = null, closedAt = null),
+                    ),
                     token,
                 )
             },
@@ -329,30 +361,21 @@ class InstanceCloseCoordinatorTest {
     }
 
     @Test
-    fun serverResponseControlsWhetherTheInstanceIsUpdatedOrRemoved() {
+    fun successfulDeleteRemovesInstanceWhenCloseStatusFieldsAreOmitted() = runTest {
         val target = personalTarget()
-        val originalData = closedInstance(active = true, closedAt = null).copy(nUsers = 3)
-        val original = InstanceVo(originalData)
-        val profile = WorldProfileVo(
-            worldId = WORLD_ID,
-            instances = listOf(original),
+        val profileState = MutableStateFlow<WorldProfileVo?>(
+            WorldProfileVo(
+                worldId = WORLD_ID,
+                instances = listOf(InstanceVo(closedInstance(active = true, closedAt = null))),
+            )
         )
+        val response = closedInstance(active = true, closedAt = null)
+            .asInstanceCloseResponse()
+            .copy(active = null, closedAt = null)
 
-        val stillActive = profile.applyInstanceCloseResponse(
-            target,
-            originalData.copy(nUsers = 2).asInstanceCloseResponse(),
-        )
-        assertEquals(2, stillActive.instances.single().currentUsers)
-        assertTrue(stillActive.instances.single().owner === original.owner)
+        WorldInstanceStateStore(profileState).applyClose(target, response)
 
-        val closed = stillActive.applyInstanceCloseResponse(
-            target,
-            originalData.copy(
-                active = false,
-                closedAt = "2026-08-31T08:00:00.000Z",
-            ).asInstanceCloseResponse(),
-        )
-        assertTrue(closed.instances.isEmpty())
+        assertTrue(profileState.value!!.instances.isEmpty())
     }
 
     private fun coordinator(
@@ -372,6 +395,10 @@ class InstanceCloseCoordinatorTest {
                 token,
             )
         },
+        fetchInstanceResponse: suspend (
+            AccountSessionToken,
+            InstanceCloseTarget,
+        ) -> InstanceCloseSessionResult<InstanceCloseResponse>? = { _, _ -> null },
         closeInstance: suspend (
             AccountSessionToken,
             InstanceCloseTarget,
@@ -383,12 +410,13 @@ class InstanceCloseCoordinatorTest {
         isCurrentSession = { it == currentSession() },
         fetchGroupPermissions = groupPermissions,
         fetchInstance = { token, target ->
-            fetchInstance(token, target)?.let { response ->
-                InstanceCloseSessionResult(
-                    result = response.result.map { it.asInstanceCloseResponse() },
-                    sessionToken = response.sessionToken,
-                )
-            }
+            fetchInstanceResponse(token, target)
+                ?: fetchInstance(token, target)?.let { response ->
+                    InstanceCloseSessionResult(
+                        result = response.result.map { it.asInstanceCloseResponse() },
+                        sessionToken = response.sessionToken,
+                    )
+                }
         },
         closeInstance = { token, target ->
             closeInstance(token, target)?.let { response ->

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldProfileInstanceCloseTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldProfileInstanceCloseTest.kt
@@ -1,0 +1,249 @@
+package io.github.vrcmteam.vrcm.presentation.screens.world
+
+import androidx.lifecycle.ViewModelStore
+import com.russhwolf.settings.MapSettings
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
+import io.github.vrcmteam.vrcm.di.supports.PersistentCookiesStorage
+import io.github.vrcmteam.vrcm.network.api.auth.AuthApi
+import io.github.vrcmteam.vrcm.network.api.files.FileApi
+import io.github.vrcmteam.vrcm.network.api.groups.GroupsApi
+import io.github.vrcmteam.vrcm.network.api.instances.InstancesApi
+import io.github.vrcmteam.vrcm.network.api.invite.InviteApi
+import io.github.vrcmteam.vrcm.network.api.users.UsersApi
+import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
+import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
+import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntrySource
+import io.github.vrcmteam.vrcm.presentation.screens.world.data.InstanceVo
+import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
+import io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStringsZhHans
+import io.github.vrcmteam.vrcm.service.AuthService
+import io.github.vrcmteam.vrcm.service.WorldPlatformService
+import io.github.vrcmteam.vrcm.storage.AccountCacheManager
+import io.github.vrcmteam.vrcm.storage.AccountDao
+import io.github.vrcmteam.vrcm.storage.InMemoryFriendListCacheStore
+import io.github.vrcmteam.vrcm.storage.InMemorySecureStorage
+import io.github.vrcmteam.vrcm.storage.InMemoryUserProfileCacheStore
+import io.github.vrcmteam.vrcm.storage.WorldProfileCacheStore
+import io.github.vrcmteam.vrcm.storage.data.WorldProfileCache
+import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardAssetStore
+import io.github.vrcmteam.vrcm.storage.meetup.MeetupCardConfigDao
+import io.github.vrcmteam.vrcm.testing.MainDispatcherTest
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import kotlinx.serialization.json.Json
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.koin.core.logger.EmptyLogger
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class WorldProfileInstanceCloseTest : MainDispatcherTest() {
+    private val models = mutableListOf<WorldProfileScreenModel>()
+
+    @AfterTest
+    fun cleanUp() = runBlocking {
+        models.forEach { model ->
+            ViewModelStore().apply {
+                put("test", model)
+                clear()
+            }
+        }
+        SharedFlowCentre.emitLogout()
+    }
+
+    @Test
+    fun closeWinsOverAnEarlierInstanceRefreshResponse() = runBlocking {
+        val refreshStarted = CompletableDeferred<Unit>()
+        val releaseRefresh = CompletableDeferred<Unit>()
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when {
+                        request.method == HttpMethod.Get && request.url.encodedPath ==
+                            "/worlds/$WORLD_ID/$INSTANCE_ID" -> {
+                            refreshStarted.complete(Unit)
+                            releaseRefresh.await()
+                            respondJson(instanceJson(active = true, closedAt = null))
+                        }
+
+                        request.method == HttpMethod.Delete && request.url.encodedPath ==
+                            "/instances/$LOCATION" ->
+                            respondJson(instanceJson(active = false, closedAt = CLOSED_AT))
+
+                        request.url.encodedPath.startsWith("/users/") ->
+                            respond("owner unavailable", HttpStatusCode.InternalServerError)
+
+                        else -> error("Unexpected request: ${request.method} ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+        val model = createModel(client)
+        SharedFlowCentre.emitAuthenticated(
+            io.github.vrcmteam.vrcm.service.data.AccountDto(userId = USER_ID, username = "owner")
+        )
+
+        try {
+            model.loadWorldData(
+                WorldProfileVo(
+                    worldId = WORLD_ID,
+                    instances = listOf(InstanceVo(id = LOCATION, instanceId = INSTANCE_ID,
+                        worldId = WORLD_ID, location = LOCATION, ownerId = USER_ID)),
+                )
+            )
+            refreshStarted.await()
+
+            model.requestInstanceClose(model.worldProfileState.value!!.instances.single(), LocaleStringsZhHans)
+            awaitUntil { model.instanceCloseState.value is InstanceCloseState.AwaitingConfirmation }
+            model.confirmInstanceClose(LocaleStringsZhHans)
+            awaitUntil { model.worldProfileState.value?.instances?.isEmpty() == true }
+
+            releaseRefresh.complete(Unit)
+            awaitUntil { !model.isLoading.value }
+
+            assertTrue(model.worldProfileState.value!!.instances.isEmpty())
+        } finally {
+            client.close()
+        }
+    }
+
+    private fun createModel(client: HttpClient): WorldProfileScreenModel {
+        val authService = AuthService(
+            authApi = AuthApi(client),
+            accountDao = AccountDao(MapSettings(), InMemorySecureStorage()),
+            cookiesStorage = PersistentCookiesStorage(EmptyLogger()),
+            accountCacheManager = AccountCacheManager(
+                friendListCacheStore = InMemoryFriendListCacheStore(),
+                userProfileCacheStore = InMemoryUserProfileCacheStore(),
+                friendActivityStore = io.github.vrcmteam.vrcm.storage.NoOpFriendActivityCacheStore,
+                meetupCardConfigDao = MeetupCardConfigDao(MapSettings()),
+                meetupCardAssetStore = MeetupCardAssetStore(FakeFileSystem(), "/assets".toPath()),
+            ),
+        )
+        val worldData = worldData()
+        val cacheStore = object : WorldProfileCacheStore {
+            override suspend fun load(worldId: String) = WorldProfileCache(
+                world = worldData,
+                cachedAtEpochMilliseconds = Long.MAX_VALUE,
+            )
+
+            override suspend fun save(cache: WorldProfileCache) = Unit
+            override suspend fun clearAll() = Unit
+        }
+        val favoriteSource = object : FavoriteEntrySource {
+            private val favorites = MutableStateFlow(emptyMap<
+                io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteGroupData,
+                List<io.github.vrcmteam.vrcm.network.api.favorite.data.FavoriteData>,
+            >())
+
+            override fun favoritesByGroup(
+                type: io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType,
+            ) = favorites
+
+            override suspend fun load(
+                type: io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType,
+            ) = Result.success(Unit)
+        }
+        return WorldProfileScreenModel(
+            worldsApi = WorldsApi(client),
+            instancesApi = InstancesApi(client),
+            usersApi = UsersApi(client),
+            groupsApi = GroupsApi(client),
+            authService = authService,
+            favoriteEntrySource = favoriteSource,
+            inviteApi = InviteApi(client),
+            worldPlatformService = WorldPlatformService(FileApi(client)),
+            worldProfileCacheStore = cacheStore,
+        ).also(models::add)
+    }
+
+    private fun worldData() = WorldData(
+        authorId = USER_ID,
+        authorName = "Owner",
+        capacity = 16,
+        createdAt = null,
+        description = null,
+        favorites = 0,
+        featured = false,
+        heat = 0,
+        id = WORLD_ID,
+        imageUrl = "",
+        labsPublicationDate = "",
+        name = "World",
+        namespace = null,
+        organization = "",
+        popularity = 0,
+        publicationDate = "",
+        recommendedCapacity = 16,
+        releaseStatus = "public",
+        tags = emptyList(),
+        thumbnailImageUrl = null,
+        udonProducts = emptyList(),
+        unityPackages = emptyList(),
+        instances = listOf(listOf(INSTANCE_ID)),
+        updatedAt = null,
+        version = 1,
+        visits = 0,
+    )
+
+    private fun instanceJson(active: Boolean, closedAt: String?): String =
+        """
+        {
+          "active":$active,"canRequestInvite":false,"capacity":16,"clientNumber":"1",
+          "closedAt":${closedAt?.let { "\"$it\"" } ?: "null"},"full":false,"hidden":null,
+          "id":"$LOCATION","instanceId":"$INSTANCE_ID","location":"$LOCATION","n_users":0,
+          "name":"12345","ownerId":"$USER_ID","permanent":false,"photonRegion":"us",
+          "platforms":{"android":0,"ios":0,"standalonewindows":0},"queueEnabled":false,
+          "queueSize":0,"recommendedCapacity":16,"region":"us","secureName":"secure",
+          "strict":false,"tags":[],"type":"private","userCount":0,
+          "world":${worldJson()},"worldId":"$WORLD_ID"
+        }
+        """.trimIndent()
+
+    private fun worldJson(): String =
+        """
+        {"authorId":"$USER_ID","authorName":"Owner","capacity":16,"created_at":null,
+        "description":null,"favorites":0,"featured":false,"heat":0,"id":"$WORLD_ID",
+        "imageUrl":"","labsPublicationDate":"","name":"World","namespace":null,
+        "organization":"","popularity":0,"publicationDate":"","recommendedCapacity":16,
+        "releaseStatus":"public","tags":[],"thumbnailImageUrl":null,"udonProducts":[],
+        "unityPackages":[],"updated_at":null,"version":1,"visits":0}
+        """.trimIndent()
+
+    private fun io.ktor.client.engine.mock.MockRequestHandleScope.respondJson(content: String) =
+        respond(
+            content = content,
+            status = HttpStatusCode.OK,
+            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+        )
+
+    private suspend fun awaitUntil(predicate: () -> Boolean) {
+        withTimeout(2_000) {
+            while (!predicate()) yield()
+        }
+    }
+
+    private companion object {
+        const val USER_ID = "usr_00000000-0000-0000-0000-000000000001"
+        const val WORLD_ID = "wrld_00000000-0000-0000-0000-000000000002"
+        const val INSTANCE_ID = "12345~region(us)"
+        const val LOCATION = "$WORLD_ID:$INSTANCE_ID"
+        const val CLOSED_AT = "2026-09-01T00:00:00.000Z"
+    }
+}


### PR DESCRIPTION
## 变更内容
- 在世界实例详情中增加普通立即关闭入口、二次确认、提交中状态和明确的失败反馈。
- 个人实例要求当前账号为所有者；群组实例要求拥有管理实例权限或通配权限。
- 将确认目标绑定到规范化 location 与精确账号会话，处理重复提交、认证续期、换号、登出和旧响应。
- 以服务端返回的实例数据为权威结果，校验目标一致后更新或移除页面条目。
- 关闭响应使用专用 DTO 容忍协议允许缺失的字段；DELETE 成功本身作为立即关闭事实，并通过位置版本与关闭墓碑阻止更早的刷新响应回写。
- 对关闭接口的 403 使用同一会话复查实例状态：明确已关闭时按成功收敛，仍活跃、状态缺失或无法确认时保留可重试确认态并报告通用失败。
- 同步英文、日文、简体中文和繁体中文文案。

## 实现假设清单
- 关闭接口成功时返回目标实例数据；由于 DELETE 200 已经表示立即关闭，即使 active、closedAt 等协议可选字段缺失，也按成功结果移除目标实例。
- 403 复查使用 GET 实例状态：只有明确 active=false 或 closedAt 非空才确认实例已关闭；状态字段缺失时不把实例误判为已关闭。
- 普通立即关闭会立刻停止接受新用户，但不承诺断开实例内现有用户。
- 本功能不发送任何高级关闭参数，仅执行普通立即关闭。
- 个人实例仅允许所有者操作；群组实例允许具有 group-instance-manage 或通配权限的当前成员操作。
- 同账号认证续期产生的新会话 generation 可以承接原请求；其他会话变化必须撤销待确认状态或丢弃旧响应。
- 服务端明确返回已关闭的 location 在当前页面生命周期内不会重新开放；该 location 的后续旧刷新响应会被关闭墓碑拒绝。

## 验证
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests io.github.vrcmteam.vrcm.network.api.instances.InstancesApiTest --tests io.github.vrcmteam.vrcm.presentation.screens.world.InstanceCloseCoordinatorTest --tests io.github.vrcmteam.vrcm.presentation.screens.world.WorldProfileInstanceCloseTest`：通过。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest`：822 项中 820 项通过；`DesktopWindowTitleBarLocaleTest` 在无图形会话中因 `HeadlessException` 失败，`MeetupCardScreenModelTest` 因完整套件共享异常状态在测试开始前失败，均为知识库已记录的基线问题。
- `~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests io.github.vrcmteam.vrcm.presentation.screens.meetup.MeetupCardScreenModelTest.shortTextRejectsMoreThanEightyCodePointsWithoutPersisting`：隔离复跑通过。
- `git diff --check`：通过。

## 代码逻辑图
```mermaid
flowchart TD
    A[实例详情点击关闭] --> B[InstanceCloseCoordinator.authorize 绑定规范化 location 与当前会话 token]
    B --> C{CAS Idle 到 Authorizing}
    C -->|失败| C1[返回 Busy]
    C -->|成功| D{ownerId 类型}
    D -->|个人| E{token.userId 等于 ownerId}
    D -->|群组| F[runSessionBoundCatching 获取群组权限]
    D -->|其他| G[Authorizing 到 Idle并提示无权限]
    E -->|否| G
    E -->|是且会话仍匹配| H[CAS Authorizing 到 AwaitingConfirmation]
    F -->|401| F1[同账号认证续期并重试权限请求]
    F1 --> F
    F -->|无管理或通配权限| G
    F -->|请求失败| G1[Authorizing 到 Idle并提示失败]
    F -->|有权限且会话仍匹配| H
    H --> I{用户操作或会话变化}
    I -->|取消/换号/登出| I1[AwaitingConfirmation 到 Idle或返回 Abandoned]
    I -->|确认| J{CAS AwaitingConfirmation 到 Submitting}
    J -->|失败| C1
    J -->|成功| K[runSessionBoundCatching DELETE instances/location]
    K -->|401| K1[同账号认证续期并重试关闭请求]
    K1 --> K
    K -->|换号/登出/旧响应| K2[Submitting 到 Idle并丢弃响应]
    K -->|非403失败或目标不一致| L[Submitting 回到 AwaitingConfirmation并提示失败]
    K -->|403| M[同一会话 GET InstancesApi.closeStatus]
    M -->|401| M1[同账号认证续期并重试复查]
    M1 --> M
    M -->|已明确关闭且目标一致| N[CAS Submitting 到 Idle]
    M -->|仍活跃、状态缺失或无法确认| L
    K -->|DELETE 200且目标一致即视为关闭| N
    N --> O[WorldInstanceStateStore.applyClose 校验目标并提升 location revision]
    O --> P[记录 closed location 墓碑并移除实例条目]
    R[loadInstanceData 发出实例 GET] --> S[捕获 location revision]
    S --> T[GET 返回后进入 commitMutex]
    T --> U{revision 已变化或命中墓碑}
    U -->|是| V[丢弃关闭之前发出的旧响应]
    U -->|否且响应已关闭| P
    U -->|否且仍活跃| W[更新当前实例条目]
```
