### PR TITLE
test: 修复收藏限制接口测试夹具

### DIFF
--- a/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/home/pager/FriendListPagerModelTest.kt
@@ -104,7 +104,8 @@ class FriendListPagerModelTest : MainDispatcherTest() {
                             jsonResponse("[]")
                         }
                         "/auth/user" -> respond("unavailable", HttpStatusCode.InternalServerError)
-                        "/auth/user/favoritelimits", "/favorites", "/favorite/groups" -> jsonResponse("[]")
+                        "/auth/user/favoritelimits" -> jsonResponse(favoriteLimitsJson())
+                        "/favorites", "/favorite/groups" -> jsonResponse("[]")
                         else -> error("Unexpected request: ${request.url}")
                     }
                 }


### PR DESCRIPTION
修复 `FriendListPagerModelTest.sameAccountReauthenticationRepublishesRetainedFriendSnapshot` 的 mock：`/auth/user/favoritelimits` 返回符合 `FavoriteLimits` 契约的 JSON 对象，收藏列表继续返回空数组，避免 `FavoriteService` 后台初始化因数组解析异常泄漏到后续测试。

## 实现假设清单

- `/auth/user/favoritelimits` 按 `FavoriteLimits` 对象契约返回，测试服务使用同一解析路径。
- `favoriteLimitsJson()` 已在该测试文件提供合法对象，不需要新增生产代码或改变默认限制逻辑。
- PR 目标分支为上游仓库的 `newui`。

## 代码逻辑图

```mermaid
flowchart TD
    A[测试创建 FavoriteService] --> B[Mock 请求 /auth/user/favoritelimits]
    B --> C{返回 FavoriteLimits 对象}
    C --> D[后台初始化成功]
    D --> E[测试清理服务作用域]
    E --> F[后续 Meetup 测试正常开始]
```