### PR TITLE
fix: 修复宽屏详情页主导航消失

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
@@ -84,7 +84,8 @@ object HomeScreen : AppListRoute {
         val scope = rememberCoroutineScope()
         val drawerState = rememberDrawerState(DrawerValue.Closed)
         val drawerCoordinator = remember { HomeDrawerStateCoordinator() }
-        val useRail = LocalAppWindowWidthClass.current != AppWindowWidthClass.Compact
+        val windowWidthClass = LocalAppWindowWidthClass.current
+        val useRail = windowWidthClass != AppWindowWidthClass.Compact
         val supportBlur = getAppPlatform().isSupportBlur
         val hazeState = if (supportBlur) remember { HazeState() } else null
         val selectedDestination = HomeDestination.entries[model.selectedDestinationIndex]
@@ -93,7 +94,9 @@ object HomeScreen : AppListRoute {
         } else {
             null
         }
-        val showMainNavigation = navigator.lastItem == HomeScreen
+        val topRoute = navigator.lastItem
+        val showMainNavigation = topRoute == HomeScreen ||
+            (windowWidthClass == AppWindowWidthClass.Expanded && topRoute is AppDetailRoute)
         var statusVisible by remember { mutableStateOf(true) }
         val onDestinationSelected: (HomeDestination) -> Unit = { destination ->
             if (model.selectDestination(destination)) {


### PR DESCRIPTION
## 修改说明

- 修复宽屏选择用户、世界或其他详情项后，首页左侧菜单与顶部头像、名称一起消失的问题。
- 仅在 Expanded 窗口与详情路由并排展示时保留首页导航外壳；独立全屏页面与非宽屏布局保持原行为。

## 实现假设清单

- `AppWindowWidthClass.Expanded` 与当前列表-详情场景进入双 Pane 布局的宽度断点一致。
- 用户、世界及同类详情页面继续实现现有 `AppDetailRoute` 契约；独立任务页面继续使用 `FullWindow` 路由。
- 本次不改变 Pane 宽度、导航动画、共享元素 key 或详情页自身布局。

## 代码逻辑图

```mermaid
flowchart TD
    A[HomeScreen 组合] --> B[读取窗口宽度级别与栈顶路由]
    B --> C{栈顶是 HomeScreen?}
    C -- 是 --> D[显示身份栏与主导航]
    C -- 否 --> E{Expanded 且栈顶是 AppDetailRoute?}
    E -- 是 --> D
    E -- 否 --> F[隐藏首页导航外壳]
    D --> G[列表 Pane 与详情 Pane 并排显示]
```

## 验证

- `./gradlew :composeApp:desktopTest --tests "*AppListDetailSceneStrategyTest" --tests "*AppRoutePanePolicyTest" --tests "*SharedTransitionScreenAdaptiveTest" --tests "*HomeMeetupCardGestureTest" --tests "*MeetupCardTemplateLayoutTest.landscapeSpotlightKeepsContentInsideSafeDrawingArea*"`：通过。
- `./gradlew :composeApp:desktopTest`：两次均执行到 802 项，但分别被与本次修改无关且单独复跑可通过的跨测试协程泄漏/桌面图像偶发用例阻断；相关异常已拆分到独立任务处理。
- `git diff --check`：通过。