### PR TITLE
feat(world): 支持 Home World 设置与重置

### DIFF
--- a/composeApp/src/commonMain/kotlin/di/modules/ServiceModule.kt
+++ b/composeApp/src/commonMain/kotlin/di/modules/ServiceModule.kt
@@ -34,6 +34,7 @@ val serviceModule: Module = module {
     singleOf(::VrchatStatusNotificationService)
     singleOf(::NetworkBoopRequest) bind BoopRequest::class
     singleOf(::BoopService)
+    singleOf(::HomeWorldService) bind HomeWorldManager::class
     singleOf(::WorldPlatformService)
     singleOf(::OfficialLinkService)
     singleOf(::HttpMeetupRemoteBytesLoader) bind MeetupRemoteBytesLoader::class

--- a/composeApp/src/commonMain/kotlin/network/api/users/data/UpdateUserInfoData.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/users/data/UpdateUserInfoData.kt
@@ -9,6 +9,7 @@ data class UpdateUserInfoData(
     val ageVerificationStatus: AgeVerificationStatus? = null,
     val bio: String? = null,
     val bioLinks: List<String>? = null,
+    val homeLocation: String? = null,
     val status: UserStatus? = null,
     val statusDescription: String? = null,
     val pronouns: String? = null,

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
@@ -24,7 +24,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home as FilledHome
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.outlined.Home as OutlinedHome
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -58,6 +60,7 @@ import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import io.github.vrcmteam.vrcm.core.extensions.toLocalDate
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
 import io.github.vrcmteam.vrcm.network.api.files.data.PlatformType.*
 import io.github.vrcmteam.vrcm.presentation.compoments.*
@@ -72,10 +75,17 @@ import io.github.vrcmteam.vrcm.presentation.screens.world.components.InstanceCar
 import io.github.vrcmteam.vrcm.presentation.screens.world.components.InstancesDialog
 import io.github.vrcmteam.vrcm.presentation.screens.world.data.*
 import io.github.vrcmteam.vrcm.presentation.screens.world.data.SheetState
+import io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStrings
 import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
 import presentation.compoments.TopMenuBar
 import kotlin.math.abs
+
+internal fun HomeWorldNotice.localizedToast(locale: LocaleStrings): ToastText = when (this) {
+    HomeWorldNotice.Set -> ToastText.Success(locale.worldProfileHomeWorldSetSuccess)
+    HomeWorldNotice.Reset -> ToastText.Success(locale.worldProfileHomeWorldResetSuccess)
+    HomeWorldNotice.UpdateFailed -> ToastText.Error(locale.worldProfileHomeWorldUpdateFailed)
+}
 
 /**
  *
@@ -103,10 +113,25 @@ class WorldProfileScreen(
         // 收集ViewModel状态
         val profileVoState by screenModel.worldProfileState.collectAsState()
         val isLoading by screenModel.isLoading.collectAsState()
+        val homeWorldActionState by screenModel.homeWorldActionState.collectAsState()
         val currentNavigator = currentNavigator
+        val locale = strings
+        var showHomeWorldConfirmation by remember { mutableStateOf(false) }
         // 组件首次加载时自动刷新数据
         LaunchedEffect(Unit) {
             screenModel.loadWorldData(worldProfileVO)
+        }
+
+        LaunchedEffect(screenModel, locale) {
+            screenModel.homeWorldNotices.collect { notice ->
+                SharedFlowCentre.toastText.emit(notice.localizedToast(locale))
+            }
+        }
+
+        LaunchedEffect(homeWorldActionState.availability) {
+            if (homeWorldActionState.availability == HomeWorldActionAvailability.Unavailable) {
+                showHomeWorldConfirmation = false
+            }
         }
 
         CompositionLocalProvider(
@@ -118,20 +143,65 @@ class WorldProfileScreen(
                 onMenu = { /* 打开菜单 */ },
                 isRefreshing = isLoading,
                 onRefresh = screenModel::refreshWorldData,
+                homeWorldActionState = homeWorldActionState,
+                onHomeWorldClick = { showHomeWorldConfirmation = true },
                 sharedKeyPrefix = sharedKeyPrefix,
                 sharedImageCacheKey = sharedImageCacheKey,
+            )
+        }
+
+        if (showHomeWorldConfirmation) {
+            val resetHomeWorld = homeWorldActionState.availability == HomeWorldActionAvailability.Current
+            AlertDialog(
+                onDismissRequest = {
+                    if (!homeWorldActionState.isUpdating) showHomeWorldConfirmation = false
+                },
+                title = {
+                    Text(
+                        if (resetHomeWorld) strings.worldProfileResetHomeWorld
+                        else strings.worldProfileSetHomeWorld
+                    )
+                },
+                text = {
+                    Text(
+                        if (resetHomeWorld) strings.worldProfileResetHomeWorldConfirmation
+                        else strings.worldProfileSetHomeWorldConfirmation
+                    )
+                },
+                confirmButton = {
+                    TextButton(
+                        enabled = !homeWorldActionState.isUpdating &&
+                            homeWorldActionState.availability != HomeWorldActionAvailability.Unavailable,
+                        onClick = {
+                            showHomeWorldConfirmation = false
+                            screenModel.updateHomeWorld()
+                        },
+                    ) {
+                        Text(strings.confirm)
+                    }
+                },
+                dismissButton = {
+                    TextButton(
+                        enabled = !homeWorldActionState.isUpdating,
+                        onClick = { showHomeWorldConfirmation = false },
+                    ) {
+                        Text(strings.cancel)
+                    }
+                },
             )
         }
     }
 
     // 主要内容组件
     @Composable
-    fun WorldProfileContent(
+    internal fun WorldProfileContent(
         worldProfileVo: WorldProfileVo,
         onReturn: () -> Unit = {},
         onMenu: () -> Unit = {},
         isRefreshing: Boolean = false,
         onRefresh: () -> Unit = {},
+        homeWorldActionState: HomeWorldActionState = HomeWorldActionState(),
+        onHomeWorldClick: () -> Unit = {},
         sharedKeyPrefix: String = "",
         sharedImageCacheKey: String? = null,
     ) {
@@ -227,7 +297,9 @@ class WorldProfileScreen(
                 onMenu = onMenu,
                 onCollapse = { sheetState = SheetState.COLLAPSED },
                 isRefreshing = isRefreshing,
-                onRefresh = onRefresh
+                onRefresh = onRefresh,
+                homeWorldActionState = homeWorldActionState,
+                onHomeWorldClick = onHomeWorldClick,
             )
 
             // ========== BottomSheet ==========
@@ -729,6 +801,8 @@ private fun RenderTopBar(
     onCollapse: () -> Unit,
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
+    homeWorldActionState: HomeWorldActionState,
+    onHomeWorldClick: () -> Unit,
 ) {
     BoxWithConstraints(
         modifier = Modifier
@@ -736,7 +810,7 @@ private fun RenderTopBar(
             .zIndex(20f) // 确保在所有内容之上
     ) {
         val topBarRatio = (1 - blurProgress).coerceIn(0f, 1f)
-        val titleMaxWidth = (maxWidth - 208.dp).coerceIn(40.dp, 200.dp)
+        val titleMaxWidth = (maxWidth - 256.dp).coerceIn(40.dp, 200.dp)
 
         // 添加TopMenuBar
         TopMenuBar(
@@ -751,6 +825,11 @@ private fun RenderTopBar(
                 OfficialUrlShareButton(
                     url = "https://vrchat.com/home/world/$worldId",
                     colors = colors,
+                )
+                HomeWorldActionButton(
+                    state = homeWorldActionState,
+                    colors = colors,
+                    onClick = onHomeWorldClick,
                 )
                 IconButton(
                     enabled = !isRefreshing,
@@ -798,6 +877,41 @@ private fun RenderTopBar(
                     overflow = TextOverflow.Ellipsis
                 )
 
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun HomeWorldActionButton(
+    state: HomeWorldActionState,
+    colors: IconButtonColors,
+    onClick: () -> Unit,
+) {
+    val current = state.availability == HomeWorldActionAvailability.Current
+    val description = when (state.availability) {
+        HomeWorldActionAvailability.Unavailable -> strings.worldProfileHomeWorldUnavailable
+        HomeWorldActionAvailability.CanSet -> strings.worldProfileSetHomeWorld
+        HomeWorldActionAvailability.Current -> strings.worldProfileResetHomeWorld
+    }
+    ATooltipBox(tooltip = { Text(description) }) {
+        IconButton(
+            enabled = state.availability != HomeWorldActionAvailability.Unavailable && !state.isUpdating,
+            colors = colors,
+            onClick = onClick,
+        ) {
+            if (state.isUpdating) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(22.dp),
+                    color = LocalContentColor.current,
+                    strokeWidth = 2.dp,
+                )
+            } else {
+                Icon(
+                    imageVector = if (current) Icons.Filled.FilledHome else Icons.Outlined.OutlinedHome,
+                    contentDescription = description,
+                )
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
@@ -22,6 +22,9 @@ import io.github.vrcmteam.vrcm.presentation.screens.world.data.InstanceVo.Owner
 import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
 import io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStrings
 import io.github.vrcmteam.vrcm.service.AuthService
+import io.github.vrcmteam.vrcm.service.HomeWorldManager
+import io.github.vrcmteam.vrcm.service.HomeWorldSessionChangedException
+import io.github.vrcmteam.vrcm.service.HomeWorldUserContext
 import io.github.vrcmteam.vrcm.service.WorldPlatformService
 import io.github.vrcmteam.vrcm.storage.WorldProfileCacheStore
 import io.github.vrcmteam.vrcm.storage.data.WorldProfileCache
@@ -32,6 +35,23 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
+
+internal enum class HomeWorldActionAvailability {
+    Unavailable,
+    CanSet,
+    Current,
+}
+
+internal data class HomeWorldActionState(
+    val availability: HomeWorldActionAvailability = HomeWorldActionAvailability.Unavailable,
+    val isUpdating: Boolean = false,
+)
+
+internal sealed interface HomeWorldNotice {
+    data object Set : HomeWorldNotice
+    data object Reset : HomeWorldNotice
+    data object UpdateFailed : HomeWorldNotice
+}
 
 /**
  * 世界档案页面的ViewModel，负责处理世界数据的加载和刷新
@@ -47,6 +67,7 @@ class WorldProfileScreenModel internal constructor(
     private val inviteApi: InviteApi,
     private val worldPlatformService: WorldPlatformService,
     private val worldProfileCacheStore: WorldProfileCacheStore,
+    private val homeWorldManager: HomeWorldManager,
 ) : ViewModel() {
     // 世界数据状态
     private val _worldProfileState = MutableStateFlow<WorldProfileVo?>(null)
@@ -55,6 +76,29 @@ class WorldProfileScreenModel internal constructor(
     // 加载状态
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val currentHomeWorldUser = homeWorldManager.currentUser.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = null,
+    )
+    private val isUpdatingHomeWorld = MutableStateFlow(false)
+    internal val homeWorldActionState: StateFlow<HomeWorldActionState> = combine(
+        worldProfileState,
+        currentHomeWorldUser,
+        isUpdatingHomeWorld,
+    ) { world, user, isUpdating ->
+        HomeWorldActionState(
+            availability = homeWorldActionAvailability(world?.worldId, user),
+            isUpdating = isUpdating,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = HomeWorldActionState(),
+    )
+    private val _homeWorldNotices = MutableSharedFlow<HomeWorldNotice>(extraBufferCapacity = 1)
+    internal val homeWorldNotices: SharedFlow<HomeWorldNotice> = _homeWorldNotices.asSharedFlow()
 
     private val favoriteEntry = FavoriteEntryStateModel(
         favoriteType = FavoriteType.World,
@@ -65,6 +109,38 @@ class WorldProfileScreenModel internal constructor(
 
     internal fun retryFavoriteEntryLoad() {
         favoriteEntry.retry()
+    }
+
+    internal fun updateHomeWorld() {
+        val worldId = worldProfileState.value?.worldId ?: return
+        val reset = when (homeWorldActionState.value.availability) {
+            HomeWorldActionAvailability.CanSet -> false
+            HomeWorldActionAvailability.Current -> true
+            HomeWorldActionAvailability.Unavailable -> return
+        }
+        if (!isUpdatingHomeWorld.compareAndSet(expect = false, update = true)) return
+
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                homeWorldManager.updateHomeWorld(worldId.takeUnless { reset })
+                    .onSuccess {
+                        if (_worldProfileState.value?.worldId == worldId) {
+                            _homeWorldNotices.emit(
+                                if (reset) HomeWorldNotice.Reset else HomeWorldNotice.Set
+                            )
+                        }
+                    }
+                    .onFailure { error ->
+                        if (error !is HomeWorldSessionChangedException &&
+                            _worldProfileState.value?.worldId == worldId
+                        ) {
+                            _homeWorldNotices.emit(HomeWorldNotice.UpdateFailed)
+                        }
+                    }
+            } finally {
+                isUpdatingHomeWorld.value = false
+            }
+        }
     }
 
     /**
@@ -333,4 +409,14 @@ class WorldProfileScreenModel internal constructor(
             refreshWorldData()
         }
     }
-} 
+}
+
+internal fun homeWorldActionAvailability(
+    worldId: String?,
+    user: HomeWorldUserContext?,
+): HomeWorldActionAvailability = when {
+    worldId == null || !io.github.vrcmteam.vrcm.service.isWorldId(worldId) || user == null ->
+        HomeWorldActionAvailability.Unavailable
+    user.homeLocation == worldId -> HomeWorldActionAvailability.Current
+    else -> HomeWorldActionAvailability.CanSet
+}

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
@@ -251,6 +251,15 @@ sealed class LocaleStrings {
     open val worldProfilePublishDate: String = "Publish Date"
     open val worldProfileUpdateDate: String = "Update Date"
     open val worldProfileLabReleaseDate: String = "Lab Release Date"
+    open val worldProfileSetHomeWorld: String = "Set as Home World"
+    open val worldProfileResetHomeWorld: String = "Reset Home World"
+    open val worldProfileHomeWorldUnavailable: String = "Home World action unavailable"
+    open val worldProfileSetHomeWorldConfirmation: String = "Use this world as your Home World?"
+    open val worldProfileResetHomeWorldConfirmation: String =
+        "Remove your custom Home World and restore VRChat's default?"
+    open val worldProfileHomeWorldSetSuccess: String = "Home World updated"
+    open val worldProfileHomeWorldResetSuccess: String = "Home World reset"
+    open val worldProfileHomeWorldUpdateFailed: String = "Couldn't update Home World"
     open val unknown: String = "Unknown"
 
     // CreateInstanceDialog

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
@@ -236,6 +236,14 @@ internal object LocaleStringsJa : LocaleStrings() {
     override val worldProfilePublishDate = "公開日"
     override val worldProfileUpdateDate = "更新日"
     override val worldProfileLabReleaseDate = "ラボ公開日"
+    override val worldProfileSetHomeWorld = "Home World に設定"
+    override val worldProfileResetHomeWorld = "Home World をリセット"
+    override val worldProfileHomeWorldUnavailable = "Home World の操作は利用できません"
+    override val worldProfileSetHomeWorldConfirmation = "このワールドを Home World に設定しますか？"
+    override val worldProfileResetHomeWorldConfirmation = "カスタム Home World を解除して VRChat のデフォルトに戻しますか？"
+    override val worldProfileHomeWorldSetSuccess = "Home World を更新しました"
+    override val worldProfileHomeWorldResetSuccess = "Home World をリセットしました"
+    override val worldProfileHomeWorldUpdateFailed = "Home World を更新できませんでした"
     override val unknown = "不明"
 
     // CreateInstanceDialog

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
@@ -235,6 +235,14 @@ internal object LocaleStringsZhHans : LocaleStrings() {
     override val worldProfilePublishDate = "发布日期"
     override val worldProfileUpdateDate = "更新日期"
     override val worldProfileLabReleaseDate = "实验室发布日期"
+    override val worldProfileSetHomeWorld = "设为 Home World"
+    override val worldProfileResetHomeWorld = "重置 Home World"
+    override val worldProfileHomeWorldUnavailable = "Home World 操作不可用"
+    override val worldProfileSetHomeWorldConfirmation = "将此世界设为你的 Home World？"
+    override val worldProfileResetHomeWorldConfirmation = "移除自定义 Home World 并恢复 VRChat 默认设置？"
+    override val worldProfileHomeWorldSetSuccess = "Home World 已更新"
+    override val worldProfileHomeWorldResetSuccess = "Home World 已重置"
+    override val worldProfileHomeWorldUpdateFailed = "无法更新 Home World"
     override val unknown = "未知"
 
     // CreateInstanceDialog

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
@@ -235,6 +235,14 @@ internal object LocaleStringsZhHant : LocaleStrings() {
     override val worldProfilePublishDate = "發布日期"
     override val worldProfileUpdateDate = "更新日期"
     override val worldProfileLabReleaseDate = "實驗室發布日期"
+    override val worldProfileSetHomeWorld = "設為 Home World"
+    override val worldProfileResetHomeWorld = "重設 Home World"
+    override val worldProfileHomeWorldUnavailable = "Home World 操作不可用"
+    override val worldProfileSetHomeWorldConfirmation = "將此世界設為你的 Home World？"
+    override val worldProfileResetHomeWorldConfirmation = "移除自訂 Home World 並恢復 VRChat 預設設定？"
+    override val worldProfileHomeWorldSetSuccess = "Home World 已更新"
+    override val worldProfileHomeWorldResetSuccess = "Home World 已重設"
+    override val worldProfileHomeWorldUpdateFailed = "無法更新 Home World"
     override val unknown = "未知"
 
     // CreateInstanceDialog

--- a/composeApp/src/commonMain/kotlin/service/AuthService.kt
+++ b/composeApp/src/commonMain/kotlin/service/AuthService.kt
@@ -162,6 +162,17 @@ class AuthService(
         }
     }
 
+    internal fun applyCurrentUserHomeLocation(
+        sessionToken: AccountSessionToken,
+        userId: String,
+        homeLocation: String,
+    ): Boolean = synchronized(currentUserLock) {
+        if (!SharedFlowCentre.isCurrentSession(sessionToken)) return@synchronized false
+        val existing = currentUser?.takeIf { it.id == userId } ?: return@synchronized false
+        publishCurrentUserLocked(existing.copy(homeLocation = homeLocation))
+        true
+    }
+
     fun applySocketUserUpdate(user: UserContent) {
         synchronized(currentUserLock) {
             val existing = currentUser ?: return@synchronized

--- a/composeApp/src/commonMain/kotlin/service/HomeWorldService.kt
+++ b/composeApp/src/commonMain/kotlin/service/HomeWorldService.kt
@@ -1,0 +1,100 @@
+package io.github.vrcmteam.vrcm.service
+
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
+import io.github.vrcmteam.vrcm.network.api.users.UsersApi
+import io.github.vrcmteam.vrcm.network.api.users.data.UpdateUserInfoData
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+
+internal data class HomeWorldUserContext(
+    val sessionToken: AccountSessionToken,
+    val homeLocation: String,
+)
+
+internal interface HomeWorldManager {
+    val currentUser: Flow<HomeWorldUserContext?>
+
+    /** A null target removes the custom Home World and restores VRChat's default. */
+    suspend fun updateHomeWorld(worldId: String?): Result<String>
+}
+
+internal class HomeWorldSessionChangedException : IllegalStateException(
+    "The authenticated account changed while updating the Home World"
+)
+
+internal class InvalidHomeWorldException : IllegalArgumentException("Invalid VRChat world ID")
+
+internal class HomeWorldUpdateInFlightException : IllegalStateException(
+    "A Home World update is already in progress"
+)
+
+/** Updates the authenticated user's Home World without allowing stale sessions to publish state. */
+internal class HomeWorldService(
+    private val usersApi: UsersApi,
+    private val authService: AuthService,
+) : HomeWorldManager {
+    private val updateInFlight = atomic(false)
+
+    override val currentUser: Flow<HomeWorldUserContext?> = combine(
+        authService.currentUserState,
+        SharedFlowCentre.currentSession,
+    ) { user, session ->
+        if (user == null || session == null || user.id != session.account.userId) {
+            null
+        } else {
+            HomeWorldUserContext(
+                sessionToken = session.token,
+                homeLocation = user.homeLocation,
+            )
+        }
+    }
+
+    override suspend fun updateHomeWorld(worldId: String?): Result<String> {
+        val homeLocation = when {
+            worldId == null -> ""
+            isWorldId(worldId) -> worldId.trim()
+            else -> return Result.failure(InvalidHomeWorldException())
+        }
+        if (!updateInFlight.compareAndSet(expect = false, update = true)) {
+            return Result.failure(HomeWorldUpdateInFlightException())
+        }
+        return try {
+            performHomeWorldUpdate(homeLocation)
+        } finally {
+            updateInFlight.value = false
+        }
+    }
+
+    private suspend fun performHomeWorldUpdate(homeLocation: String): Result<String> {
+        val session = SharedFlowCentre.currentSession.value
+            ?: return Result.failure(HomeWorldSessionChangedException())
+        val response = authService.runSessionBoundCatching(session.token) {
+            usersApi.updateUserInfo(
+                userId = session.account.userId,
+                updateUserInfoData = UpdateUserInfoData(homeLocation = homeLocation),
+            )
+        } ?: return Result.failure(HomeWorldSessionChangedException())
+
+        return response.result.mapCatching { updatedUser ->
+            check(updatedUser.id == response.sessionToken.userId) {
+                "Home World update returned a different user"
+            }
+            if (!authService.applyCurrentUserHomeLocation(
+                    sessionToken = response.sessionToken,
+                    userId = updatedUser.id,
+                    homeLocation = updatedUser.homeLocation,
+                )
+            ) {
+                throw HomeWorldSessionChangedException()
+            }
+            updatedUser.homeLocation
+        }
+    }
+}
+
+internal fun isWorldId(value: String): Boolean {
+    val target = parseOfficialId(value)
+    return target?.type == OfficialLinkType.World && target.id == value.trim()
+}

--- a/composeApp/src/commonTest/kotlin/network/api/users/UsersApiHomeWorldTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/api/users/UsersApiHomeWorldTest.kt
@@ -1,0 +1,72 @@
+package io.github.vrcmteam.vrcm.network.api.users
+
+import io.github.vrcmteam.vrcm.di.modules.createNetworkJson
+import io.github.vrcmteam.vrcm.network.api.users.data.UpdateUserInfoData
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UsersApiHomeWorldTest {
+    @Test
+    fun setHomeWorldOnlySendsTheRequestedLocation() = runBlocking {
+        val request = captureUpdate(UpdateUserInfoData(homeLocation = "wrld_home"))
+
+        assertEquals(HttpMethod.Put, request.method)
+        assertEquals("/users/usr_owner", request.path)
+        assertEquals("{\n    \"homeLocation\": \"wrld_home\"\n}", request.body)
+    }
+
+    @Test
+    fun resetHomeWorldKeepsTheEmptyLocationInTheRequest() = runBlocking {
+        val request = captureUpdate(UpdateUserInfoData(homeLocation = ""))
+
+        assertEquals("{\n    \"homeLocation\": \"\"\n}", request.body)
+    }
+
+    private suspend fun captureUpdate(data: UpdateUserInfoData): CapturedRequest {
+        lateinit var captured: CapturedRequest
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    captured = CapturedRequest(
+                        method = request.method,
+                        path = request.url.encodedPath,
+                        body = request.bodyText(),
+                    )
+                    respond(
+                        content = "not used",
+                        status = HttpStatusCode.InternalServerError,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+            }
+            install(ContentNegotiation) { json(createNetworkJson()) }
+        }
+        try {
+            runCatching { UsersApi(client).updateUserInfo("usr_owner", data) }
+            return captured
+        } finally {
+            client.close()
+        }
+    }
+
+    private fun HttpRequestData.bodyText(): String =
+        (body as OutgoingContent.ByteArrayContent).bytes().decodeToString()
+
+    private data class CapturedRequest(
+        val method: HttpMethod,
+        val path: String,
+        val body: String,
+    )
+}

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/HomeWorldActionStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/HomeWorldActionStateTest.kt
@@ -1,0 +1,41 @@
+package io.github.vrcmteam.vrcm.presentation.screens.world
+
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+import io.github.vrcmteam.vrcm.service.HomeWorldUserContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HomeWorldActionStateTest {
+    private val user = HomeWorldUserContext(
+        sessionToken = AccountSessionToken(userId = "usr_owner", generation = 1),
+        homeLocation = "wrld_current",
+    )
+
+    @Test
+    fun currentHomeWorldOffersReset() {
+        assertEquals(
+            HomeWorldActionAvailability.Current,
+            homeWorldActionAvailability("wrld_current", user),
+        )
+    }
+
+    @Test
+    fun anotherValidWorldOffersSet() {
+        assertEquals(
+            HomeWorldActionAvailability.CanSet,
+            homeWorldActionAvailability("wrld_other", user),
+        )
+    }
+
+    @Test
+    fun missingSessionOrInvalidWorldDisablesTheAction() {
+        assertEquals(
+            HomeWorldActionAvailability.Unavailable,
+            homeWorldActionAvailability("wrld_other", null),
+        )
+        assertEquals(
+            HomeWorldActionAvailability.Unavailable,
+            homeWorldActionAvailability("avtr_not-a-world", user),
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
@@ -7,6 +7,7 @@ import io.github.vrcmteam.vrcm.network.api.attributes.AUTH_COOKIE
 import io.github.vrcmteam.vrcm.network.api.attributes.AuthState
 import io.github.vrcmteam.vrcm.network.api.avatars.AvatarsApi
 import io.github.vrcmteam.vrcm.network.api.auth.AuthApi
+import io.github.vrcmteam.vrcm.network.api.users.UsersApi
 import io.github.vrcmteam.vrcm.network.supports.VRCApiException
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.NetworkAvatarSelector
 import io.github.vrcmteam.vrcm.service.data.AccountDto
@@ -27,6 +28,7 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
@@ -77,6 +79,120 @@ class AuthServiceTest : MainDispatcherTest() {
         assertTrue(requests.single().first.orEmpty().contains("auth=cached-auth"))
         assertTrue(requests.single().first.orEmpty().contains("twoFactorAuth=cached-2fa"))
         assertEquals("usr_cached", fixture.service.currentUserState.value?.id)
+        fixture.client.close()
+    }
+
+    @Test
+    fun homeWorldUpdateRetriesAuthenticationAndPublishesServerResponse() = runTest {
+        var updateRequests = 0
+        val fixture = fixture { request ->
+            when (request.method) {
+                HttpMethod.Put -> {
+                    updateRequests++
+                    if (updateRequests == 1) {
+                        respond(
+                            content = "expired",
+                            status = HttpStatusCode.Unauthorized,
+                        )
+                    } else {
+                        jsonResponse(
+                            currentUserJson(
+                                account = cachedAccount(),
+                                homeLocation = "wrld_server_authoritative",
+                            )
+                        )
+                    }
+                }
+                else -> jsonResponse(currentUserJson(cachedAccount()))
+            }
+        }
+        assertIs<AuthState.Authed>(fixture.service.restoreAuth())
+
+        val result = HomeWorldService(
+            usersApi = UsersApi(fixture.client),
+            authService = fixture.service,
+        ).updateHomeWorld("wrld_requested")
+
+        assertEquals("wrld_server_authoritative", result.getOrThrow())
+        assertEquals("wrld_server_authoritative", fixture.service.currentUserState.value?.homeLocation)
+        assertEquals(2, updateRequests)
+        fixture.client.close()
+    }
+
+    @Test
+    fun accountSwitchRejectsLateHomeWorldResponse() = runTest {
+        val updateStarted = CompletableDeferred<Unit>()
+        val releaseUpdate = CompletableDeferred<Unit>()
+        val fixture = fixture { request ->
+            if (request.method == HttpMethod.Put) {
+                updateStarted.complete(Unit)
+                releaseUpdate.await()
+                jsonResponse(
+                    currentUserJson(
+                        account = cachedAccount(),
+                        homeLocation = "wrld_late",
+                    )
+                )
+            } else {
+                jsonResponse(currentUserJson(cachedAccount()))
+            }
+        }
+        assertIs<AuthState.Authed>(fixture.service.restoreAuth())
+        val update = async(start = CoroutineStart.UNDISPATCHED) {
+            HomeWorldService(
+                usersApi = UsersApi(fixture.client),
+                authService = fixture.service,
+            ).updateHomeWorld("wrld_requested")
+        }
+        updateStarted.await()
+
+        SharedFlowCentre.emitAuthenticated(AccountDto(userId = "usr_other", username = "other"))
+        releaseUpdate.complete(Unit)
+
+        assertIs<HomeWorldSessionChangedException>(update.await().exceptionOrNull())
+        assertTrue(fixture.service.currentUserState.value?.homeLocation != "wrld_late")
+        fixture.client.close()
+    }
+
+    @Test
+    fun duplicateHomeWorldUpdateIsRejectedUntilTheFirstRequestFinishes() = runTest {
+        val firstUpdateStarted = CompletableDeferred<Unit>()
+        val releaseFirstUpdate = CompletableDeferred<Unit>()
+        var updateRequests = 0
+        val fixture = fixture { request ->
+            if (request.method == HttpMethod.Put) {
+                updateRequests++
+                if (updateRequests == 1) {
+                    firstUpdateStarted.complete(Unit)
+                    releaseFirstUpdate.await()
+                }
+                jsonResponse(
+                    currentUserJson(
+                        account = cachedAccount(),
+                        homeLocation = "wrld_server_$updateRequests",
+                    )
+                )
+            } else {
+                jsonResponse(currentUserJson(cachedAccount()))
+            }
+        }
+        assertIs<AuthState.Authed>(fixture.service.restoreAuth())
+        val homeWorldService = HomeWorldService(UsersApi(fixture.client), fixture.service)
+        val first = async(start = CoroutineStart.UNDISPATCHED) {
+            homeWorldService.updateHomeWorld("wrld_first")
+        }
+        firstUpdateStarted.await()
+
+        assertIs<HomeWorldUpdateInFlightException>(
+            homeWorldService.updateHomeWorld("wrld_duplicate").exceptionOrNull()
+        )
+        releaseFirstUpdate.complete(Unit)
+        assertEquals("wrld_server_1", first.await().getOrThrow())
+        assertEquals(
+            "wrld_server_2",
+            homeWorldService.updateHomeWorld("wrld_after-completion").getOrThrow(),
+        )
+        assertEquals(2, updateRequests)
         fixture.client.close()
     }
 
@@ -674,6 +790,7 @@ class AuthServiceTest : MainDispatcherTest() {
         currentAvatar: String = "",
         presenceWorld: String = "",
         presenceInstance: String = "",
+        homeLocation: String = "",
     ): String = """
         {
           "requiresTwoFactorAuth":null,
@@ -687,7 +804,7 @@ class AuthServiceTest : MainDispatcherTest() {
           "fallbackAvatar":"","friendGroupNames":[],"friendKey":"","friends":[],
           "googleId":"","hasBirthday":true,"hasEmail":true,
           "hasLoggedInFromClient":true,"hasPendingEmail":false,
-          "hideContentFilterSettings":false,"homeLocation":"","id":"${account.userId}",
+          "hideContentFilterSettings":false,"homeLocation":"$homeLocation","id":"${account.userId}",
           "isFriend":false,"last_activity":"","last_login":"",
           "last_platform":"standalonewindows","obfuscatedEmail":"",
           "obfuscatedPendingEmail":"","oculusId":"","offlineFriends":[],


### PR DESCRIPTION
## 功能概述

- 在世界详情页提供设置 Home World 与重置 Home World 的入口。
- 通过现有 `PUT /users/{userId}` 更新当前用户资料，并以服务端返回的 `homeLocation` 为准同步本地资料。
- 处理世界 ID 校验、认证续期、换号/登出后的迟到响应、重复点击和失败提示。
- 同步英语、日语、简体中文和繁体中文文案。

## 实现假设清单

- VRChat 实际接受在 `PUT /users/{userId}` 请求体中使用 `homeLocation` 字段设置 Home World。
- 设置 Home World 时发送 `{"homeLocation":"wrld_..."}`；重置时发送 `{"homeLocation":""}`。
- `homeLocation` 的服务端返回值是当前账号 Home World 的权威状态，客户端不以请求参数直接覆盖资料。
- 当前用户资料与认证会话通过现有 `AuthService` 和 `SharedFlowCentre` 维护；会话变更或登出后，迟到响应不得回写新会话。
- 本 PR 不包含世界 Unity Package 下载能力（对应 API-023）。

## 代码逻辑图

```mermaid
flowchart TD
    A[世界详情页加载] --> B[读取世界 ID与当前用户资料]
    B --> C{世界 ID 合法且会话有效?}
    C -- 否 --> D[禁用 Home World 操作]
    C -- 是 --> E{当前世界是否为 Home World?}
    E -- 否 --> F[显示设置 Home World]
    E -- 是 --> G[显示重置 Home World]
    F --> H[确认设置]
    G --> I[确认重置]
    H --> J[校验 wrld_ 世界 ID]
    I --> K[生成空 homeLocation]
    J --> L[按会话 token 执行 PUT users/{userId}]
    K --> L
    L --> M{请求未授权?}
    M -- 是 --> N[认证续期并重试]
    M -- 否 --> O[读取请求结果]
    N --> O
    O --> P{会话仍为当前账号?}
    P -- 否 --> Q[丢弃迟到响应]
    P -- 是 --> R[采用服务端 homeLocation 回写当前资料]
    R --> S[刷新按钮状态并显示成功提示]
    O --> T{请求失败?}
    T -- 是 --> U[保持原资料并显示失败提示]
```

## 验证

- `./gradlew :composeApp:compileKotlinDesktop`
- `./gradlew :composeApp:desktopTest --tests '*HomeWorldActionStateTest' --tests '*UsersApiHomeWorldTest' --tests '*AuthServiceTest'`
- 完整 `:composeApp:desktopTest` 共执行 810 项；Home World 相关测试通过，另有 1 项与本 PR 无关的既有 `MeetupCardScreenModelTest` 协程异常失败。
- `git diff --check`