### PR TITLE
feat(world): 添加世界预览图与封面管理

### DIFF
--- a/composeApp/src/commonMain/kotlin/core/shared/SharedFlowCentre.kt
+++ b/composeApp/src/commonMain/kotlin/core/shared/SharedFlowCentre.kt
@@ -46,6 +46,15 @@ internal class AuthenticationSessionRegistry {
     fun isCurrent(token: AccountSessionToken): Boolean = synchronized(lock) {
         _currentSession.value?.token == token
     }
+
+    /** 在认证状态锁内校验 [token] 并完成不可挂起的状态提交。 */
+    fun commitIfCurrent(
+        token: AccountSessionToken,
+        commit: (AuthenticatedAccount) -> Boolean,
+    ): Boolean = synchronized(lock) {
+        val session = _currentSession.value ?: return@synchronized false
+        session.token == token && commit(session)
+    }
 }
 
 object SharedFlowCentre {
@@ -80,4 +89,9 @@ object SharedFlowCentre {
 
     fun isCurrentSession(token: AccountSessionToken): Boolean =
         sessionRegistry.isCurrent(token)
+
+    internal fun commitIfCurrentSession(
+        token: AccountSessionToken,
+        commit: (AuthenticatedAccount) -> Boolean,
+    ): Boolean = sessionRegistry.commitIfCurrent(token, commit)
 }

--- a/composeApp/src/commonMain/kotlin/di/modules/PresentationModule.kt
+++ b/composeApp/src/commonMain/kotlin/di/modules/PresentationModule.kt
@@ -49,6 +49,8 @@ import io.github.vrcmteam.vrcm.presentation.screens.user.MutualFriendsScreenMode
 import io.github.vrcmteam.vrcm.presentation.screens.user.UserProfileScreenModel
 import io.github.vrcmteam.vrcm.presentation.screens.world.RecentWorldsScreenModel
 import io.github.vrcmteam.vrcm.presentation.screens.world.WorldProfileScreenModel
+import io.github.vrcmteam.vrcm.presentation.screens.world.NetworkWorldImageEditor
+import io.github.vrcmteam.vrcm.presentation.screens.world.WorldImageEditor
 import io.github.vrcmteam.vrcm.presentation.settings.SettingsModel
 import io.github.vrcmteam.vrcm.presentation.settings.theme.ThemeColor
 import io.github.vrcmteam.vrcm.presentation.theme.blue.BlueThemeColor
@@ -109,7 +111,8 @@ val presentationModule: Module = module {
         )
     }
     singleOf(::PrintUploadService) bind PrintUploader::class
-    single<ImageEditorSubmitter> { NetworkImageEditorSubmitter(get(), get(), get()) }
+    singleOf(::NetworkWorldImageEditor) bind WorldImageEditor::class
+    single<ImageEditorSubmitter> { NetworkImageEditorSubmitter(get(), get(), get(), get()) }
     viewModel { parameters ->
         val sessionId = parameters.get<String>()
         val sessionStore = get<PrintImageEditorSessionStore>()
@@ -124,6 +127,7 @@ val presentationModule: Module = module {
             processor = when (session.target) {
                 ImageEditorTarget.Print -> get()
                 is ImageEditorTarget.AvatarCover -> get(AvatarCoverImageProcessorQualifier)
+                is ImageEditorTarget.WorldCover -> get(AvatarCoverImageProcessorQualifier)
                 is ImageEditorTarget.Gallery -> DefaultPrintImageProcessor(
                     codec = get(),
                     spec = session.target.canvasSpec,

--- a/composeApp/src/commonMain/kotlin/network/api/files/FileApi.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/files/FileApi.kt
@@ -32,6 +32,10 @@ class FileApi(private val client: HttpClient) {
             if (fileId.isBlank() || fileVersion < 1) return ""
             return "https://api.vrchat.cloud/api/1/image/$fileId/$fileVersion/$fileSize"
         }
+        fun originalFileUrl(fileId: String, fileVersion: Int): String {
+            if (fileId.isBlank() || fileVersion < 1) return ""
+            return "https://api.vrchat.cloud/api/1/file/$fileId/$fileVersion/file"
+        }
         fun convertFileUrl(fileUrl: String, fileSize: Int = 1024): String {
             if (fileUrl.isEmpty()) return ""
             val fileId = findFileId(fileUrl)
@@ -173,7 +177,8 @@ internal fun vrcxImageUploadParameters(
 ): FileImageUploadParameters = when (tagType) {
     FileTagType.Gallery,
     FileTagType.Icon,
-    FileTagType.AvatarImage -> FileImageUploadParameters(tag = tagType.value)
+    FileTagType.AvatarImage,
+    FileTagType.WorldImage -> FileImageUploadParameters(tag = tagType.value)
 
     FileTagType.Sticker -> FileImageUploadParameters(
         tag = tagType.value,

--- a/composeApp/src/commonMain/kotlin/network/api/files/data/FileData.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/files/data/FileData.kt
@@ -23,6 +23,9 @@ enum class FileTagType(val value: String) {
     @SerialName("avatarimage")
     AvatarImage("avatarimage"),
 
+    @SerialName("worldimage")
+    WorldImage("worldimage"),
+
     @SerialName("print")
     Print("print");
     

--- a/composeApp/src/commonMain/kotlin/network/api/worlds/WorldsApi.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/worlds/WorldsApi.kt
@@ -5,9 +5,11 @@ import io.github.vrcmteam.vrcm.network.api.attributes.WORLDS_API_PREFIX
 import io.github.vrcmteam.vrcm.network.api.instances.data.InstanceData
 import io.github.vrcmteam.vrcm.network.api.worlds.data.FavoritedWorld
 import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
+import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldUpdateData
 import io.github.vrcmteam.vrcm.network.extensions.checkSuccess
 import io.ktor.client.*
 import io.ktor.client.request.*
+import io.ktor.http.*
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -23,6 +25,12 @@ class WorldsApi(private val client: HttpClient)  {
      */
     suspend fun getWorldById(worldId: String): WorldData =
         client.get("$WORLDS_API_PREFIX/$worldId").checkSuccess()
+
+    suspend fun updateWorld(worldId: String, update: WorldUpdateData): WorldData =
+        client.put("$WORLDS_API_PREFIX/$worldId") {
+            contentType(ContentType.Application.Json)
+            setBody(update)
+        }.checkSuccess()
 
     suspend fun getRecentWorlds(
         n: Int = 50,

--- a/composeApp/src/commonMain/kotlin/network/api/worlds/data/WorldUpdateData.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/worlds/data/WorldUpdateData.kt
@@ -1,0 +1,8 @@
+package io.github.vrcmteam.vrcm.network.api.worlds.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WorldUpdateData(
+    val imageUrl: String? = null,
+)

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/GalleryScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/GalleryScreenModel.kt
@@ -35,7 +35,9 @@ class GalleryScreenModel internal constructor(
     private val _filesByTag = mutableStateMapOf<FileTagType, List<FileData>>().apply {
         // 不包含 Print，Print 使用独立的 API
         FileTagType.entries.filter {
-            it != FileTagType.Print && it != FileTagType.AvatarImage
+            it != FileTagType.Print &&
+                it != FileTagType.AvatarImage &&
+                it != FileTagType.WorldImage
         }.forEach { tagType ->
             this[tagType] = emptyList()
         }
@@ -188,7 +190,7 @@ class GalleryScreenModel internal constructor(
      * 获取指定标签类型的数量上限（参照 VRCX）
      */
     fun getMaxCount(tagType: FileTagType): Int = when (tagType) {
-        FileTagType.Gallery, FileTagType.Icon, FileTagType.AvatarImage,
+        FileTagType.Gallery, FileTagType.Icon, FileTagType.AvatarImage, FileTagType.WorldImage,
         FileTagType.Print -> MAX_FIXED_FILES
         FileTagType.Emoji -> MAX_EMOJI_DEFAULT
         FileTagType.Sticker -> MAX_STICKER_DEFAULT

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/GalleryTabPager.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/GalleryTabPager.kt
@@ -389,14 +389,15 @@ sealed class GalleryTabPager(private val tagType: FileTagType) {
         galleryScreenModel: GalleryScreenModel,
     ) {
         val minimumCellSize = when (tagType) {
-            FileTagType.Gallery, FileTagType.AvatarImage, FileTagType.Print -> 160.dp
+            FileTagType.Gallery, FileTagType.AvatarImage, FileTagType.WorldImage,
+            FileTagType.Print -> 160.dp
             FileTagType.Emoji, FileTagType.Sticker -> 104.dp
             FileTagType.Icon -> 80.dp
         }
         // 根据文件类型设置不同的宽高比
         val aspectRatio = when (tagType) {
             FileTagType.Icon -> 1.0f  // 圆形展示，使用1:1比例
-            FileTagType.Gallery, FileTagType.AvatarImage,
+            FileTagType.Gallery, FileTagType.AvatarImage, FileTagType.WorldImage,
             FileTagType.Print -> 16f / 9f  // 16:9比例
             FileTagType.Emoji, FileTagType.Sticker -> 1.0f  // 正方形展示，使用1:1比例
         }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/ImageEditorSubmission.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/ImageEditorSubmission.kt
@@ -1,15 +1,23 @@
 package io.github.vrcmteam.vrcm.presentation.screens.gallery.editor
 
 import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
 import io.github.vrcmteam.vrcm.network.api.files.data.FileTagType
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.AvatarCoverFile
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.AvatarEditor
 import io.github.vrcmteam.vrcm.presentation.screens.gallery.GalleryDataSource
 import io.github.vrcmteam.vrcm.service.PrintUploader
+import io.github.vrcmteam.vrcm.presentation.screens.world.WorldImageEditor
+import io.github.vrcmteam.vrcm.presentation.screens.world.WorldImageFile
+import io.github.vrcmteam.vrcm.presentation.screens.world.WorldImageUpdate
 
 sealed interface ImageEditorTarget {
     data object Print : ImageEditorTarget
     data class AvatarCover(val avatarId: String) : ImageEditorTarget
+    data class WorldCover(
+        val worldId: String,
+        val sessionToken: AccountSessionToken,
+    ) : ImageEditorTarget
     data class Gallery(val tagType: FileTagType) : ImageEditorTarget {
         init {
             require(
@@ -26,7 +34,8 @@ sealed interface ImageEditorTarget {
 internal val ImageEditorTarget.canvasBackground: CanvasBackground
     get() = when (this) {
         ImageEditorTarget.Print,
-        is ImageEditorTarget.AvatarCover -> CanvasBackground.White
+        is ImageEditorTarget.AvatarCover,
+        is ImageEditorTarget.WorldCover -> CanvasBackground.White
         is ImageEditorTarget.Gallery -> CanvasBackground.Transparent
     }
 
@@ -38,12 +47,14 @@ internal val ImageEditorTarget.Gallery.canvasSpec: PrintCanvasSpec
         FileTagType.Emoji,
         FileTagType.Sticker -> SquareCanvasSpec
         FileTagType.AvatarImage,
+        FileTagType.WorldImage,
         FileTagType.Print -> error("Unsupported gallery editor target: $tagType")
     }
 
 sealed interface ImageEditorSubmission {
     data object Print : ImageEditorSubmission
     data class AvatarCover(val avatar: AvatarData) : ImageEditorSubmission
+    data class WorldCover(val update: WorldImageUpdate) : ImageEditorSubmission
     data class Gallery(val tagType: FileTagType) : ImageEditorSubmission
 }
 
@@ -59,6 +70,7 @@ internal class NetworkImageEditorSubmitter(
     private val printUploader: PrintUploader,
     private val avatarEditor: AvatarEditor,
     private val galleryDataSource: GalleryDataSource,
+    private val worldImageEditor: WorldImageEditor,
 ) : ImageEditorSubmitter {
     override suspend fun submit(
         target: ImageEditorTarget,
@@ -76,6 +88,16 @@ internal class NetworkImageEditorSubmitter(
                 mimeType = "image/png",
             ),
         ).map(ImageEditorSubmission::AvatarCover)
+
+        is ImageEditorTarget.WorldCover -> worldImageEditor.updateImage(
+            sessionToken = target.sessionToken,
+            worldId = target.worldId,
+            image = WorldImageFile(
+                bytes = imageBytes,
+                fileName = fileName,
+                mimeType = "image/png",
+            ),
+        ).map(ImageEditorSubmission::WorldCover)
 
         is ImageEditorTarget.Gallery -> galleryDataSource.uploadImage(
             fileBytes = imageBytes,

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreen.kt
@@ -78,6 +78,8 @@ import io.github.vrcmteam.vrcm.presentation.compoments.ATooltipBox
 import io.github.vrcmteam.vrcm.presentation.compoments.ToastText
 import io.github.vrcmteam.vrcm.presentation.navigation.BlockBackNavigation
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.AvatarCoverUpdateFailure
+import io.github.vrcmteam.vrcm.presentation.screens.world.WorldImageSessionChanged
+import io.github.vrcmteam.vrcm.presentation.screens.world.WorldImageUpdateFailure
 import io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStrings
 import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
 import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
@@ -123,16 +125,19 @@ class PrintImageEditorScreen(
         val title = when (session.target) {
             ImageEditorTarget.Print -> locale.printEditorTitle
             is ImageEditorTarget.AvatarCover -> locale.avatarEditCover
+            is ImageEditorTarget.WorldCover -> locale.worldImageEditTitle
             is ImageEditorTarget.Gallery -> locale.galleryTabUploadImage
         }
         val submitLabel = when (session.target) {
             ImageEditorTarget.Print -> locale.printEditorUpload
             is ImageEditorTarget.AvatarCover -> locale.avatarEditUploadCover
+            is ImageEditorTarget.WorldCover -> locale.worldImageEditUpload
             is ImageEditorTarget.Gallery -> locale.galleryTabUploadImage
         }
         val uploadingText = when (session.target) {
             ImageEditorTarget.Print -> locale.printEditorUploading
             is ImageEditorTarget.AvatarCover -> locale.avatarEditUploadingCover
+            is ImageEditorTarget.WorldCover -> locale.worldImageEditUploading
             is ImageEditorTarget.Gallery -> locale.galleryTabUploading
         }
 
@@ -151,6 +156,7 @@ class PrintImageEditorScreen(
                                 ToastText.Success(currentLocale.galleryTabUploadSuccess),
                             )
                             is ImageEditorSubmission.AvatarCover -> Unit
+                            is ImageEditorSubmission.WorldCover -> Unit
                         }
                         navigator.pop()
                     }
@@ -713,9 +719,16 @@ private fun EditorError.localizedMessage(
         is PrintUploadFailure.Unknown -> locale.printEditorUploadUnknownFailed
         is AvatarCoverUpdateFailure.Upload -> locale.avatarEditCoverUploadFailed
         is AvatarCoverUpdateFailure.Assignment -> locale.avatarEditCoverAssignmentFailed
+        is WorldImageUpdateFailure -> when {
+            cause.cause is WorldImageSessionChanged -> locale.worldImageEditSessionChanged
+            cause is WorldImageUpdateFailure.Upload -> locale.worldImageEditUploadFailed
+            cause is WorldImageUpdateFailure.Assignment -> locale.worldImageEditAssignmentFailed
+            else -> locale.worldImageEditRefreshFailed
+        }
         else -> when (target) {
             ImageEditorTarget.Print -> locale.printEditorUploadUnknownFailed
             is ImageEditorTarget.AvatarCover -> locale.avatarEditCoverUploadFailed
+            is ImageEditorTarget.WorldCover -> locale.worldImageEditUploadFailed
             is ImageEditorTarget.Gallery -> locale.galleryTabUploadFailed
         }
     }
@@ -723,7 +736,9 @@ private fun EditorError.localizedMessage(
 
 private val ImageEditorTarget.cropAspectRatio: Float
     get() = when (this) {
-        ImageEditorTarget.Print, is ImageEditorTarget.AvatarCover -> 16f / 9f
+        ImageEditorTarget.Print,
+        is ImageEditorTarget.AvatarCover,
+        is ImageEditorTarget.WorldCover -> 16f / 9f
         is ImageEditorTarget.Gallery -> canvasSpec.aspectRatio
     }
 

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorScreenModel.kt
@@ -357,5 +357,6 @@ private fun ImageSize.isValid(): Boolean = width > 0 && height > 0
 private fun ImageEditorTarget.uploadFileName(sourceFileName: String, nowMillis: Long): String = when (this) {
     ImageEditorTarget.Print -> "print-$nowMillis.png"
     is ImageEditorTarget.AvatarCover -> "avatar-cover-$nowMillis.png"
+    is ImageEditorTarget.WorldCover -> "world-cover-$nowMillis.png"
     is ImageEditorTarget.Gallery -> sourceFileName.ifBlank { "${tagType.value}-$nowMillis.png" }
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorSessionStore.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/gallery/editor/PrintImageEditorSessionStore.kt
@@ -2,6 +2,7 @@ package io.github.vrcmteam.vrcm.presentation.screens.gallery.editor
 
 import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
 import io.github.vrcmteam.vrcm.network.api.files.data.FileTagType
+import io.github.vrcmteam.vrcm.presentation.screens.world.WorldImageUpdate
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,12 +23,15 @@ class PrintImageEditorSessionStore {
     private val completionChannel = Channel<Unit>(capacity = Channel.BUFFERED)
     private val galleryCompletionChannel = Channel<FileTagType>(capacity = Channel.BUFFERED)
     private val _avatarCoverUpdates = MutableStateFlow<Map<String, AvatarData>>(emptyMap())
+    private val _worldCoverUpdates = MutableStateFlow<Map<String, WorldImageUpdate>>(emptyMap())
     private var nextSessionId = 0L
 
     val uploadCompletions: Flow<Unit> = completionChannel.receiveAsFlow()
     val galleryUploadCompletions: Flow<FileTagType> = galleryCompletionChannel.receiveAsFlow()
     val avatarCoverUpdates: StateFlow<Map<String, AvatarData>> =
         _avatarCoverUpdates.asStateFlow()
+    val worldCoverUpdates: StateFlow<Map<String, WorldImageUpdate>> =
+        _worldCoverUpdates.asStateFlow()
 
     fun create(
         source: SelectedImage,
@@ -66,6 +70,14 @@ class PrintImageEditorSessionStore {
                 check(target.avatarId == submission.avatar.id)
                 _avatarCoverUpdates.update { it + (submission.avatar.id to submission.avatar) }
             }
+            is ImageEditorSubmission.WorldCover -> {
+                val target = session.target as? ImageEditorTarget.WorldCover
+                    ?: error("World cover result completed a non-world editor session")
+                check(target.worldId == submission.update.world.id)
+                _worldCoverUpdates.update {
+                    it + (submission.update.world.id to submission.update)
+                }
+            }
             is ImageEditorSubmission.Gallery -> {
                 val target = session.target as? ImageEditorTarget.Gallery
                     ?: error("Gallery result completed a non-gallery editor session")
@@ -78,6 +90,12 @@ class PrintImageEditorSessionStore {
     fun consumeAvatarCoverUpdate(avatarId: String): AvatarData? {
         val update = _avatarCoverUpdates.value[avatarId] ?: return null
         _avatarCoverUpdates.update { it - avatarId }
+        return update
+    }
+
+    fun consumeWorldCoverUpdate(worldId: String): WorldImageUpdate? {
+        val update = _worldCoverUpdates.value[worldId] ?: return null
+        _worldCoverUpdates.update { it - worldId }
         return update
     }
 }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldImageEditSheet.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldImageEditSheet.kt
@@ -1,0 +1,203 @@
+package io.github.vrcmteam.vrcm.presentation.screens.world
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import coil3.ImageLoader
+import io.github.vinceglb.filekit.name
+import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
+import io.github.vrcmteam.vrcm.presentation.screens.gallery.galleryImagePickerType
+import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PreparedImage
+import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PrintImageFailure
+import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PrintImageProcessor
+import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.SelectedImage
+import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.localizedMessage
+import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.readBoundedBytes
+import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
+import io.github.vrcmteam.vrcm.presentation.settings.locale.strings
+import io.github.vrcmteam.vrcm.presentation.supports.AppIcons
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun WorldImageEditSheet(
+    world: WorldProfileVo,
+    imageProcessor: PrintImageProcessor,
+    onDismiss: () -> Unit,
+    onEditImage: (SelectedImage, PreparedImage) -> Unit,
+) {
+    var errorText by remember(world.worldId) { mutableStateOf<String?>(null) }
+    var isPreparing by remember(world.worldId) { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+    val locale = strings
+    val picker = rememberFilePickerLauncher(
+        type = galleryImagePickerType(WorldImageLimits.ALLOWED_EXTENSIONS),
+    ) { file ->
+        if (file != null && !isPreparing) {
+            scope.launch {
+                isPreparing = true
+                errorText = null
+                try {
+                    val bytes = file.readBoundedBytes(WorldImageLimits.MAX_FILE_BYTES)
+                    when (val validation = validateWorldImage(file.name, bytes)) {
+                        WorldImageValidation.FileTooLarge -> {
+                            errorText = locale.worldImageEditFileTooLarge
+                        }
+                        WorldImageValidation.UnsupportedFormat -> {
+                            errorText = locale.worldImageEditUnsupportedFormat
+                        }
+                        is WorldImageValidation.Valid -> {
+                            val source = SelectedImage(
+                                fileName = validation.image.fileName,
+                                bytes = validation.image.bytes,
+                            )
+                            val prepared = imageProcessor.prepare(source).getOrElse { failure ->
+                                if (failure is CancellationException) throw failure
+                                errorText = (failure as? PrintImageFailure)
+                                    ?.localizedMessage(locale)
+                                    ?: locale.worldImageEditReadFailed
+                                return@launch
+                            }
+                            onEditImage(source, prepared)
+                        }
+                    }
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (_: PrintImageFailure.FileTooLarge) {
+                    errorText = locale.worldImageEditFileTooLarge
+                } catch (_: Exception) {
+                    errorText = locale.worldImageEditReadFailed
+                } finally {
+                    isPreparing = false
+                }
+            }
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = { if (!isPreparing) onDismiss() },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 720.dp)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = locale.worldImageEditTitle,
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            WorldImagePreview(
+                label = locale.worldImageEditPreview,
+                imageUrl = world.worldImageUrl,
+            )
+            WorldImagePreview(
+                label = locale.worldImageEditThumbnail,
+                imageUrl = world.thumbnailImageUrl ?: world.worldImageUrl,
+            )
+            Text(
+                text = locale.worldImageEditHint,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            OutlinedButton(
+                onClick = picker::launch,
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !isPreparing,
+            ) {
+                if (isPreparing) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        color = LocalContentColor.current,
+                        strokeWidth = 2.dp,
+                    )
+                } else {
+                    Icon(
+                        imageVector = AppIcons.Edit,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+                Spacer(Modifier.size(8.dp))
+                Text(locale.worldImageEditChoose)
+            }
+            errorText?.let { error ->
+                Text(
+                    text = error,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+            TextButton(
+                onClick = onDismiss,
+                modifier = Modifier.align(Alignment.End),
+                enabled = !isPreparing,
+            ) {
+                Text(locale.cancel)
+            }
+            Spacer(Modifier.height(12.dp))
+        }
+    }
+}
+
+@Composable
+private fun WorldImagePreview(
+    label: String,
+    imageUrl: String?,
+) {
+    val imageLoader: ImageLoader = koinInject()
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text(text = label, style = MaterialTheme.typography.titleSmall)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(16f / 9f)
+                .clip(RoundedCornerShape(8.dp)),
+            contentAlignment = Alignment.Center,
+        ) {
+            AsyncImage(
+                model = imageUrl,
+                contentDescription = label,
+                imageLoader = imageLoader,
+                modifier = Modifier.matchParentSize(),
+                contentScale = ContentScale.Crop,
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldImageEditSheet.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldImageEditSheet.kt
@@ -19,14 +19,17 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -63,6 +66,13 @@ internal fun WorldImageEditSheet(
     var isPreparing by remember(world.worldId) { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
     val locale = strings
+    val latestIsPreparing = rememberUpdatedState(isPreparing)
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true,
+        confirmValueChange = { targetValue ->
+            targetValue != SheetValue.Hidden || !latestIsPreparing.value
+        },
+    )
     val picker = rememberFilePickerLauncher(
         type = galleryImagePickerType(WorldImageLimits.ALLOWED_EXTENSIONS),
     ) { file ->
@@ -109,6 +119,8 @@ internal fun WorldImageEditSheet(
 
     ModalBottomSheet(
         onDismissRequest = { if (!isPreparing) onDismiss() },
+        sheetState = sheetState,
+        sheetGesturesEnabled = !isPreparing,
     ) {
         Column(
             modifier = Modifier

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldImageEditor.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldImageEditor.kt
@@ -1,0 +1,197 @@
+package io.github.vrcmteam.vrcm.presentation.screens.world
+
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+import io.github.vrcmteam.vrcm.network.api.files.FileApi
+import io.github.vrcmteam.vrcm.network.api.files.data.FileTagType
+import io.github.vrcmteam.vrcm.network.api.worlds.WorldsApi
+import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
+import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldUpdateData
+import io.github.vrcmteam.vrcm.service.AuthService
+import kotlinx.coroutines.CancellationException
+
+internal object WorldImageLimits {
+    const val MAX_FILE_BYTES: Long = 10L * 1024L * 1024L
+    val ALLOWED_EXTENSIONS = listOf("jpg", "jpeg", "png", "webp")
+}
+
+internal data class WorldImageFile(
+    val bytes: ByteArray,
+    val fileName: String,
+    val mimeType: String,
+)
+
+internal sealed interface WorldImageValidation {
+    data class Valid(val image: WorldImageFile) : WorldImageValidation
+    data object FileTooLarge : WorldImageValidation
+    data object UnsupportedFormat : WorldImageValidation
+}
+
+private enum class WorldImageFormat(
+    val extensions: Set<String>,
+    val mimeType: String,
+) {
+    Jpeg(setOf("jpg", "jpeg"), "image/jpeg"),
+    Png(setOf("png"), "image/png"),
+    WebP(setOf("webp"), "image/webp"),
+}
+
+internal fun validateWorldImage(
+    fileName: String,
+    bytes: ByteArray,
+): WorldImageValidation {
+    if (bytes.size.toLong() > WorldImageLimits.MAX_FILE_BYTES) {
+        return WorldImageValidation.FileTooLarge
+    }
+
+    val extension = fileName.substringAfterLast('.', missingDelimiterValue = "").lowercase()
+    val declaredFormat = WorldImageFormat.entries.firstOrNull { extension in it.extensions }
+        ?: return WorldImageValidation.UnsupportedFormat
+    val detectedFormat = when {
+        bytes.hasPrefix(0xFF, 0xD8, 0xFF) -> WorldImageFormat.Jpeg
+        bytes.hasPrefix(0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A) ->
+            WorldImageFormat.Png
+        bytes.hasAsciiAt(0, "RIFF") && bytes.hasAsciiAt(8, "WEBP") -> WorldImageFormat.WebP
+        else -> null
+    }
+    if (detectedFormat != declaredFormat) return WorldImageValidation.UnsupportedFormat
+
+    return WorldImageValidation.Valid(
+        WorldImageFile(
+            bytes = bytes,
+            fileName = fileName,
+            mimeType = detectedFormat.mimeType,
+        )
+    )
+}
+
+internal data class SessionBoundValue<T>(
+    val value: T,
+    val sessionToken: AccountSessionToken,
+)
+
+/** Server-authoritative world detail returned after an image update. */
+data class WorldImageUpdate(
+    val world: WorldData,
+    val sessionToken: AccountSessionToken,
+)
+
+internal class WorldImageSessionChanged : Exception("Account session changed")
+
+internal sealed class WorldImageUpdateFailure(
+    message: String,
+    cause: Throwable,
+) : Exception(message, cause) {
+    class Upload(cause: Throwable) :
+        WorldImageUpdateFailure("World image upload failed", cause)
+
+    class Assignment(cause: Throwable) :
+        WorldImageUpdateFailure("World image assignment failed", cause)
+
+    class Refresh(cause: Throwable) :
+        WorldImageUpdateFailure("World refresh after image update failed", cause)
+}
+
+internal interface WorldImageEditor {
+    suspend fun uploadImage(
+        sessionToken: AccountSessionToken,
+        image: WorldImageFile,
+    ): Result<SessionBoundValue<String>>
+
+    suspend fun assignImage(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+        imageUrl: String,
+    ): Result<SessionBoundValue<Unit>>
+
+    suspend fun refreshWorld(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+    ): Result<WorldImageUpdate>
+
+    suspend fun updateImage(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+        image: WorldImageFile,
+    ): Result<WorldImageUpdate> {
+        val upload = uploadImage(sessionToken, image).getOrElse { cause ->
+            cause.rethrowIfCancellation()
+            return Result.failure(WorldImageUpdateFailure.Upload(cause))
+        }
+        val assignment = assignImage(upload.sessionToken, worldId, upload.value)
+            .getOrElse { cause ->
+                cause.rethrowIfCancellation()
+                return Result.failure(WorldImageUpdateFailure.Assignment(cause))
+            }
+        return refreshWorld(assignment.sessionToken, worldId).fold(
+            onSuccess = Result.Companion::success,
+            onFailure = { cause ->
+                cause.rethrowIfCancellation()
+                Result.failure(WorldImageUpdateFailure.Refresh(cause))
+            },
+        )
+    }
+}
+
+internal class NetworkWorldImageEditor(
+    private val worldsApi: WorldsApi,
+    private val fileApi: FileApi,
+    private val authService: AuthService,
+) : WorldImageEditor {
+    override suspend fun uploadImage(
+        sessionToken: AccountSessionToken,
+        image: WorldImageFile,
+    ): Result<SessionBoundValue<String>> = sessionBound(sessionToken) {
+        val uploaded = fileApi.uploadImageFile(
+            fileBytes = image.bytes,
+            fileName = image.fileName,
+            mimeType = image.mimeType,
+            tagType = FileTagType.WorldImage,
+        ).getOrThrow()
+        val version = uploaded.versions.maxOfOrNull { it.version }
+            ?: error("Uploaded world image has no file version")
+        FileApi.originalFileUrl(uploaded.id, version)
+    }
+
+    override suspend fun assignImage(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+        imageUrl: String,
+    ): Result<SessionBoundValue<Unit>> = sessionBound(sessionToken) {
+        worldsApi.updateWorld(worldId, WorldUpdateData(imageUrl = imageUrl))
+        Unit
+    }
+
+    override suspend fun refreshWorld(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+    ): Result<WorldImageUpdate> = sessionBound(sessionToken) {
+        worldsApi.getWorldById(worldId)
+    }.map { response ->
+        WorldImageUpdate(response.value, response.sessionToken)
+    }
+
+    private suspend fun <T> sessionBound(
+        sessionToken: AccountSessionToken,
+        block: suspend () -> T,
+    ): Result<SessionBoundValue<T>> {
+        val response = authService.runSessionBoundCatching(sessionToken, block)
+            ?: return Result.failure(WorldImageSessionChanged())
+        return response.result.map { value ->
+            SessionBoundValue(value, response.sessionToken)
+        }
+    }
+}
+
+private fun Throwable.rethrowIfCancellation() {
+    if (this is CancellationException) throw this
+}
+
+private fun ByteArray.hasPrefix(vararg expected: Int): Boolean =
+    size >= expected.size && expected.indices.all { index ->
+        this[index].toInt() and 0xFF == expected[index]
+    }
+
+private fun ByteArray.hasAsciiAt(offset: Int, expected: String): Boolean =
+    size >= offset + expected.length && expected.indices.all { index ->
+        this[offset + index].toInt() and 0xFF == expected[index].code
+    }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
@@ -50,6 +50,7 @@ import io.github.vrcmteam.vrcm.presentation.navigation.AppDetailRoute
 import io.github.vrcmteam.vrcm.presentation.navigation.AppRoute
 import io.github.vrcmteam.vrcm.presentation.navigation.HandleBackNavigation
 import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 import kotlinx.serialization.Serializable
 import io.github.vrcmteam.vrcm.presentation.navigation.LocalNavigator
 import io.github.vrcmteam.vrcm.presentation.navigation.currentOrThrow
@@ -58,6 +59,7 @@ import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import io.github.vrcmteam.vrcm.core.extensions.toLocalDate
+import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
 import io.github.vrcmteam.vrcm.network.api.files.data.PlatformType.*
 import io.github.vrcmteam.vrcm.presentation.compoments.*
@@ -65,6 +67,11 @@ import io.github.vrcmteam.vrcm.presentation.extensions.*
 import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntryState
 import io.github.vrcmteam.vrcm.presentation.screens.user.UserProfileScreen
 import io.github.vrcmteam.vrcm.presentation.screens.user.data.UserProfileVo
+import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.ImageEditorTarget
+import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PrintImageEditorScreen
+import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PrintImageEditorSessionStore
+import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PrintImageProcessor
+import io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.handoffPreparedImageToEditor
 import io.github.vrcmteam.vrcm.presentation.screens.world.components.CreateInstanceDialog
 import io.github.vrcmteam.vrcm.presentation.screens.world.components.EmptyInstanceCard
 import io.github.vrcmteam.vrcm.presentation.screens.world.components.FavoriteGroupBottomSheet
@@ -99,27 +106,79 @@ class WorldProfileScreen(
     override fun Content() {
         // 创建ViewModel
         val screenModel: WorldProfileScreenModel = koinViewModel()
+        val imageProcessor: PrintImageProcessor = koinInject()
+        val editorSessionStore: PrintImageEditorSessionStore = koinInject()
 
         // 收集ViewModel状态
         val profileVoState by screenModel.worldProfileState.collectAsState()
         val isLoading by screenModel.isLoading.collectAsState()
+        val imageEditState by screenModel.imageEditState.collectAsState()
+        val worldCoverUpdates by editorSessionStore.worldCoverUpdates.collectAsState()
         val currentNavigator = currentNavigator
+        val locale = strings
+        var showImageEditSheet by remember { mutableStateOf(false) }
+
+        LaunchedEffect(screenModel, locale) {
+            screenModel.notices.collect { notice ->
+                val text = when (notice) {
+                    WorldProfileNotice.ImageSaved -> locale.worldImageEditSaved
+                }
+                SharedFlowCentre.toastText.emit(ToastText.Success(text))
+            }
+        }
         // 组件首次加载时自动刷新数据
         LaunchedEffect(Unit) {
             screenModel.loadWorldData(worldProfileVO)
+        }
+
+        LaunchedEffect(imageEditState.canEdit) {
+            if (!imageEditState.canEdit) showImageEditSheet = false
+        }
+
+        val displayedWorld = profileVoState ?: worldProfileVO
+        LaunchedEffect(displayedWorld.worldId, worldCoverUpdates) {
+            val update = worldCoverUpdates[displayedWorld.worldId]
+                ?: return@LaunchedEffect
+            screenModel.applyWorldImageUpdate(update)
+            editorSessionStore.consumeWorldCoverUpdate(displayedWorld.worldId)
         }
 
         CompositionLocalProvider(
             LocalSharedSuffixKey provides sharedSuffixKey,
         ) {
             WorldProfileContent(
-                worldProfileVo = profileVoState ?: worldProfileVO,
+                worldProfileVo = displayedWorld,
                 onReturn = { currentNavigator.pop() },
                 onMenu = { /* 打开菜单 */ },
                 isRefreshing = isLoading,
                 onRefresh = screenModel::refreshWorldData,
+                canEditImage = imageEditState.canEdit,
+                onEditImage = { showImageEditSheet = true },
                 sharedKeyPrefix = sharedKeyPrefix,
                 sharedImageCacheKey = sharedImageCacheKey,
+            )
+        }
+        val editToken = imageEditState.sessionToken
+        if (showImageEditSheet && imageEditState.canEdit && editToken != null) {
+            WorldImageEditSheet(
+                world = displayedWorld,
+                imageProcessor = imageProcessor,
+                onDismiss = { showImageEditSheet = false },
+                onEditImage = { source, prepared ->
+                    handoffPreparedImageToEditor(
+                        source = source,
+                        prepared = prepared,
+                        sessionStore = editorSessionStore,
+                        target = ImageEditorTarget.WorldCover(
+                            worldId = displayedWorld.worldId,
+                            sessionToken = editToken,
+                        ),
+                        push = { sessionId ->
+                            currentNavigator.push(PrintImageEditorScreen(sessionId))
+                            showImageEditSheet = false
+                        },
+                    )
+                },
             )
         }
     }
@@ -132,6 +191,8 @@ class WorldProfileScreen(
         onMenu: () -> Unit = {},
         isRefreshing: Boolean = false,
         onRefresh: () -> Unit = {},
+        canEditImage: Boolean = false,
+        onEditImage: () -> Unit = {},
         sharedKeyPrefix: String = "",
         sharedImageCacheKey: String? = null,
     ) {
@@ -227,7 +288,9 @@ class WorldProfileScreen(
                 onMenu = onMenu,
                 onCollapse = { sheetState = SheetState.COLLAPSED },
                 isRefreshing = isRefreshing,
-                onRefresh = onRefresh
+                onRefresh = onRefresh,
+                canEditImage = canEditImage,
+                onEditImage = onEditImage,
             )
 
             // ========== BottomSheet ==========
@@ -729,6 +792,8 @@ private fun RenderTopBar(
     onCollapse: () -> Unit,
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
+    canEditImage: Boolean = false,
+    onEditImage: () -> Unit = {},
 ) {
     BoxWithConstraints(
         modifier = Modifier
@@ -736,7 +801,8 @@ private fun RenderTopBar(
             .zIndex(20f) // 确保在所有内容之上
     ) {
         val topBarRatio = (1 - blurProgress).coerceIn(0f, 1f)
-        val titleMaxWidth = (maxWidth - 208.dp).coerceIn(40.dp, 200.dp)
+        val reservedActionsWidth = if (canEditImage) 256.dp else 208.dp
+        val titleMaxWidth = (maxWidth - reservedActionsWidth).coerceIn(40.dp, 200.dp)
 
         // 添加TopMenuBar
         TopMenuBar(
@@ -748,6 +814,17 @@ private fun RenderTopBar(
             onReturn = onReturn,
             onMenu = null,
             actions = { colors ->
+                if (canEditImage) {
+                    IconButton(
+                        colors = colors,
+                        onClick = onEditImage,
+                    ) {
+                        Icon(
+                            imageVector = AppIcons.Edit,
+                            contentDescription = strings.worldImageEditTitle,
+                        )
+                    }
+                }
                 OfficialUrlShareButton(
                     url = "https://vrchat.com/home/world/$worldId",
                     colors = colors,

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
@@ -144,33 +144,36 @@ class WorldProfileScreenModel internal constructor(
         val session = SharedFlowCentre.currentSession.value
         if (!isCurrentWorldImageUpdate(current, session, update)) return false
 
-        if (!worldProfileCacheStore.saveIfCurrent(
+        if (!worldProfileCacheStore.saveAndCommitIfCurrent(
             WorldProfileCache(
                 world = update.world,
                 cachedAtEpochMilliseconds = Clock.System.now().toEpochMilliseconds(),
             ),
-            isCurrent = {
+            canStart = {
                 isCurrentWorldImageUpdate(
                     currentWorld = _worldProfileState.value,
                     currentSession = SharedFlowCentre.currentSession.value,
                     update = update,
                 )
             },
+            commit = {
+                SharedFlowCentre.commitIfCurrentSession(update.sessionToken) { currentSession ->
+                    val latest = _worldProfileState.value
+                        ?: return@commitIfCurrentSession false
+                    if (!isCurrentWorldImageUpdate(latest, currentSession, update)) {
+                        return@commitIfCurrentSession false
+                    }
+                    _worldProfileState.compareAndSet(
+                        expect = latest,
+                        update = WorldProfileVo(
+                            world = update.world,
+                            instancesList = latest.instances,
+                            platformFileSizes = latest.platformFileSizes,
+                        ),
+                    )
+                }
+            },
         )) return false
-
-        val latest = _worldProfileState.value
-        if (!isCurrentWorldImageUpdate(
-                currentWorld = latest,
-                currentSession = SharedFlowCentre.currentSession.value,
-                update = update,
-            )
-        ) return false
-
-        _worldProfileState.value = WorldProfileVo(
-            world = update.world,
-            instancesList = latest?.instances.orEmpty(),
-            platformFileSizes = latest?.platformFileSizes.orEmpty(),
-        )
         _notices.emit(WorldProfileNotice.ImageSaved)
         return true
     }

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
@@ -120,7 +120,8 @@ class WorldProfileScreenModel internal constructor(
 
     private suspend fun applyCachedWorld(worldId: String, worldProfileVO: WorldProfileVo) {
         val cached = worldProfileCacheStore.load(worldId)
-        if (cached != null && _worldProfileState.value?.worldId == worldId) {
+        if (_worldProfileState.value?.worldId != worldId) return
+        if (cached != null) {
             _worldProfileState.value = WorldProfileVo(
                 world = cached.world,
                 instancesList = worldProfileVO.instances,
@@ -143,12 +144,19 @@ class WorldProfileScreenModel internal constructor(
         val session = SharedFlowCentre.currentSession.value
         if (!isCurrentWorldImageUpdate(current, session, update)) return false
 
-        worldProfileCacheStore.save(
+        if (!worldProfileCacheStore.saveIfCurrent(
             WorldProfileCache(
                 world = update.world,
                 cachedAtEpochMilliseconds = Clock.System.now().toEpochMilliseconds(),
-            )
-        )
+            ),
+            isCurrent = {
+                isCurrentWorldImageUpdate(
+                    currentWorld = _worldProfileState.value,
+                    currentSession = SharedFlowCentre.currentSession.value,
+                    update = update,
+                )
+            },
+        )) return false
 
         val latest = _worldProfileState.value
         if (!isCurrentWorldImageUpdate(

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.github.vrcmteam.vrcm.core.extensions.removeFirst
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+import io.github.vrcmteam.vrcm.core.shared.AuthenticatedAccount
 import io.github.vrcmteam.vrcm.network.api.attributes.AccessType
 import io.github.vrcmteam.vrcm.network.api.attributes.BlueprintType
 import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
@@ -33,6 +35,24 @@ import kotlinx.coroutines.launch
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
+internal data class WorldImageEditState(
+    val canEdit: Boolean = false,
+    val sessionToken: AccountSessionToken? = null,
+)
+
+internal sealed interface WorldProfileNotice {
+    data object ImageSaved : WorldProfileNotice
+}
+
+internal fun isCurrentWorldImageUpdate(
+    currentWorld: WorldProfileVo?,
+    currentSession: AuthenticatedAccount?,
+    update: WorldImageUpdate,
+): Boolean = currentWorld?.worldId == update.world.id &&
+    currentWorld.authorID == update.world.authorId &&
+    update.world.authorId == currentSession?.account?.userId &&
+    update.sessionToken == currentSession?.token
+
 /**
  * 世界档案页面的ViewModel，负责处理世界数据的加载和刷新
  */
@@ -55,6 +75,25 @@ class WorldProfileScreenModel internal constructor(
     // 加载状态
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    internal val imageEditState: StateFlow<WorldImageEditState> = combine(
+        worldProfileState,
+        SharedFlowCentre.currentSession,
+    ) { world, session ->
+        val canEdit = world?.authorID?.isNotBlank() == true &&
+            world.authorID == session?.account?.userId
+        WorldImageEditState(
+            canEdit = canEdit,
+            sessionToken = session?.token?.takeIf { canEdit },
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = WorldImageEditState(),
+    )
+
+    private val _notices = MutableSharedFlow<WorldProfileNotice>(extraBufferCapacity = 1)
+    internal val notices: SharedFlow<WorldProfileNotice> = _notices.asSharedFlow()
 
     private val favoriteEntry = FavoriteEntryStateModel(
         favoriteType = FavoriteType.World,
@@ -81,7 +120,7 @@ class WorldProfileScreenModel internal constructor(
 
     private suspend fun applyCachedWorld(worldId: String, worldProfileVO: WorldProfileVo) {
         val cached = worldProfileCacheStore.load(worldId)
-        if (cached != null) {
+        if (cached != null && _worldProfileState.value?.worldId == worldId) {
             _worldProfileState.value = WorldProfileVo(
                 world = cached.world,
                 instancesList = worldProfileVO.instances,
@@ -97,6 +136,35 @@ class WorldProfileScreenModel internal constructor(
         } else {
             loadCachedInstances(cached.world.instances.orEmpty())
         }
+    }
+
+    internal suspend fun applyWorldImageUpdate(update: WorldImageUpdate): Boolean {
+        val current = _worldProfileState.value
+        val session = SharedFlowCentre.currentSession.value
+        if (!isCurrentWorldImageUpdate(current, session, update)) return false
+
+        worldProfileCacheStore.save(
+            WorldProfileCache(
+                world = update.world,
+                cachedAtEpochMilliseconds = Clock.System.now().toEpochMilliseconds(),
+            )
+        )
+
+        val latest = _worldProfileState.value
+        if (!isCurrentWorldImageUpdate(
+                currentWorld = latest,
+                currentSession = SharedFlowCentre.currentSession.value,
+                update = update,
+            )
+        ) return false
+
+        _worldProfileState.value = WorldProfileVo(
+            world = update.world,
+            instancesList = latest?.instances.orEmpty(),
+            platformFileSizes = latest?.platformFileSizes.orEmpty(),
+        )
+        _notices.emit(WorldProfileNotice.ImageSaved)
+        return true
     }
 
     private fun loadCachedInstances(worldInstances: List<List<String>>) {

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStrings.kt
@@ -251,6 +251,26 @@ sealed class LocaleStrings {
     open val worldProfilePublishDate: String = "Publish Date"
     open val worldProfileUpdateDate: String = "Update Date"
     open val worldProfileLabReleaseDate: String = "Lab Release Date"
+    open val worldImageEditTitle: String = "Manage World Image"
+    open val worldImageEditPreview: String = "Preview image"
+    open val worldImageEditThumbnail: String = "Cover thumbnail"
+    open val worldImageEditHint: String =
+        "Choose a JPEG, PNG, or WebP up to 10 MiB. The editor exports a 1920 x 1080 image; VRChat generates the cover thumbnail."
+    open val worldImageEditChoose: String = "Choose image"
+    open val worldImageEditUpload: String = "Update world image"
+    open val worldImageEditUploading: String = "Uploading world image..."
+    open val worldImageEditSaved: String = "World preview and cover updated"
+    open val worldImageEditUploadFailed: String = "World image upload failed"
+    open val worldImageEditAssignmentFailed: String =
+        "The image was uploaded, but VRChat could not assign it to the world. Try updating the image again."
+    open val worldImageEditRefreshFailed: String =
+        "The image was updated, but the latest world details could not be loaded. Refresh the world to verify it."
+    open val worldImageEditSessionChanged: String =
+        "Your account session changed. Reopen image management and try again."
+    open val worldImageEditUnsupportedFormat: String =
+        "The image format is unsupported or does not match its extension. Choose a valid JPEG, PNG, or WebP file."
+    open val worldImageEditFileTooLarge: String = "The selected image is larger than 10 MiB"
+    open val worldImageEditReadFailed: String = "The selected world image could not be read"
     open val unknown: String = "Unknown"
 
     // CreateInstanceDialog

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsJa.kt
@@ -236,6 +236,26 @@ internal object LocaleStringsJa : LocaleStrings() {
     override val worldProfilePublishDate = "公開日"
     override val worldProfileUpdateDate = "更新日"
     override val worldProfileLabReleaseDate = "ラボ公開日"
+    override val worldImageEditTitle = "ワールド画像を管理"
+    override val worldImageEditPreview = "プレビュー画像"
+    override val worldImageEditThumbnail = "カバーのサムネイル"
+    override val worldImageEditHint =
+        "10 MiB 以下の JPEG、PNG、WebP を選択してください。編集後は 1920 x 1080 で出力され、カバーのサムネイルは VRChat が生成します。"
+    override val worldImageEditChoose = "画像を選択"
+    override val worldImageEditUpload = "ワールド画像を更新"
+    override val worldImageEditUploading = "ワールド画像をアップロード中..."
+    override val worldImageEditSaved = "ワールドのプレビューとカバーを更新しました"
+    override val worldImageEditUploadFailed = "ワールド画像のアップロードに失敗しました"
+    override val worldImageEditAssignmentFailed =
+        "画像はアップロードされましたが、VRChat でワールドに設定できませんでした。画像の更新を再試行してください。"
+    override val worldImageEditRefreshFailed =
+        "画像は更新されましたが、最新のワールド情報を取得できませんでした。ワールドを更新して確認してください。"
+    override val worldImageEditSessionChanged =
+        "アカウントのセッションが変更されました。画像管理を開き直して再試行してください。"
+    override val worldImageEditUnsupportedFormat =
+        "画像形式が未対応か、拡張子と内容が一致しません。有効な JPEG、PNG、WebP を選択してください。"
+    override val worldImageEditFileTooLarge = "選択した画像は 10 MiB を超えています"
+    override val worldImageEditReadFailed = "選択したワールド画像を読み込めませんでした"
     override val unknown = "不明"
 
     // CreateInstanceDialog

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHans.kt
@@ -235,6 +235,25 @@ internal object LocaleStringsZhHans : LocaleStrings() {
     override val worldProfilePublishDate = "发布日期"
     override val worldProfileUpdateDate = "更新日期"
     override val worldProfileLabReleaseDate = "实验室发布日期"
+    override val worldImageEditTitle = "管理世界图片"
+    override val worldImageEditPreview = "预览图"
+    override val worldImageEditThumbnail = "封面缩略图"
+    override val worldImageEditHint =
+        "请选择不超过 10 MiB 的 JPEG、PNG 或 WebP 图片。编辑器将输出 1920 x 1080 图片，封面缩略图由 VRChat 生成。"
+    override val worldImageEditChoose = "选择图片"
+    override val worldImageEditUpload = "更新世界图片"
+    override val worldImageEditUploading = "正在上传世界图片..."
+    override val worldImageEditSaved = "世界预览图和封面已更新"
+    override val worldImageEditUploadFailed = "世界图片上传失败"
+    override val worldImageEditAssignmentFailed =
+        "图片已上传，但 VRChat 未能将其设为世界图片，请重新尝试更新。"
+    override val worldImageEditRefreshFailed =
+        "图片已更新，但无法获取最新世界详情，请刷新世界以确认结果。"
+    override val worldImageEditSessionChanged = "账号会话已改变，请重新打开图片管理后再试。"
+    override val worldImageEditUnsupportedFormat =
+        "图片格式不受支持或扩展名与内容不符，请选择有效的 JPEG、PNG 或 WebP 文件。"
+    override val worldImageEditFileTooLarge = "所选图片超过 10 MiB"
+    override val worldImageEditReadFailed = "无法读取所选世界图片"
     override val unknown = "未知"
 
     // CreateInstanceDialog

--- a/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/settings/locale/LocaleStringsZhHant.kt
@@ -235,6 +235,25 @@ internal object LocaleStringsZhHant : LocaleStrings() {
     override val worldProfilePublishDate = "發布日期"
     override val worldProfileUpdateDate = "更新日期"
     override val worldProfileLabReleaseDate = "實驗室發布日期"
+    override val worldImageEditTitle = "管理世界圖片"
+    override val worldImageEditPreview = "預覽圖"
+    override val worldImageEditThumbnail = "封面縮圖"
+    override val worldImageEditHint =
+        "請選擇不超過 10 MiB 的 JPEG、PNG 或 WebP 圖片。編輯器將輸出 1920 x 1080 圖片，封面縮圖由 VRChat 產生。"
+    override val worldImageEditChoose = "選擇圖片"
+    override val worldImageEditUpload = "更新世界圖片"
+    override val worldImageEditUploading = "正在上傳世界圖片..."
+    override val worldImageEditSaved = "世界預覽圖和封面已更新"
+    override val worldImageEditUploadFailed = "世界圖片上傳失敗"
+    override val worldImageEditAssignmentFailed =
+        "圖片已上傳，但 VRChat 未能將其設為世界圖片，請重新嘗試更新。"
+    override val worldImageEditRefreshFailed =
+        "圖片已更新，但無法取得最新世界詳情，請重新整理世界以確認結果。"
+    override val worldImageEditSessionChanged = "帳號工作階段已變更，請重新開啟圖片管理後再試。"
+    override val worldImageEditUnsupportedFormat =
+        "圖片格式不受支援或副檔名與內容不符，請選擇有效的 JPEG、PNG 或 WebP 檔案。"
+    override val worldImageEditFileTooLarge = "所選圖片超過 10 MiB"
+    override val worldImageEditReadFailed = "無法讀取所選世界圖片"
     override val unknown = "未知"
 
     // CreateInstanceDialog

--- a/composeApp/src/commonMain/kotlin/storage/CacheStores.kt
+++ b/composeApp/src/commonMain/kotlin/storage/CacheStores.kt
@@ -61,6 +61,16 @@ interface WorldProfileCacheStore {
 
     suspend fun save(cache: WorldProfileCache)
 
+    /**
+     * 仅在 [isCurrent] 在写入前后均为真时提交缓存。
+     * 默认实现用于兼容轻量测试存储，Room 实现会在会话失效后恢复旧值。
+     */
+    suspend fun saveIfCurrent(cache: WorldProfileCache, isCurrent: () -> Boolean): Boolean {
+        if (!isCurrent()) return false
+        save(cache)
+        return isCurrent()
+    }
+
     suspend fun clearAll()
 }
 
@@ -208,6 +218,7 @@ internal class RoomWorldProfileCacheStore(
     nowMillis: () -> Long,
     retained: Int = 60,
 ) : WorldProfileCacheStore {
+    private val mutationMutex = Mutex()
     private val cache = JsonBlobCache(
         dao = dao,
         scope = CacheScopes.WORLD_PROFILE,
@@ -219,9 +230,29 @@ internal class RoomWorldProfileCacheStore(
 
     override suspend fun load(worldId: String): WorldProfileCache? = cache.load(worldId)
 
-    override suspend fun save(cache: WorldProfileCache) = this.cache.save(cache.world.id, cache)
+    override suspend fun save(cache: WorldProfileCache) = mutationMutex.withLock {
+        this.cache.save(cache.world.id, cache)
+    }
 
-    override suspend fun clearAll() = cache.clear()
+    override suspend fun saveIfCurrent(cache: WorldProfileCache, isCurrent: () -> Boolean): Boolean =
+        mutationMutex.withLock {
+            if (!isCurrent()) return@withLock false
+            val worldId = cache.world.id
+            val previous = this.cache.load(worldId)
+            this.cache.save(worldId, cache)
+            if (isCurrent()) {
+                true
+            } else {
+                if (previous == null) {
+                    this.cache.delete(worldId)
+                } else {
+                    this.cache.save(worldId, previous)
+                }
+                false
+            }
+        }
+
+    override suspend fun clearAll() = mutationMutex.withLock { cache.clear() }
 }
 
 internal class RoomGroupProfileCacheStore(

--- a/composeApp/src/commonMain/kotlin/storage/CacheStores.kt
+++ b/composeApp/src/commonMain/kotlin/storage/CacheStores.kt
@@ -62,14 +62,14 @@ interface WorldProfileCacheStore {
     suspend fun save(cache: WorldProfileCache)
 
     /**
-     * 仅在 [isCurrent] 在写入前后均为真时提交缓存。
-     * 默认实现用于兼容轻量测试存储，Room 实现会在会话失效后恢复旧值。
+     * 暂存缓存后执行同步状态提交；提交失败时恢复原缓存。
+     * [commit] 不得调用此存储的挂起方法。
      */
-    suspend fun saveIfCurrent(cache: WorldProfileCache, isCurrent: () -> Boolean): Boolean {
-        if (!isCurrent()) return false
-        save(cache)
-        return isCurrent()
-    }
+    suspend fun saveAndCommitIfCurrent(
+        cache: WorldProfileCache,
+        canStart: () -> Boolean,
+        commit: () -> Boolean,
+    ): Boolean
 
     suspend fun clearAll()
 }
@@ -228,31 +228,44 @@ internal class RoomWorldProfileCacheStore(
         prune = { it.copy(world = it.world.prunedForProfileCache()) },
     )
 
-    override suspend fun load(worldId: String): WorldProfileCache? = cache.load(worldId)
+    override suspend fun load(worldId: String): WorldProfileCache? = mutationMutex.withLock {
+        cache.load(worldId)
+    }
 
     override suspend fun save(cache: WorldProfileCache) = mutationMutex.withLock {
         this.cache.save(cache.world.id, cache)
     }
 
-    override suspend fun saveIfCurrent(cache: WorldProfileCache, isCurrent: () -> Boolean): Boolean =
+    override suspend fun saveAndCommitIfCurrent(
+        cache: WorldProfileCache,
+        canStart: () -> Boolean,
+        commit: () -> Boolean,
+    ): Boolean =
         mutationMutex.withLock {
-            if (!isCurrent()) return@withLock false
+            if (!canStart()) return@withLock false
             val worldId = cache.world.id
             val previous = this.cache.load(worldId)
             this.cache.save(worldId, cache)
-            if (isCurrent()) {
-                true
-            } else {
-                if (previous == null) {
-                    this.cache.delete(worldId)
-                } else {
-                    this.cache.save(worldId, previous)
-                }
-                false
+
+            val committed = try {
+                commit()
+            } catch (error: Throwable) {
+                restore(worldId, previous)
+                throw error
             }
+            if (!committed) restore(worldId, previous)
+            committed
         }
 
     override suspend fun clearAll() = mutationMutex.withLock { cache.clear() }
+
+    private suspend fun restore(worldId: String, previous: WorldProfileCache?) {
+        if (previous == null) {
+            cache.delete(worldId)
+        } else {
+            cache.save(worldId, previous)
+        }
+    }
 }
 
 internal class RoomGroupProfileCacheStore(

--- a/composeApp/src/commonTest/kotlin/network/api/files/FileApiUploadTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/api/files/FileApiUploadTest.kt
@@ -67,6 +67,15 @@ class FileApiUploadTest {
     }
 
     @Test
+    fun worldImageUploadUsesTheVrchatWorldImageTag() = runBlocking {
+        val capturedBody = captureUploadBody(FileTagType.WorldImage)
+
+        assertTrue(capturedBody.contains("filename=\"blob\""))
+        assertTrue(capturedBody.contains("worldimage"))
+        assertFalse(capturedBody.contains("name=maskTag"))
+    }
+
+    @Test
     fun animatedEmojiUploadUsesVrcxFilenameMetadata() = runBlocking {
         val capturedBody = captureUploadBody(
             tagType = FileTagType.Emoji,

--- a/composeApp/src/commonTest/kotlin/network/api/worlds/WorldsApiTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/api/worlds/WorldsApiTest.kt
@@ -1,0 +1,71 @@
+package io.github.vrcmteam.vrcm.network.api.worlds
+
+import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldUpdateData
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WorldsApiTest {
+    @Test
+    fun updateWorldOnlySendsImageUrlAndParsesServerThumbnail() = runBlocking {
+        var request: HttpRequestData? = null
+        var body = ""
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { captured ->
+                    request = captured
+                    body = (captured.body as OutgoingContent.ByteArrayContent)
+                        .bytes()
+                        .decodeToString()
+                    respond(
+                        content = worldJson(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+            }
+            defaultRequest { url("https://api.vrchat.cloud/api/1/") }
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+        val updated = WorldsApi(client).updateWorld(
+            worldId = "wrld_owned",
+            update = WorldUpdateData(imageUrl = "https://api.vrchat.cloud/api/1/file/file_image/2/file"),
+        )
+
+        assertEquals(HttpMethod.Put, request?.method)
+        assertEquals("/api/1/worlds/wrld_owned", request?.url?.encodedPath)
+        assertEquals(
+            "{\"imageUrl\":\"https://api.vrchat.cloud/api/1/file/file_image/2/file\"}",
+            body,
+        )
+        assertEquals("https://cdn.example/thumbnail.png", updated.thumbnailImageUrl)
+        client.close()
+    }
+
+    private fun worldJson() = """{
+        "authorId":"usr_owner","authorName":"Owner","capacity":32,
+        "created_at":"2026-01-01T00:00:00Z","description":"World",
+        "favorites":1,"featured":false,"heat":1,"id":"wrld_owned",
+        "imageUrl":"https://cdn.example/original.png","labsPublicationDate":"",
+        "name":"Owned World","namespace":null,"organization":"vrchat",
+        "popularity":1,"privateOccupants":0,"publicOccupants":0,
+        "publicationDate":"","recommendedCapacity":16,"releaseStatus":"private",
+        "tags":[],"thumbnailImageUrl":"https://cdn.example/thumbnail.png",
+        "udonProducts":[],"unityPackages":[],"updated_at":"2026-01-02T00:00:00Z",
+        "version":2,"visits":1
+    }""".trimIndent()
+}

--- a/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/ImageEditorSubmitterTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/ImageEditorSubmitterTest.kt
@@ -8,6 +8,11 @@ import io.github.vrcmteam.vrcm.presentation.screens.avatar.AvatarCoverFile
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.AvatarCoverUpdateFailure
 import io.github.vrcmteam.vrcm.presentation.screens.avatar.AvatarEditor
 import io.github.vrcmteam.vrcm.presentation.screens.gallery.GalleryDataSource
+import io.github.vrcmteam.vrcm.presentation.screens.world.SessionBoundValue
+import io.github.vrcmteam.vrcm.presentation.screens.world.WorldImageEditor
+import io.github.vrcmteam.vrcm.presentation.screens.world.WorldImageFile
+import io.github.vrcmteam.vrcm.presentation.screens.world.WorldImageUpdate
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
 import io.github.vrcmteam.vrcm.service.PrintUploader
 import io.github.vrcmteam.vrcm.network.api.prints.data.PrintData
 import kotlinx.coroutines.runBlocking
@@ -24,7 +29,12 @@ class ImageEditorSubmitterTest {
             uploadResult = Result.failure(IllegalStateException("unused")),
             assignmentResult = Result.failure(IllegalStateException("unused")),
         )
-        val submitter = NetworkImageEditorSubmitter(printUploader, avatarEditor, UnusedGalleryDataSource)
+        val submitter = NetworkImageEditorSubmitter(
+            printUploader,
+            avatarEditor,
+            UnusedGalleryDataSource,
+            UnusedWorldImageEditor,
+        )
         val png = byteArrayOf(1, 2, 3)
 
         val result = submitter.submit(
@@ -54,6 +64,7 @@ class ImageEditorSubmitterTest {
             printUploader = UnusedPrintUploader,
             avatarEditor = avatarEditor,
             galleryDataSource = UnusedGalleryDataSource,
+            worldImageEditor = UnusedWorldImageEditor,
         )
         val png = byteArrayOf(1, 2, 3)
 
@@ -81,6 +92,7 @@ class ImageEditorSubmitterTest {
             UnusedPrintUploader,
             avatarEditor,
             UnusedGalleryDataSource,
+            UnusedWorldImageEditor,
         )
 
         val result = submitter.submit(
@@ -104,6 +116,7 @@ class ImageEditorSubmitterTest {
             UnusedPrintUploader,
             avatarEditor,
             UnusedGalleryDataSource,
+            UnusedWorldImageEditor,
         )
 
         val result = submitter.submit(
@@ -123,6 +136,7 @@ class ImageEditorSubmitterTest {
             printUploader = UnusedPrintUploader,
             avatarEditor = UnusedAvatarEditor,
             galleryDataSource = galleryDataSource,
+            worldImageEditor = UnusedWorldImageEditor,
         )
         val png = byteArrayOf(1, 2, 3)
 
@@ -179,6 +193,24 @@ private data object UnusedAvatarEditor : AvatarEditor {
 
     override suspend fun assignCover(avatarId: String, imageUrl: String): Result<AvatarData> =
         error("Avatar editing is not used")
+}
+
+private data object UnusedWorldImageEditor : WorldImageEditor {
+    override suspend fun uploadImage(
+        sessionToken: AccountSessionToken,
+        image: WorldImageFile,
+    ): Result<SessionBoundValue<String>> = error("World image editing is not used")
+
+    override suspend fun assignImage(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+        imageUrl: String,
+    ): Result<SessionBoundValue<Unit>> = error("World image editing is not used")
+
+    override suspend fun refreshWorld(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+    ): Result<WorldImageUpdate> = error("World image editing is not used")
 }
 
 private data object UnusedGalleryDataSource : GalleryDataSource {

--- a/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/PrintImageEditorSessionStoreTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/gallery/editor/PrintImageEditorSessionStoreTest.kt
@@ -6,6 +6,8 @@ import androidx.compose.ui.graphics.colorspace.ColorSpace
 import androidx.compose.ui.graphics.colorspace.ColorSpaces
 import io.github.vrcmteam.vrcm.network.api.avatars.data.AvatarData
 import io.github.vrcmteam.vrcm.network.api.files.data.FileTagType
+import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
+import io.github.vrcmteam.vrcm.presentation.screens.world.WorldImageUpdate
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
@@ -85,6 +87,52 @@ class PrintImageEditorSessionStoreTest {
 
         assertEquals(FileTagType.Emoji, store.galleryUploadCompletions.first())
         assertNull(store.get(id))
+    }
+
+    @Test
+    fun worldCoverCompletionIsConsumedOnlyByTheMatchingWorld() {
+        val store = PrintImageEditorSessionStore()
+        val token = io.github.vrcmteam.vrcm.core.shared.AccountSessionToken("usr_owner", 1)
+        val target = ImageEditorTarget.WorldCover("wrld_test", token)
+        val id = store.create(
+            source = SelectedImage("source.jpg", byteArrayOf(1)),
+            prepared = PreparedImage(SessionTestImageBitmap, ImageSize(16, 9)),
+            target = target,
+        )
+        val world = WorldData(
+            authorId = "usr_owner",
+            authorName = "Owner",
+            capacity = 16,
+            createdAt = null,
+            description = null,
+            favorites = null,
+            featured = null,
+            heat = 0,
+            id = "wrld_test",
+            imageUrl = "https://example.test/original.png",
+            labsPublicationDate = "",
+            name = "World",
+            namespace = null,
+            organization = "vrchat",
+            popularity = 0,
+            publicationDate = "",
+            recommendedCapacity = 8,
+            releaseStatus = "private",
+            tags = emptyList(),
+            thumbnailImageUrl = "https://example.test/thumbnail.png",
+            udonProducts = emptyList(),
+            unityPackages = emptyList(),
+            updatedAt = null,
+            version = 1,
+            visits = 0,
+        )
+        val update = WorldImageUpdate(world, token)
+
+        store.complete(id, ImageEditorSubmission.WorldCover(update))
+
+        assertEquals(null, store.consumeWorldCoverUpdate("wrld_other"))
+        assertEquals(update, store.consumeWorldCoverUpdate("wrld_test"))
+        assertEquals(null, store.consumeWorldCoverUpdate("wrld_test"))
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldImageEditorTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldImageEditorTest.kt
@@ -1,0 +1,195 @@
+package io.github.vrcmteam.vrcm.presentation.screens.world
+
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
+import io.github.vrcmteam.vrcm.core.shared.AuthenticatedAccount
+import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
+import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
+import io.github.vrcmteam.vrcm.service.data.AccountDto
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class WorldImageEditorTest {
+    @Test
+    fun updateCarriesRenewedSessionAcrossAllStagesAndReturnsAuthoritativeRefresh() = runBlocking {
+        val initial = AccountSessionToken("usr_owner", 1)
+        val afterUpload = AccountSessionToken("usr_owner", 2)
+        val afterAssignment = AccountSessionToken("usr_owner", 3)
+        val authoritative = worldData(
+            imageUrl = "https://cdn.example/authoritative.png",
+            thumbnailImageUrl = "https://cdn.example/thumbnail.png",
+        )
+        val editor = RecordingWorldImageEditor(
+            uploadResult = Result.success(
+                SessionBoundValue("https://api.vrchat.cloud/api/1/file/file_image/2/file", afterUpload)
+            ),
+            assignmentResult = Result.success(SessionBoundValue(Unit, afterAssignment)),
+            refreshResult = Result.success(WorldImageUpdate(authoritative, afterAssignment)),
+        )
+
+        val result = editor.updateImage(initial, authoritative.id, testImage()).getOrThrow()
+
+        assertEquals(authoritative, result.world)
+        assertEquals(listOf(initial), editor.uploadTokens)
+        assertEquals(listOf(afterUpload), editor.assignmentTokens)
+        assertEquals(listOf(afterAssignment), editor.refreshTokens)
+    }
+
+    @Test
+    fun uploadFailureStopsBeforeWorldMutation() = runBlocking {
+        val editor = RecordingWorldImageEditor(
+            uploadResult = Result.failure(IllegalStateException("upload")),
+            assignmentResult = Result.success(
+                SessionBoundValue(Unit, AccountSessionToken("usr_owner", 1))
+            ),
+            refreshResult = Result.success(
+                WorldImageUpdate(worldData(), AccountSessionToken("usr_owner", 1))
+            ),
+        )
+
+        val result = editor.updateImage(
+            AccountSessionToken("usr_owner", 1),
+            "wrld_owned",
+            testImage(),
+        )
+
+        assertIs<WorldImageUpdateFailure.Upload>(result.exceptionOrNull())
+        assertTrue(editor.assignmentTokens.isEmpty())
+        assertTrue(editor.refreshTokens.isEmpty())
+    }
+
+    @Test
+    fun assignmentFailureDoesNotPretendTheUploadedFileChangedTheWorld() = runBlocking {
+        val token = AccountSessionToken("usr_owner", 1)
+        val editor = RecordingWorldImageEditor(
+            uploadResult = Result.success(
+                SessionBoundValue("https://api.vrchat.cloud/api/1/file/file_image/2/file", token)
+            ),
+            assignmentResult = Result.failure(IllegalStateException("assignment")),
+            refreshResult = Result.success(WorldImageUpdate(worldData(), token)),
+        )
+
+        val result = editor.updateImage(token, "wrld_owned", testImage())
+
+        assertIs<WorldImageUpdateFailure.Assignment>(result.exceptionOrNull())
+        assertTrue(editor.refreshTokens.isEmpty())
+    }
+
+    @Test
+    fun resultGateRejectsOldSessionGenerationEvenForTheSameUser() {
+        val currentToken = AccountSessionToken("usr_owner", 8)
+        val world = worldData()
+        val profile = WorldProfileVo(world)
+        val currentSession = AuthenticatedAccount(
+            account = AccountDto(userId = "usr_owner"),
+            token = currentToken,
+        )
+
+        assertTrue(
+            isCurrentWorldImageUpdate(
+                profile,
+                currentSession,
+                WorldImageUpdate(world, currentToken),
+            )
+        )
+        assertFalse(
+            isCurrentWorldImageUpdate(
+                profile,
+                currentSession,
+                WorldImageUpdate(world, currentToken.copy(generation = 7)),
+            )
+        )
+        assertFalse(
+            isCurrentWorldImageUpdate(
+                profile,
+                currentSession,
+                WorldImageUpdate(world.copy(id = "wrld_other"), currentToken),
+            )
+        )
+    }
+
+    @Test
+    fun extensionCannotDisguiseAnotherWorldImageFormat() {
+        val jpeg = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xE0.toByte())
+
+        assertEquals(
+            WorldImageValidation.UnsupportedFormat,
+            validateWorldImage("world.png", jpeg),
+        )
+    }
+}
+
+private class RecordingWorldImageEditor(
+    private val uploadResult: Result<SessionBoundValue<String>>,
+    private val assignmentResult: Result<SessionBoundValue<Unit>>,
+    private val refreshResult: Result<WorldImageUpdate>,
+) : WorldImageEditor {
+    val uploadTokens = mutableListOf<AccountSessionToken>()
+    val assignmentTokens = mutableListOf<AccountSessionToken>()
+    val refreshTokens = mutableListOf<AccountSessionToken>()
+
+    override suspend fun uploadImage(
+        sessionToken: AccountSessionToken,
+        image: WorldImageFile,
+    ): Result<SessionBoundValue<String>> {
+        uploadTokens += sessionToken
+        return uploadResult
+    }
+
+    override suspend fun assignImage(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+        imageUrl: String,
+    ): Result<SessionBoundValue<Unit>> {
+        assignmentTokens += sessionToken
+        return assignmentResult
+    }
+
+    override suspend fun refreshWorld(
+        sessionToken: AccountSessionToken,
+        worldId: String,
+    ): Result<WorldImageUpdate> {
+        refreshTokens += sessionToken
+        return refreshResult
+    }
+}
+
+private fun testImage() = WorldImageFile(
+    bytes = byteArrayOf(1, 2, 3),
+    fileName = "world.png",
+    mimeType = "image/png",
+)
+
+private fun worldData(
+    imageUrl: String = "https://cdn.example/original.png",
+    thumbnailImageUrl: String? = "https://cdn.example/thumbnail.png",
+) = WorldData(
+    authorId = "usr_owner",
+    authorName = "Owner",
+    capacity = 32,
+    createdAt = "2026-01-01T00:00:00Z",
+    description = "World",
+    favorites = 1,
+    featured = false,
+    heat = 1,
+    id = "wrld_owned",
+    imageUrl = imageUrl,
+    labsPublicationDate = "",
+    name = "Owned World",
+    namespace = null,
+    organization = "vrchat",
+    popularity = 1,
+    publicationDate = "",
+    recommendedCapacity = 16,
+    releaseStatus = "private",
+    tags = emptyList(),
+    thumbnailImageUrl = thumbnailImageUrl,
+    udonProducts = emptyList(),
+    unityPackages = emptyList(),
+    updatedAt = "2026-01-02T00:00:00Z",
+    version = 2,
+    visits = 1,
+)

--- a/composeApp/src/desktopTest/kotlin/storage/RoomWorldProfileCacheStoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/storage/RoomWorldProfileCacheStoreTest.kt
@@ -2,7 +2,9 @@ package io.github.vrcmteam.vrcm.storage
 
 import androidx.room.Room
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import io.github.vrcmteam.vrcm.core.shared.AuthenticationSessionRegistry
 import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
+import io.github.vrcmteam.vrcm.service.data.AccountDto
 import io.github.vrcmteam.vrcm.storage.data.WorldProfileCache
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
@@ -13,25 +15,35 @@ import kotlin.test.assertNull
 
 class RoomWorldProfileCacheStoreTest {
     @Test
-    fun invalidatedSessionRestoresPreviousWorldCache() = withStore { store ->
+    fun sessionInvalidatedBeforeStateCommitRestoresPreviousWorldCache() = withStore { store ->
         store.save(WorldProfileCache(worldData("old.png"), cachedAtEpochMilliseconds = 1L))
+        val sessions = AuthenticationSessionRegistry()
+        val token = sessions.authenticate(AccountDto(userId = "usr_owner")).token
+        var displayedImage = "old.png"
 
-        var checks = 0
-        val committed = store.saveIfCurrent(
+        val committed = store.saveAndCommitIfCurrent(
             WorldProfileCache(worldData("new.png"), cachedAtEpochMilliseconds = 2L),
-            isCurrent = { ++checks == 1 },
+            canStart = { sessions.isCurrent(token) },
+            commit = {
+                sessions.invalidate()
+                sessions.commitIfCurrent(token) {
+                    displayedImage = "new.png"
+                    true
+                }
+            },
         )
 
         assertFalse(committed)
+        assertEquals("old.png", displayedImage)
         assertEquals("old.png", store.load("wrld_cached")?.world?.imageUrl)
     }
 
     @Test
     fun invalidatedSessionDoesNotLeaveNewWorldCache() = withStore { store ->
-        var checks = 0
-        val committed = store.saveIfCurrent(
+        val committed = store.saveAndCommitIfCurrent(
             WorldProfileCache(worldData("new.png"), cachedAtEpochMilliseconds = 1L),
-            isCurrent = { ++checks == 1 },
+            canStart = { true },
+            commit = { false },
         )
 
         assertFalse(committed)

--- a/composeApp/src/desktopTest/kotlin/storage/RoomWorldProfileCacheStoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/storage/RoomWorldProfileCacheStoreTest.kt
@@ -1,0 +1,85 @@
+package io.github.vrcmteam.vrcm.storage
+
+import androidx.room.Room
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
+import io.github.vrcmteam.vrcm.storage.data.WorldProfileCache
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class RoomWorldProfileCacheStoreTest {
+    @Test
+    fun invalidatedSessionRestoresPreviousWorldCache() = withStore { store ->
+        store.save(WorldProfileCache(worldData("old.png"), cachedAtEpochMilliseconds = 1L))
+
+        var checks = 0
+        val committed = store.saveIfCurrent(
+            WorldProfileCache(worldData("new.png"), cachedAtEpochMilliseconds = 2L),
+            isCurrent = { ++checks == 1 },
+        )
+
+        assertFalse(committed)
+        assertEquals("old.png", store.load("wrld_cached")?.world?.imageUrl)
+    }
+
+    @Test
+    fun invalidatedSessionDoesNotLeaveNewWorldCache() = withStore { store ->
+        var checks = 0
+        val committed = store.saveIfCurrent(
+            WorldProfileCache(worldData("new.png"), cachedAtEpochMilliseconds = 1L),
+            isCurrent = { ++checks == 1 },
+        )
+
+        assertFalse(committed)
+        assertNull(store.load("wrld_cached"))
+    }
+
+    private fun withStore(block: suspend (WorldProfileCacheStore) -> Unit) = runTest {
+        val database = Room.inMemoryDatabaseBuilder<VrcmDatabase>()
+            .setDriver(BundledSQLiteDriver())
+            .setQueryCoroutineContext(Dispatchers.IO)
+            .build()
+        try {
+            block(
+                RoomWorldProfileCacheStore(
+                    dao = database.cachedBlobDao(),
+                    nowMillis = { 1L },
+                ),
+            )
+        } finally {
+            database.close()
+        }
+    }
+
+    private fun worldData(imageUrl: String) = WorldData(
+        authorId = "usr_owner",
+        authorName = "Owner",
+        capacity = 32,
+        createdAt = "2026-01-01T00:00:00Z",
+        description = "World",
+        favorites = 1,
+        featured = false,
+        heat = 1,
+        id = "wrld_cached",
+        imageUrl = imageUrl,
+        labsPublicationDate = "",
+        name = "Cached World",
+        namespace = null,
+        organization = "vrchat",
+        popularity = 1,
+        publicationDate = "",
+        recommendedCapacity = 16,
+        releaseStatus = "private",
+        tags = emptyList(),
+        thumbnailImageUrl = "$imageUrl.thumb",
+        udonProducts = emptyList(),
+        unityPackages = emptyList(),
+        updatedAt = "2026-01-02T00:00:00Z",
+        version = 2,
+        visits = 1,
+    )
+}


### PR DESCRIPTION
## 功能说明

- 仅世界作者可从世界详情页进入图片管理。
- 支持 JPEG、PNG、WebP 文件选择，校验扩展名、文件签名与 10 MiB 大小上限。
- 复用图片编辑器裁剪并输出 1920 x 1080 PNG，通过 `/file/image` 以 `worldimage` 标签上传。
- 上传后仅提交 `imageUrl` 更新世界，并重新请求世界详情，以服务端返回的预览图和封面缩略图为权威状态。
- 上传、指派、刷新阶段分别报告失败；账号切换、登出或迟到响应不会写回页面与缓存。
- 同步英文、日文、简体中文和繁体中文文案，并补充相关 API、流程与会话隔离测试。

## 实现假设清单

- VRChat 世界更新接口当前只接受可写的 `imageUrl`；`thumbnailImageUrl` 由服务端生成，客户端不单独提交封面缩略图字段。
- 世界图片沿用 VRChat `/file/image` 上传接口和 `worldimage` 标签，上传结果中的最新完整文件 URL 可用于世界更新。
- 图片管理权限以当前世界 `authorId` 与当前认证账号用户 ID 一致为准；流程期间必须保持同一账号会话。
- 本次范围不包含世界 Unity Package 下载，也不修改世界文本元数据。

## 代码逻辑图

```mermaid
flowchart TD
    A[进入世界详情] --> B{当前账号是世界作者}
    B -- 否 --> C[隐藏图片编辑入口]
    B -- 是 --> D[选择 JPEG PNG 或 WebP]
    D --> E{扩展名 文件签名和大小有效}
    E -- 否 --> F[显示校验错误]
    E -- 是 --> G[WorldImageEditSheet 准备图片]
    G --> H{准备中}
    H -- 是 --> I[拒绝 sheet Hidden 与下滑]
    H -- 否 --> J[裁剪为 1920 x 1080 PNG]
    J --> K[绑定当前 session token 上传 worldimage]
    K --> L{会话仍一致}
    L -- 否 --> M[丢弃结果]
    L -- 是 --> N[PUT 世界 imageUrl]
    N --> O[GET 世界详情]
    O --> P{目标世界 作者和 token 均匹配}
    P -- 否 --> Q[消费并丢弃旧结果]
    P -- 是 --> R[RoomWorldProfileCacheStore 暂存新缓存]
    R --> S[AuthenticationSessionRegistry.commitIfCurrent]
    S --> T{token 有效且页面 CAS 成功}
    T -- 否 --> U[恢复旧缓存并丢弃结果]
    T -- 是 --> V[保留缓存与页面状态]
    V --> W[展示服务端预览图与封面缩略图]
```

## 验证

- `./gradlew :composeApp:compileKotlinDesktop`
- `./gradlew :composeApp:desktopTest --tests io.github.vrcmteam.vrcm.presentation.screens.world.WorldImageEditorTest --tests io.github.vrcmteam.vrcm.network.api.worlds.WorldsApiTest --tests io.github.vrcmteam.vrcm.network.api.files.FileApiUploadTest --tests io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.ImageEditorSubmitterTest --tests io.github.vrcmteam.vrcm.presentation.screens.gallery.editor.PrintImageEditorSessionStoreTest`
- `git diff --check`

完整 Desktop 测试套件两次均为 810 项中 1 项无关失败：`MeetupCardScreenModelTest.shortTextRejectsMoreThanEightyCodePointsWithoutPersisting` 报告 `UncaughtExceptionsBeforeTest`；该测试单独重跑通过。

## 本轮修复补充

- 新增“缓存已暂存、页面提交前会话失效”的 Room 世界缓存回归测试，确认页面和缓存都保留旧值。
- 世界图片、认证会话和 Room 世界缓存定向测试通过。
- 当前完整 `desktopTest` 共 812 项，2 项与本轮无关失败：无图形环境下 `DesktopWindowTitleBarLocaleTest.windowControlLabelsUseTheLatestLanguage` 抛 `HeadlessException`，`MeetupCardScreenModelTest.shortTextRejectsMoreThanEightyCodePointsWithoutPersisting` 报 `UncaughtExceptionsBeforeTest`；后者单独复跑通过。
- `~/ai/bin/check-gate.sh fix-review 144` 返回 `quality gate: pass`。
