### PR TITLE
fix(friends): 修复房间邀请位置参数

### DIFF
--- a/composeApp/src/commonMain/kotlin/network/api/invite/InviteApi.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/invite/InviteApi.kt
@@ -24,6 +24,7 @@ class InviteApi(private val client: HttpClient) {
 
     suspend fun inviteUser(userId: String, instanceId: String, messageSlot: Int = 0): VRChatResponse {
         requireValidSlot(messageSlot)
+        requireValidInviteLocation(instanceId)
         return client.post("$INVITE_API_PREFIX/$userId") {
             contentType(ContentType.Application.Json)
             setBody(InviteUserRequest(instanceId = instanceId, messageSlot = messageSlot))
@@ -38,9 +39,7 @@ class InviteApi(private val client: HttpClient) {
         messageSlot: Int = 0,
     ) {
         require(userId.isNotBlank()) { "userId must not be blank" }
-        require(instanceId.isNotBlank() && instanceId != "offline") {
-            "instanceId must identify an active instance"
-        }
+        requireValidInviteLocation(instanceId)
         require(messageSlot in INVITE_MESSAGE_SLOT_RANGE) { "messageSlot must be between 0 and 11" }
         require(imageBytes.hasPngSignature()) { "Invite image must be a PNG file" }
         require(imageBytes.size <= MAX_INVITE_IMAGE_BYTES) {

--- a/composeApp/src/commonMain/kotlin/network/api/invite/InviteLocation.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/invite/InviteLocation.kt
@@ -1,0 +1,33 @@
+package io.github.vrcmteam.vrcm.network.api.invite
+
+import io.github.vrcmteam.vrcm.network.api.auth.data.Presence
+import io.github.vrcmteam.vrcm.network.api.auth.data.presenceLocation
+
+internal fun Presence.inviteLocationOrNull(): String? {
+    val location = if (instance == TRAVELING_LOCATION) {
+        presenceLocation(travelingToWorld, travelingToInstance)
+    } else {
+        presenceLocation(world, instance)
+    }
+    return location.takeIf(::isValidInviteLocation)
+}
+
+internal fun requireValidInviteLocation(location: String) {
+    require(isValidInviteLocation(location)) {
+        "instanceId must be a full active instance location"
+    }
+}
+
+private fun isValidInviteLocation(location: String): Boolean {
+    val separatorIndex = location.indexOf(':')
+    if (separatorIndex <= WORLD_ID_PREFIX.length || separatorIndex == location.lastIndex) {
+        return false
+    }
+    val worldId = location.substring(0, separatorIndex)
+    val instanceId = location.substring(separatorIndex + 1)
+    return worldId.startsWith(WORLD_ID_PREFIX) && instanceId !in NON_INSTANCE_LOCATIONS
+}
+
+private const val WORLD_ID_PREFIX = "wrld_"
+private const val TRAVELING_LOCATION = "traveling"
+private val NON_INSTANCE_LOCATIONS = setOf("offline", "private", TRAVELING_LOCATION)

--- a/composeApp/src/commonMain/kotlin/network/api/invite/InviteLocation.kt
+++ b/composeApp/src/commonMain/kotlin/network/api/invite/InviteLocation.kt
@@ -1,31 +1,27 @@
 package io.github.vrcmteam.vrcm.network.api.invite
 
 import io.github.vrcmteam.vrcm.network.api.auth.data.Presence
-import io.github.vrcmteam.vrcm.network.api.auth.data.presenceLocation
 
 internal fun Presence.inviteLocationOrNull(): String? {
-    val location = if (instance == TRAVELING_LOCATION) {
-        presenceLocation(travelingToWorld, travelingToInstance)
+    val instanceId = if (instance == TRAVELING_LOCATION) {
+        travelingToInstance
     } else {
-        presenceLocation(world, instance)
+        instance
     }
-    return location.takeIf(::isValidInviteLocation)
+    return instanceId.takeIf(::isValidInviteLocation)
 }
 
 internal fun requireValidInviteLocation(location: String) {
     require(isValidInviteLocation(location)) {
-        "instanceId must be a full active instance location"
+        "instanceId must be a pure active instance ID"
     }
 }
 
 private fun isValidInviteLocation(location: String): Boolean {
-    val separatorIndex = location.indexOf(':')
-    if (separatorIndex <= WORLD_ID_PREFIX.length || separatorIndex == location.lastIndex) {
-        return false
-    }
-    val worldId = location.substring(0, separatorIndex)
-    val instanceId = location.substring(separatorIndex + 1)
-    return worldId.startsWith(WORLD_ID_PREFIX) && instanceId !in NON_INSTANCE_LOCATIONS
+    return location.isNotBlank() &&
+        location !in NON_INSTANCE_LOCATIONS &&
+        !location.startsWith(WORLD_ID_PREFIX) &&
+        ':' !in location
 }
 
 private const val WORLD_ID_PREFIX = "wrld_"

--- a/composeApp/src/commonMain/kotlin/service/ImageInviteService.kt
+++ b/composeApp/src/commonMain/kotlin/service/ImageInviteService.kt
@@ -3,6 +3,7 @@ package io.github.vrcmteam.vrcm.service
 import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
 import io.github.vrcmteam.vrcm.network.api.files.FileApi
 import io.github.vrcmteam.vrcm.network.api.invite.InviteApi
+import io.github.vrcmteam.vrcm.network.api.invite.inviteLocationOrNull
 import io.github.vrcmteam.vrcm.presentation.screens.gallery.GallerySelection
 import io.github.vrcmteam.vrcm.service.meetup.MeetupRemoteBytesLoader
 
@@ -69,10 +70,8 @@ internal class ImageInviteService(
         sessionToken: AccountSessionToken,
     ): ImageInviteRemoteResult<Unit> {
         val response = authService.runSessionBoundCatching(sessionToken) {
-            val instanceLocation = authService.currentUser().presence.instance
-            if (instanceLocation.isBlank() || instanceLocation == "offline") {
-                throw ImageInviteNotInInstanceException()
-            }
+            val instanceLocation = authService.currentUser().presence.inviteLocationOrNull()
+                ?: throw ImageInviteNotInInstanceException()
             inviteApi.inviteUserWithPhoto(
                 userId = userId,
                 instanceId = instanceLocation,

--- a/composeApp/src/commonMain/kotlin/service/InviteMessageActionService.kt
+++ b/composeApp/src/commonMain/kotlin/service/InviteMessageActionService.kt
@@ -3,6 +3,7 @@ package io.github.vrcmteam.vrcm.service
 import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.invite.InviteApi
+import io.github.vrcmteam.vrcm.network.api.invite.inviteLocationOrNull
 import io.github.vrcmteam.vrcm.network.api.invite.data.InviteMessageData
 import io.github.vrcmteam.vrcm.network.api.invite.data.InviteMessageType
 import kotlinx.atomicfu.locks.SynchronizedObject
@@ -73,9 +74,9 @@ private class NetworkInviteMessageActionCall(
     ): SessionBoundResponse<Unit>? = authService.runSessionBoundCatching(sessionToken) {
         when (action) {
             InviteMessageAction.Invite -> {
-                val instance = authService.currentUser().presence.instance
-                if (instance.isBlank() || instance == "offline") throw NotInInstanceException
-                inviteApi.inviteUser(targetUserId, instance, slot)
+                val location = authService.currentUser().presence.inviteLocationOrNull()
+                    ?: throw NotInInstanceException
+                inviteApi.inviteUser(targetUserId, location, slot)
             }
 
             InviteMessageAction.RequestInvite -> inviteApi.requestInvite(targetUserId, slot)

--- a/composeApp/src/commonTest/kotlin/network/api/invite/InviteApiPhotoTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/api/invite/InviteApiPhotoTest.kt
@@ -64,9 +64,11 @@ class InviteApiPhotoTest {
 
     @Test
     fun photoInviteRejectsInvalidInputBeforeNetworkCall() = runBlocking {
+        var requestCount = 0
         val client = HttpClient(MockEngine) {
             engine {
                 addHandler {
+                    requestCount++
                     respond("{}", HttpStatusCode.OK)
                 }
             }
@@ -76,8 +78,12 @@ class InviteApiPhotoTest {
             api.inviteUserWithPhoto("usr_friend", "offline", PNG)
         }
         assertFailsWith<IllegalArgumentException> {
+            api.inviteUserWithPhoto("usr_friend", "12345~region(use)", PNG)
+        }
+        assertFailsWith<IllegalArgumentException> {
             api.inviteUserWithPhoto("usr_friend", "wrld_world:12345", byteArrayOf(1, 2, 3))
         }
+        assertEquals(0, requestCount)
         client.close()
     }
 

--- a/composeApp/src/commonTest/kotlin/network/api/invite/InviteApiPhotoTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/api/invite/InviteApiPhotoTest.kt
@@ -46,7 +46,7 @@ class InviteApiPhotoTest {
 
         InviteApi(client).inviteUserWithPhoto(
             userId = "usr_friend",
-            instanceId = "wrld_world:12345",
+            instanceId = "12345~region(use)",
             imageBytes = PNG,
             messageSlot = 4,
         )
@@ -54,7 +54,7 @@ class InviteApiPhotoTest {
         assertEquals("/api/1/invite/usr_friend/photo", path)
         assertContains(body, "name=data")
         assertContains(body, "application/json")
-        assertContains(body, "\"instanceId\":\"wrld_world:12345\"")
+        assertContains(body, "\"instanceId\":\"12345~region(use)\"")
         assertContains(body, "\"messageSlot\":4")
         assertContains(body, "name=image")
         assertContains(body, "image/png")
@@ -78,10 +78,10 @@ class InviteApiPhotoTest {
             api.inviteUserWithPhoto("usr_friend", "offline", PNG)
         }
         assertFailsWith<IllegalArgumentException> {
-            api.inviteUserWithPhoto("usr_friend", "12345~region(use)", PNG)
+            api.inviteUserWithPhoto("usr_friend", "private", PNG)
         }
         assertFailsWith<IllegalArgumentException> {
-            api.inviteUserWithPhoto("usr_friend", "wrld_world:12345", byteArrayOf(1, 2, 3))
+            api.inviteUserWithPhoto("usr_friend", "wrld_world:12345", PNG)
         }
         assertEquals(0, requestCount)
         client.close()

--- a/composeApp/src/commonTest/kotlin/network/api/invite/InviteLocationTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/api/invite/InviteLocationTest.kt
@@ -1,0 +1,64 @@
+package io.github.vrcmteam.vrcm.network.api.invite
+
+import io.github.vrcmteam.vrcm.network.api.auth.data.Presence
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class InviteLocationTest {
+    @Test
+    fun activePresenceBuildsAFullLocationWithoutDroppingInstanceTags() {
+        val presence = presence(
+            world = "wrld_origin",
+            instance = "12345~hidden(usr_owner)~region(use)~nonce(value)",
+        )
+
+        assertEquals(
+            "wrld_origin:12345~hidden(usr_owner)~region(use)~nonce(value)",
+            presence.inviteLocationOrNull(),
+        )
+    }
+
+    @Test
+    fun travelingPresenceUsesItsDestinationLocation() {
+        val presence = presence(
+            instance = "traveling",
+            travelingToWorld = "wrld_destination",
+            travelingToInstance = "67890~region(jp)",
+        )
+
+        assertEquals(
+            "wrld_destination:67890~region(jp)",
+            presence.inviteLocationOrNull(),
+        )
+    }
+
+    @Test
+    fun presenceWithoutACompleteActiveLocationCannotBeInvitedTo() {
+        assertNull(presence(instance = "offline").inviteLocationOrNull())
+        assertNull(presence(instance = "private").inviteLocationOrNull())
+        assertNull(presence(instance = "12345~region(use)").inviteLocationOrNull())
+        assertNull(presence(instance = "traveling").inviteLocationOrNull())
+    }
+
+    private fun presence(
+        world: String = "",
+        instance: String,
+        travelingToWorld: String = "",
+        travelingToInstance: String = "",
+    ) = Presence(
+        avatarThumbnail = null,
+        displayName = null,
+        groups = emptyList(),
+        id = "usr_current",
+        instance = instance,
+        instanceType = "",
+        isRejoining = null,
+        platform = "standalonewindows",
+        profilePicOverride = null,
+        status = "active",
+        travelingToInstance = travelingToInstance,
+        travelingToWorld = travelingToWorld,
+        world = world,
+    )
+}

--- a/composeApp/src/commonTest/kotlin/network/api/invite/InviteLocationTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/api/invite/InviteLocationTest.kt
@@ -7,20 +7,20 @@ import kotlin.test.assertNull
 
 class InviteLocationTest {
     @Test
-    fun activePresenceBuildsAFullLocationWithoutDroppingInstanceTags() {
+    fun activePresenceUsesThePureInstanceWithoutDroppingInstanceTags() {
         val presence = presence(
             world = "wrld_origin",
             instance = "12345~hidden(usr_owner)~region(use)~nonce(value)",
         )
 
         assertEquals(
-            "wrld_origin:12345~hidden(usr_owner)~region(use)~nonce(value)",
+            "12345~hidden(usr_owner)~region(use)~nonce(value)",
             presence.inviteLocationOrNull(),
         )
     }
 
     @Test
-    fun travelingPresenceUsesItsDestinationLocation() {
+    fun travelingPresenceUsesItsDestinationInstanceWithoutDroppingTags() {
         val presence = presence(
             instance = "traveling",
             travelingToWorld = "wrld_destination",
@@ -28,16 +28,20 @@ class InviteLocationTest {
         )
 
         assertEquals(
-            "wrld_destination:67890~region(jp)",
+            "67890~region(jp)",
             presence.inviteLocationOrNull(),
         )
     }
 
     @Test
-    fun presenceWithoutACompleteActiveLocationCannotBeInvitedTo() {
+    fun presenceWithoutAnActiveInstanceCannotBeInvitedTo() {
         assertNull(presence(instance = "offline").inviteLocationOrNull())
         assertNull(presence(instance = "private").inviteLocationOrNull())
-        assertNull(presence(instance = "12345~region(use)").inviteLocationOrNull())
+        assertEquals(
+            "12345~region(use)",
+            presence(instance = "12345~region(use)").inviteLocationOrNull(),
+        )
+        assertNull(presence(instance = "wrld_world:12345~region(use)").inviteLocationOrNull())
         assertNull(presence(instance = "traveling").inviteLocationOrNull())
     }
 

--- a/composeApp/src/commonTest/kotlin/network/api/invite/InviteMessageSelectionApiTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/api/invite/InviteMessageSelectionApiTest.kt
@@ -29,12 +29,12 @@ class InviteMessageSelectionApiTest {
         }
         val api = InviteApi(client)
 
-        api.inviteUser("usr_friend", "wrld_test:instance", messageSlot = 7)
+        api.inviteUser("usr_friend", "12345~region(use)", messageSlot = 7)
         api.requestInvite("usr_friend", requestSlot = 4)
 
         assertEquals(HttpMethod.Post, requests[0].method)
         assertEquals("/api/1/invite/usr_friend", requests[0].url.encodedPath)
-        assertEquals("{\"instanceId\":\"wrld_test:instance\",\"messageSlot\":7}", requests[0].bodyText())
+        assertEquals("{\"instanceId\":\"12345~region(use)\",\"messageSlot\":7}", requests[0].bodyText())
         assertEquals(HttpMethod.Post, requests[1].method)
         assertEquals("/api/1/requestInvite/usr_friend", requests[1].url.encodedPath)
         assertEquals("{\"requestSlot\":4}", requests[1].bodyText())
@@ -81,7 +81,10 @@ class InviteMessageSelectionApiTest {
             api.inviteUser("usr_friend", "wrld_test:instance", messageSlot = 12)
         }
         assertFailsWith<IllegalArgumentException> {
-            api.inviteUser("usr_friend", "instance~region(use)")
+            api.inviteUser("usr_friend", "offline")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            api.inviteUser("usr_friend", "wrld_test:12345~region(use)")
         }
         assertFailsWith<IllegalArgumentException> {
             api.requestInvite("usr_friend", requestSlot = -1)

--- a/composeApp/src/commonTest/kotlin/network/api/invite/InviteMessageSelectionApiTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/api/invite/InviteMessageSelectionApiTest.kt
@@ -81,6 +81,9 @@ class InviteMessageSelectionApiTest {
             api.inviteUser("usr_friend", "wrld_test:instance", messageSlot = 12)
         }
         assertFailsWith<IllegalArgumentException> {
+            api.inviteUser("usr_friend", "instance~region(use)")
+        }
+        assertFailsWith<IllegalArgumentException> {
             api.requestInvite("usr_friend", requestSlot = -1)
         }
         assertEquals(0, requestCount)


### PR DESCRIPTION
## 修复内容

统一普通邀请和图片邀请的房间位置来源，发送前从 Presence 读取 VRChat InviteRequest 所需的纯实例段（例如 `12345~region(...)`），并在 traveling 状态使用 travelingToInstance。InviteApi 的 JSON 与 multipart 入口共享纯实例段校验，拒绝空值、offline、private、traveling 以及误传的完整 `wrld_...:instance`，避免再次收到 Invalid location。

## 实现假设清单

- VRChat 邀请接口的 InviteRequest.instanceId 要求纯实例段，而不是包含世界 ID 的完整 location。
- Presence 的 instance 与 travelingToInstance 已包含完整实例标签（如 region、nonce、hidden），发送前必须原样保留。
- 当 Presence 处于 traveling 时，应邀请到 travelingToInstance 表示的目的地实例。
- 无法形成有效纯实例段的状态视为未在可邀请房间，且不发起网络请求。

## 代码逻辑图

~~~mermaid
flowchart TD
    A[发送普通或图片邀请] --> B[读取当前用户 Presence]
    B --> C{instance 是否为 traveling}
    C -- 是 --> D[读取 travelingToInstance]
    C -- 否 --> E[读取 instance]
    D --> F{是否为有效纯实例段}
    E --> F
    F -- 否 --> G[返回未在实例错误]
    G --> H[不发起网络请求]
    F -- 是 --> I[InviteApi 共享校验]
    I --> J{邀请类型}
    J -- 普通 --> K[发送 JSON 邀请请求]
    J -- 图片 --> L[发送 multipart 图片邀请请求]
~~~

## 验证

- `:composeApp:desktopTest --tests 'io.github.vrcmteam.vrcm.network.api.invite.*'` 通过。
