### PR TITLE
fix(world): 兼容签名资源 URL

### DIFF
--- a/composeApp/src/commonMain/kotlin/service/WorldPlatformService.kt
+++ b/composeApp/src/commonMain/kotlin/service/WorldPlatformService.kt
@@ -92,15 +92,19 @@ class WorldPlatformService(
 
     private fun parseFileReference(assetUrl: String): FileReference? {
         val segments = runCatching { Url(assetUrl).segments }.getOrNull() ?: return null
-        if (segments.size < FILE_REFERENCE_SEGMENT_COUNT) return null
-        val (resource, fileId, versionText, fileType) = segments.takeLast(FILE_REFERENCE_SEGMENT_COUNT)
-        val version = versionText.toIntOrNull()?.takeIf { it > 0 } ?: return null
-        if (resource != "file" || fileType != "file" || !fileIdRegex.matches(fileId)) return null
-        return FileReference(fileId, version)
+        return segments.windowed(FILE_REFERENCE_SEGMENT_COUNT).firstNotNullOfOrNull {
+            (resource, fileId, versionText) ->
+            val version = versionText.toIntOrNull()?.takeIf { it > 0 }
+            if (resource == "file" && fileIdRegex.matches(fileId) && version != null) {
+                FileReference(fileId, version)
+            } else {
+                null
+            }
+        }
     }
 
     private companion object {
-        private const val FILE_REFERENCE_SEGMENT_COUNT = 4
+        private const val FILE_REFERENCE_SEGMENT_COUNT = 3
         private val fileIdRegex = Regex("file_[\\w-]+")
         private val supportedPlatforms = listOf(
             PlatformType.Windows to "PC",

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldPlatformFileSizesTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldPlatformFileSizesTest.kt
@@ -77,7 +77,7 @@ class WorldPlatformFileSizesTest : MainDispatcherTest() {
     }
 
     @Test
-    fun worldLoadPublishesAndCachesReferencedPlatformPackageSizes() = runBlocking {
+    fun worldLoadPublishesAndCachesSizesFromSecurityVariantPackageUrl() = runBlocking {
         val worldRequests = atomic(0)
         val client = HttpClient(MockEngine) {
             engine {
@@ -401,7 +401,8 @@ private fun MockRequestHandleScope.jsonResponse(content: String) = respond(
 )
 
 private fun worldJson(
-    androidAssetUrl: String = "https://api.vrchat.cloud/api/1/file/file_android/3/file",
+    androidAssetUrl: String =
+        "https://api.vrchat.cloud/api/1/file/file_android/3/variant/security?v=1787741575",
 ) = """
     {
       "authorId":"usr_author","authorName":"Author","capacity":16,"created_at":null,


### PR DESCRIPTION
## 变更说明

- 兼容 VRChat 世界包资源的 `/variant/security` 签名 URL，不再要求资源路径必须以 `/file` 结尾。
- 保留文件 ID 与正整数版本校验，继续拒绝缺少版本或文件 ID 非法的地址。
- 使用真实签名 URL 形态补充回归覆盖，并保留旧格式、失败重试、认证重试和缓存行为测试。

## 实现假设清单

- `UnityPackage.assetUrl` 的稳定路径信息仍为连续的 `file/{fileId}/{version}`，其后缀可以是旧版 `file` 或新版 `variant/security`，查询参数不参与文件定位。
- 平台包体大小仍应通过 `/file/{fileId}` 元数据中与 URL 版本一致的记录读取；本次不依赖可能为空的 `assetVersion` 字段。

## 代码逻辑图

```mermaid
flowchart TD
    A[打开世界详情页] --> B[读取各平台最新 UnityPackage]
    B --> C[解析 assetUrl 路径片段]
    C --> D{找到 file / fileId / version}
    D -- 否 --> E[返回该平台查询失败]
    D -- 是 --> F[请求 File API 元数据]
    F --> G[匹配 URL 中的版本]
    G --> H[读取 sizeInBytes]
    H --> I[更新页面并在结果完整时缓存]
```

## 验证

- 修复前：签名 URL 回归测试因平台大小缺失而超时失败。
- 修复后：`WorldPlatformFileSizesTest` 全部通过。
- 完整执行 `./gradlew :composeApp:desktopTest`，通过。
- 执行 `git diff --check`，通过。