### PR TITLE
fix(world): 防止设置 Home World 时错误重置

### DIFF
--- a/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/user/UserProfileScreenModel.kt
@@ -546,30 +546,32 @@ class UserProfileScreenModel(
             loadCoordinator.runLoads(
                 forceRefresh = forceRefresh,
                 loadUser = {
-                    var userLoaded = false
-                    authService.reTryAuthCatching {
+                    val responseResult = authService.reTryAuthCatching {
                         usersApi.fetchUserResponse(userId)
-                    }.onFailure {
-                        handleError(it)
-                    }.onSuccess { response ->
-                        // 防止body序列化异常
-                        runCatching { response.body<UserData>() }
-                            .onSuccess {
-                                if (it.id == cacheOwnerUserId) {
-                                    authService.applyOwnProfileRefresh(it)
-                                }
-                                val profile = UserProfileVo(it).withSelfIdentity()
-                                if (_userState.value != profile) {
-                                    _userState.value = profile
-                                    computeFriendLocation(profile.location)
-                                }
-                                saveCache(it)
-                                userLoaded = true
-                            }
-                            .onFailure { handleError(it) }
-                        _userJson.value = response.bodyAsText().pretty()
                     }
-                    userLoaded
+                    responseResult.exceptionOrNull()?.let { error -> handleError(error) }
+                    val response = responseResult.getOrNull()
+                    if (response != null) {
+                        // 防止body序列化异常
+                        val userResult = runCatching { response.body<UserData>() }
+                        userResult.exceptionOrNull()?.let { error -> handleError(error) }
+                        val user = userResult.getOrNull()
+                        if (user != null) {
+                            if (user.id == cacheOwnerUserId) {
+                                authService.applyOwnProfileRefresh(user)
+                            }
+                            val profile = UserProfileVo(user).withSelfIdentity()
+                            if (_userState.value != profile) {
+                                _userState.value = profile
+                                computeFriendLocation(profile.location)
+                            }
+                            saveCache(user)
+                        }
+                        _userJson.value = response.bodyAsText().pretty()
+                        user != null
+                    } else {
+                        false
+                    }
                 },
                 loadGroups = { loadUserGroups(userId) },
             )

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileScreen.kt
@@ -122,7 +122,10 @@ class WorldProfileScreen(
         val localeStrings = strings
         val homeWorldActionState by screenModel.homeWorldActionState.collectAsState()
         val locale = localeStrings
-        var showHomeWorldConfirmation by remember { mutableStateOf(false) }
+        val displayedWorld = profileVoState ?: worldProfileVO
+        var pendingHomeWorldAction by remember(displayedWorld.worldId) {
+            mutableStateOf<HomeWorldAction?>(null)
+        }
         val metadataEditState by screenModel.metadataEditState.collectAsState()
         var showMetadataEditor by remember { mutableStateOf(false) }
         val imageEditState by screenModel.imageEditState.collectAsState()
@@ -181,7 +184,7 @@ class WorldProfileScreen(
 
         LaunchedEffect(homeWorldActionState.availability) {
             if (homeWorldActionState.availability == HomeWorldActionAvailability.Unavailable) {
-                showHomeWorldConfirmation = false
+                pendingHomeWorldAction = null
             }
         }
 
@@ -192,7 +195,6 @@ class WorldProfileScreen(
             if (!metadataEditState.canEdit) showMetadataEditor = false
         }
 
-        val displayedWorld = profileVoState ?: worldProfileVO
         LaunchedEffect(displayedWorld.worldId, worldCoverUpdates) {
             val update = worldCoverUpdates[displayedWorld.worldId]
                 ?: return@LaunchedEffect
@@ -221,7 +223,7 @@ class WorldProfileScreen(
                 isDeleted = deletionState.isDeleted,
                 onDelete = { screenModel.deleteWorld() },
                 homeWorldActionState = homeWorldActionState,
-                onHomeWorldClick = { showHomeWorldConfirmation = true },
+                onHomeWorldClick = { action -> pendingHomeWorldAction = action },
                 canEditImage = imageEditState.canEdit,
                 onEditImage = {
                     showMetadataEditor = false
@@ -237,11 +239,15 @@ class WorldProfileScreen(
             )
         }
 
-        if (showHomeWorldConfirmation) {
-            val resetHomeWorld = homeWorldActionState.availability == HomeWorldActionAvailability.Current
+        pendingHomeWorldAction?.let { action ->
+            val resetHomeWorld = action == HomeWorldAction.Reset
+            val actionStillAllowed = homeWorldActionState.availability !=
+                HomeWorldActionAvailability.Unavailable &&
+                (action != HomeWorldAction.Reset ||
+                    homeWorldActionState.availability == HomeWorldActionAvailability.Current)
             AlertDialog(
                 onDismissRequest = {
-                    if (!homeWorldActionState.isUpdating) showHomeWorldConfirmation = false
+                    if (!homeWorldActionState.isUpdating) pendingHomeWorldAction = null
                 },
                 title = {
                     Text(
@@ -258,10 +264,10 @@ class WorldProfileScreen(
                 confirmButton = {
                     TextButton(
                         enabled = !homeWorldActionState.isUpdating &&
-                            homeWorldActionState.availability != HomeWorldActionAvailability.Unavailable,
+                            actionStillAllowed,
                         onClick = {
-                            showHomeWorldConfirmation = false
-                            screenModel.updateHomeWorld()
+                            pendingHomeWorldAction = null
+                            screenModel.updateHomeWorld(action)
                         },
                     ) {
                         Text(strings.confirm)
@@ -270,7 +276,7 @@ class WorldProfileScreen(
                 dismissButton = {
                     TextButton(
                         enabled = !homeWorldActionState.isUpdating,
-                        onClick = { showHomeWorldConfirmation = false },
+                        onClick = { pendingHomeWorldAction = null },
                     ) {
                         Text(strings.cancel)
                     }
@@ -331,7 +337,7 @@ class WorldProfileScreen(
         isDeleted: Boolean = false,
         onDelete: () -> Unit = {},
         homeWorldActionState: HomeWorldActionState = HomeWorldActionState(),
-        onHomeWorldClick: () -> Unit = {},
+        onHomeWorldClick: (HomeWorldAction) -> Unit = {},
         canEditImage: Boolean = false,
         onEditImage: () -> Unit = {},
         canEditMetadata: Boolean = false,
@@ -1232,7 +1238,7 @@ private fun WorldProfileTopBar(
     isDeleted: Boolean,
     onDelete: () -> Unit,
     homeWorldActionState: HomeWorldActionState,
-    onHomeWorldClick: () -> Unit,
+    onHomeWorldClick: (HomeWorldAction) -> Unit,
     canEditImage: Boolean,
     onEditImage: () -> Unit,
     canEditMetadata: Boolean,
@@ -1304,7 +1310,7 @@ private fun ColumnScope.WorldProfileActionSheet(
     isDeleted: Boolean,
     onDelete: () -> Unit,
     homeWorldActionState: HomeWorldActionState,
-    onHomeWorldClick: () -> Unit,
+    onHomeWorldClick: (HomeWorldAction) -> Unit,
     canEditImage: Boolean,
     onEditImage: () -> Unit,
     canEditMetadata: Boolean,
@@ -1360,10 +1366,13 @@ private fun ColumnScope.WorldProfileActionSheet(
     }
     WorldProfileSheetButton(
         text = homeWorldDescription,
-        enabled = homeWorldActionState.availability != HomeWorldActionAvailability.Unavailable &&
-            !homeWorldActionState.isUpdating,
+        enabled = homeWorldActionState.action != null && !homeWorldActionState.isUpdating,
         loading = homeWorldActionState.isUpdating,
-        onClick = { dismissAndRun(onHomeWorldClick) },
+        onClick = {
+            homeWorldActionState.action?.let { action ->
+                dismissAndRun { onHomeWorldClick(action) }
+            }
+        },
     )
     WorldProfileSheetButton(
         text = strings.worldPersistenceTitle,

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
@@ -32,6 +32,7 @@ import io.github.vrcmteam.vrcm.presentation.settings.locale.LocaleStrings
 import io.github.vrcmteam.vrcm.service.AuthService
 import io.github.vrcmteam.vrcm.service.HomeWorldManager
 import io.github.vrcmteam.vrcm.service.HomeWorldSessionChangedException
+import io.github.vrcmteam.vrcm.service.HomeWorldStateChangedException
 import io.github.vrcmteam.vrcm.service.HomeWorldUserContext
 import io.github.vrcmteam.vrcm.service.InstanceCreationResult
 import io.github.vrcmteam.vrcm.service.InstanceCreationService
@@ -354,11 +355,24 @@ class WorldProfileScreenModel internal constructor(
         }
         if (!isUpdatingHomeWorld.compareAndSet(expect = false, update = true)) return
 
+        val resetSessionToken = if (action == HomeWorldAction.Reset) {
+            currentHomeWorldUser.value
+                ?.takeIf { it.homeLocation == worldId }
+                ?.sessionToken
+        } else {
+            null
+        }
+
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 val result = when (action) {
                     HomeWorldAction.Set -> homeWorldManager.setHomeWorld(worldId)
-                    HomeWorldAction.Reset -> homeWorldManager.resetHomeWorld()
+                    HomeWorldAction.Reset -> resetSessionToken?.let { sessionToken ->
+                        homeWorldManager.resetHomeWorld(
+                            expectedWorldId = worldId,
+                            expectedSessionToken = sessionToken,
+                        )
+                    } ?: Result.failure(HomeWorldStateChangedException())
                 }
                 result
                     .onSuccess {

--- a/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/world/WorldProfileViewModel.kt
@@ -57,10 +57,22 @@ internal enum class HomeWorldActionAvailability {
     Current,
 }
 
+internal enum class HomeWorldAction {
+    Set,
+    Reset,
+}
+
 internal data class HomeWorldActionState(
     val availability: HomeWorldActionAvailability = HomeWorldActionAvailability.Unavailable,
     val isUpdating: Boolean = false,
-)
+) {
+    val action: HomeWorldAction?
+        get() = when (availability) {
+            HomeWorldActionAvailability.Unavailable -> null
+            HomeWorldActionAvailability.CanSet -> HomeWorldAction.Set
+            HomeWorldActionAvailability.Current -> HomeWorldAction.Reset
+        }
+}
 
 internal sealed interface HomeWorldNotice {
     data object Set : HomeWorldNotice
@@ -332,22 +344,31 @@ class WorldProfileScreenModel internal constructor(
     internal fun dismissWorldPersistenceDeletion() = worldPersistence.dismissDeletionConfirmation()
 
     internal fun confirmWorldPersistenceDeletion() = worldPersistence.confirmDeletion()
-    internal fun updateHomeWorld() {
+    internal fun updateHomeWorld(action: HomeWorldAction) {
         val worldId = worldProfileState.value?.worldId ?: return
-        val reset = when (homeWorldActionState.value.availability) {
-            HomeWorldActionAvailability.CanSet -> false
-            HomeWorldActionAvailability.Current -> true
-            HomeWorldActionAvailability.Unavailable -> return
+        val availability = homeWorldActionState.value.availability
+        if (availability == HomeWorldActionAvailability.Unavailable ||
+            action == HomeWorldAction.Reset && availability != HomeWorldActionAvailability.Current
+        ) {
+            return
         }
         if (!isUpdatingHomeWorld.compareAndSet(expect = false, update = true)) return
 
         viewModelScope.launch(Dispatchers.IO) {
             try {
-                homeWorldManager.updateHomeWorld(worldId.takeUnless { reset })
+                val result = when (action) {
+                    HomeWorldAction.Set -> homeWorldManager.setHomeWorld(worldId)
+                    HomeWorldAction.Reset -> homeWorldManager.resetHomeWorld()
+                }
+                result
                     .onSuccess {
                         if (_worldProfileState.value?.worldId == worldId) {
                             _homeWorldNotices.emit(
-                                if (reset) HomeWorldNotice.Reset else HomeWorldNotice.Set
+                                if (action == HomeWorldAction.Reset) {
+                                    HomeWorldNotice.Reset
+                                } else {
+                                    HomeWorldNotice.Set
+                                }
                             )
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/service/AuthService.kt
+++ b/composeApp/src/commonMain/kotlin/service/AuthService.kt
@@ -53,6 +53,7 @@ class AuthService(
     private val serviceJob = Job()
     private val scope = CoroutineScope(serviceJob)
     private val authMutex = Mutex()
+    private val homeWorldMutationGate = Mutex()
     private val currentUserLock = SynchronizedObject()
 
     private var currentUser: CurrentUserData? = null
@@ -67,8 +68,10 @@ class AuthService(
         scope.launch {
             SharedFlowCentre.authed.collect { session ->
                 val accountDto = session.account
-                synchronized(currentUserLock) {
-                    if (currentUser?.id != accountDto.userId) clearCurrentUserLocked()
+                homeWorldMutationGate.withLock {
+                    synchronized(currentUserLock) {
+                        if (currentUser?.id != accountDto.userId) clearCurrentUserLocked()
+                    }
                 }
                 currentAccountDto = accountDto
                 accountDao.saveAccountInfo(accountDto)
@@ -122,25 +125,27 @@ class AuthService(
     }
 
     suspend fun currentUser(isRefresh: Boolean = false): CurrentUserData {
-        val cached = synchronized(currentUserLock) { currentUser }
-        if (cached != null && !isRefresh) return cached
-        val refreshed = authApi.currentUser()
-        return synchronized(currentUserLock) {
-            publishCurrentUserLocked(
-                refreshed.copy(
-                    presence = selectCurrentPresence(refreshed.presence, socketPresence),
+        return homeWorldMutationGate.withLock {
+            val cached = synchronized(currentUserLock) { currentUser }
+            if (cached != null && !isRefresh) return@withLock cached
+            val refreshed = authApi.currentUser()
+            synchronized(currentUserLock) {
+                publishCurrentUserLocked(
+                    refreshed.copy(
+                        presence = selectCurrentPresence(refreshed.presence, socketPresence),
+                    )
                 )
-            )
+            }
         }
     }
 
     internal suspend fun refreshCurrentUserPresence(
         sessionToken: AccountSessionToken,
-    ): CurrentUserData? {
-        if (!SharedFlowCentre.isCurrentSession(sessionToken)) return null
+    ): CurrentUserData? = homeWorldMutationGate.withLock {
+        if (!SharedFlowCentre.isCurrentSession(sessionToken)) return@withLock null
         val requestSocketRevision = synchronized(currentUserLock) { socketPresenceRevision }
         val refreshed = authApi.currentUser()
-        return synchronized(currentUserLock) {
+        synchronized(currentUserLock) {
             if (!SharedFlowCentre.isCurrentSession(sessionToken) ||
                 refreshed.id != sessionToken.userId
             ) {
@@ -164,7 +169,15 @@ class AuthService(
         }
     }
 
-    internal fun applyCurrentUserHomeLocation(
+    internal suspend fun applyCurrentUserHomeLocation(
+        sessionToken: AccountSessionToken,
+        userId: String,
+        homeLocation: String,
+    ): Boolean = homeWorldMutationGate.withLock {
+        applyCurrentUserHomeLocationLocked(sessionToken, userId, homeLocation)
+    }
+
+    internal fun applyCurrentUserHomeLocationLocked(
         sessionToken: AccountSessionToken,
         userId: String,
         homeLocation: String,
@@ -175,7 +188,11 @@ class AuthService(
         true
     }
 
-    /** Reads the current user's Home World while holding the same lock as user updates. */
+    /** Runs a Home World check and the associated request as one serializable mutation. */
+    internal suspend fun <T> withHomeWorldMutation(action: suspend () -> T): T =
+        homeWorldMutationGate.withLock { action() }
+
+    /** Reads the current user's Home World while holding the user-state lock. */
     internal fun isCurrentUserHomeWorld(
         sessionToken: AccountSessionToken,
         expectedWorldId: String,
@@ -183,6 +200,64 @@ class AuthService(
         if (!SharedFlowCentre.isCurrentSession(sessionToken)) return@synchronized false
         currentUser?.let { it.id == sessionToken.userId && it.homeLocation == expectedWorldId }
             ?: false
+    }
+
+    fun applySocketUserLocation(location: String, travelingToLocation: String) {
+        synchronized(currentUserLock) {
+            val existing = currentUser ?: return@synchronized
+            val (world, instance) = socketLocationToPresenceParts(location)
+            val (travelingToWorld, travelingToInstance) =
+                socketLocationToPresenceParts(travelingToLocation)
+            val updatedPresence = existing.presence.copy(
+                world = world,
+                instance = instance,
+                travelingToWorld = travelingToWorld,
+                travelingToInstance = travelingToInstance,
+            )
+            socketPresence = updatedPresence
+            socketPresenceRevision++
+            publishCurrentUserLocked(existing.copy(presence = updatedPresence))
+        }
+    }
+
+    suspend fun applyOwnProfileRefresh(user: UserData) {
+        homeWorldMutationGate.withLock {
+            synchronized(currentUserLock) {
+                val existing = currentUser ?: return@synchronized
+                if (existing.id != user.id) return@synchronized
+                val (world, instance) = socketLocationToPresenceParts(user.location)
+                val (travelingToWorld, travelingToInstance) =
+                    socketLocationToPresenceParts(user.travelingToLocation.orEmpty())
+                val updatedPresence = existing.presence.copy(
+                    world = world,
+                    instance = instance,
+                    travelingToWorld = travelingToWorld,
+                    travelingToInstance = travelingToInstance,
+                    platform = user.lastPlatform.ifBlank { existing.presence.platform },
+                )
+                socketPresence = updatedPresence
+                socketPresenceRevision++
+                publishCurrentUserLocked(
+                    existing.copy(
+                        currentAvatarImageUrl = user.currentAvatarImageUrl,
+                        currentAvatarTags = user.currentAvatarTags,
+                        currentAvatarThumbnailImageUrl = user.currentAvatarThumbnailImageUrl,
+                        displayName = user.displayName,
+                        lastActivity = user.lastActivity,
+                        lastLogin = user.lastLogin,
+                        lastPlatform = user.lastPlatform,
+                        profilePicOverride = user.profilePicOverride,
+                        state = user.state.value,
+                        status = user.status,
+                        statusDescription = user.statusDescription,
+                        tags = user.tags,
+                        userIcon = user.userIcon,
+                        pronouns = user.pronouns,
+                        presence = updatedPresence,
+                    )
+                )
+            }
+        }
     }
 
     fun applySocketUserUpdate(user: UserContent) {
@@ -209,62 +284,6 @@ class AuthService(
             )
         }
     }
-
-    fun applySocketUserLocation(location: String, travelingToLocation: String) {
-        synchronized(currentUserLock) {
-            val existing = currentUser ?: return@synchronized
-            val (world, instance) = socketLocationToPresenceParts(location)
-            val (travelingToWorld, travelingToInstance) = socketLocationToPresenceParts(travelingToLocation)
-            val updatedPresence = existing.presence.copy(
-                world = world,
-                instance = instance,
-                travelingToWorld = travelingToWorld,
-                travelingToInstance = travelingToInstance,
-            )
-            socketPresence = updatedPresence
-            socketPresenceRevision++
-            publishCurrentUserLocked(existing.copy(presence = updatedPresence))
-        }
-    }
-
-    fun applyOwnProfileRefresh(user: UserData) {
-        synchronized(currentUserLock) {
-            val existing = currentUser ?: return@synchronized
-            if (existing.id != user.id) return@synchronized
-            val (world, instance) = socketLocationToPresenceParts(user.location)
-            val (travelingToWorld, travelingToInstance) =
-                socketLocationToPresenceParts(user.travelingToLocation.orEmpty())
-            val updatedPresence = existing.presence.copy(
-                world = world,
-                instance = instance,
-                travelingToWorld = travelingToWorld,
-                travelingToInstance = travelingToInstance,
-                platform = user.lastPlatform.ifBlank { existing.presence.platform },
-            )
-            socketPresence = updatedPresence
-            socketPresenceRevision++
-            publishCurrentUserLocked(
-                existing.copy(
-                    currentAvatarImageUrl = user.currentAvatarImageUrl,
-                    currentAvatarTags = user.currentAvatarTags,
-                    currentAvatarThumbnailImageUrl = user.currentAvatarThumbnailImageUrl,
-                    displayName = user.displayName,
-                    lastActivity = user.lastActivity,
-                    lastLogin = user.lastLogin,
-                    lastPlatform = user.lastPlatform,
-                    profilePicOverride = user.profilePicOverride,
-                    state = user.state.value,
-                    status = user.status,
-                    statusDescription = user.statusDescription,
-                    tags = user.tags,
-                    userIcon = user.userIcon,
-                    pronouns = user.pronouns,
-                    presence = updatedPresence,
-                )
-            )
-        }
-    }
-
 
     suspend fun verify(
         password: String,
@@ -295,12 +314,14 @@ class AuthService(
                 authCookie = cookiesStorage.cookieValue(AUTH_COOKIE),
                 twoFactorAuthCookie = cookiesStorage.cookieValue(TWO_FACTOR_AUTH_COOKIE),
             )
-            synchronized(currentUserLock) {
-                publishCurrentUserLocked(
-                    userData.copy(
-                        presence = selectCurrentPresence(userData.presence, socketPresence),
+            homeWorldMutationGate.withLock {
+                synchronized(currentUserLock) {
+                    publishCurrentUserLocked(
+                        userData.copy(
+                            presence = selectCurrentPresence(userData.presence, socketPresence),
+                        )
                     )
-                )
+                }
             }
             currentAccountDto = accountDto
             accountDao.saveAccountInfo(accountDto)
@@ -338,7 +359,9 @@ class AuthService(
 
     private suspend fun invalidateCurrentSessionLocked() {
         if (SharedFlowCentre.currentSession.value == null) return
-        synchronized(currentUserLock) { clearCurrentUserLocked() }
+        homeWorldMutationGate.withLock {
+            synchronized(currentUserLock) { clearCurrentUserLocked() }
+        }
         currentAccountDto = accountDao.currentAccountDtoOrNull()
         SharedFlowCentre.emitLogout()
     }
@@ -474,7 +497,9 @@ class AuthService(
             ?: synchronized(currentUserLock) { currentUser?.id }
             ?: accountDto().userId
         clearAuthCookie(userId)
-        synchronized(currentUserLock) { clearCurrentUserLocked() }
+        homeWorldMutationGate.withLock {
+            synchronized(currentUserLock) { clearCurrentUserLocked() }
+        }
         currentAccountDto = accountDao.currentAccountDtoOrNull()
         SharedFlowCentre.emitLogout()
     }

--- a/composeApp/src/commonMain/kotlin/service/AuthService.kt
+++ b/composeApp/src/commonMain/kotlin/service/AuthService.kt
@@ -39,6 +39,18 @@ internal data class SessionBoundResponse<T>(
     val sessionToken: AccountSessionToken,
 )
 
+internal sealed interface HomeWorldMutationState {
+    data class Ready(val revision: Long) : HomeWorldMutationState
+    data object SessionChanged : HomeWorldMutationState
+    data object HomeWorldChanged : HomeWorldMutationState
+}
+
+internal enum class HomeWorldMutationCommitResult {
+    Applied,
+    SessionChanged,
+    StateChanged,
+}
+
 /**
  * 负责辅助登录验证的类
  * 主要作用是统一验证失效时的重试逻辑
@@ -57,6 +69,7 @@ class AuthService(
     private val currentUserLock = SynchronizedObject()
 
     private var currentUser: CurrentUserData? = null
+    private var homeWorldRevision = 0L
     private var socketPresence: Presence? = null
     private var socketPresenceRevision = 0L
     private val _currentUserState = MutableStateFlow<CurrentUserData?>(null)
@@ -188,19 +201,42 @@ class AuthService(
         true
     }
 
+    internal fun homeWorldMutationState(
+        sessionToken: AccountSessionToken,
+        expectedWorldId: String?,
+    ): HomeWorldMutationState = synchronized(currentUserLock) {
+        if (!SharedFlowCentre.isCurrentSession(sessionToken)) {
+            return@synchronized HomeWorldMutationState.SessionChanged
+        }
+        val existing = currentUser?.takeIf { it.id == sessionToken.userId }
+            ?: return@synchronized HomeWorldMutationState.SessionChanged
+        if (expectedWorldId != null && existing.homeLocation != expectedWorldId) {
+            return@synchronized HomeWorldMutationState.HomeWorldChanged
+        }
+        HomeWorldMutationState.Ready(homeWorldRevision)
+    }
+
+    internal fun commitHomeWorldMutationLocked(
+        sessionToken: AccountSessionToken,
+        userId: String,
+        expectedRevision: Long,
+        homeLocation: String,
+    ): HomeWorldMutationCommitResult = synchronized(currentUserLock) {
+        if (!SharedFlowCentre.isCurrentSession(sessionToken)) {
+            return@synchronized HomeWorldMutationCommitResult.SessionChanged
+        }
+        val existing = currentUser?.takeIf { it.id == userId }
+            ?: return@synchronized HomeWorldMutationCommitResult.SessionChanged
+        if (homeWorldRevision != expectedRevision) {
+            return@synchronized HomeWorldMutationCommitResult.StateChanged
+        }
+        publishCurrentUserLocked(existing.copy(homeLocation = homeLocation))
+        HomeWorldMutationCommitResult.Applied
+    }
+
     /** Runs a Home World check and the associated request as one serializable mutation. */
     internal suspend fun <T> withHomeWorldMutation(action: suspend () -> T): T =
         homeWorldMutationGate.withLock { action() }
-
-    /** Reads the current user's Home World while holding the user-state lock. */
-    internal fun isCurrentUserHomeWorld(
-        sessionToken: AccountSessionToken,
-        expectedWorldId: String,
-    ): Boolean = synchronized(currentUserLock) {
-        if (!SharedFlowCentre.isCurrentSession(sessionToken)) return@synchronized false
-        currentUser?.let { it.id == sessionToken.userId && it.homeLocation == expectedWorldId }
-            ?: false
-    }
 
     fun applySocketUserLocation(location: String, travelingToLocation: String) {
         synchronized(currentUserLock) {
@@ -441,10 +477,18 @@ class AuthService(
     internal suspend fun <T> runSessionBoundCatching(
         sessionToken: AccountSessionToken,
         callback: suspend () -> T,
+    ): SessionBoundResponse<T>? = runSessionBoundCatchingWithToken(
+        sessionToken = sessionToken,
+        callback = { _: AccountSessionToken -> callback() },
+    )
+
+    internal suspend fun <T> runSessionBoundCatchingWithToken(
+        sessionToken: AccountSessionToken,
+        callback: suspend (AccountSessionToken) -> T,
     ): SessionBoundResponse<T>? = authMutex.withLock {
         if (!SharedFlowCentre.isCurrentSession(sessionToken)) return@withLock null
 
-        val first = runRequestCatching(callback)
+        val first = runRequestCatching { callback(sessionToken) }
         val firstError = first.exceptionOrNull()
         if (firstError !is VRCApiException ||
             firstError.code != HttpStatusCode.Unauthorized.value
@@ -468,7 +512,7 @@ class AuthService(
         ) {
             return@withLock null
         }
-        val retried = runRequestCatching(callback)
+        val retried = runRequestCatching { callback(refreshedSession.token) }
         if (!SharedFlowCentre.isCurrentSession(refreshedSession.token)) return@withLock null
         SessionBoundResponse(retried, refreshedSession.token)
     }
@@ -524,12 +568,16 @@ class AuthService(
     }
 
     private fun publishCurrentUserLocked(user: CurrentUserData): CurrentUserData {
+        if (currentUser?.id != user.id || currentUser?.homeLocation != user.homeLocation) {
+            homeWorldRevision++
+        }
         currentUser = user
         _currentUserState.value = user
         return user
     }
 
     private fun clearCurrentUserLocked() {
+        if (currentUser != null) homeWorldRevision++
         currentUser = null
         socketPresence = null
         socketPresenceRevision++

--- a/composeApp/src/commonMain/kotlin/service/AuthService.kt
+++ b/composeApp/src/commonMain/kotlin/service/AuthService.kt
@@ -482,39 +482,57 @@ class AuthService(
         callback = { _: AccountSessionToken -> callback() },
     )
 
+    internal suspend fun <T> runSessionBoundCatchingForUser(
+        userId: String,
+        callback: suspend (AccountSessionToken) -> T,
+    ): SessionBoundResponse<T>? = authMutex.withLock {
+        val sessionToken = SharedFlowCentre.currentSession.value
+            ?.takeIf { it.account.userId == userId }
+            ?.token
+            ?: return@withLock null
+        runSessionBoundCatchingLocked(sessionToken, callback)
+    }
+
     internal suspend fun <T> runSessionBoundCatchingWithToken(
         sessionToken: AccountSessionToken,
         callback: suspend (AccountSessionToken) -> T,
     ): SessionBoundResponse<T>? = authMutex.withLock {
-        if (!SharedFlowCentre.isCurrentSession(sessionToken)) return@withLock null
+        runSessionBoundCatchingLocked(sessionToken, callback)
+    }
+
+    private suspend fun <T> runSessionBoundCatchingLocked(
+        sessionToken: AccountSessionToken,
+        callback: suspend (AccountSessionToken) -> T,
+    ): SessionBoundResponse<T>? {
+        if (!SharedFlowCentre.isCurrentSession(sessionToken)) return null
 
         val first = runRequestCatching { callback(sessionToken) }
         val firstError = first.exceptionOrNull()
         if (firstError !is VRCApiException ||
             firstError.code != HttpStatusCode.Unauthorized.value
         ) {
-            return@withLock SessionBoundResponse(first, sessionToken)
+            return SessionBoundResponse(first, sessionToken)
         }
-        if (!SharedFlowCentre.isCurrentSession(sessionToken)) return@withLock null
+        if (!SharedFlowCentre.isCurrentSession(sessionToken)) return null
         val reauthenticated = runRequestCatching {
             doReTryAuthLocked(sessionToken.userId)
         }
         reauthenticated.exceptionOrNull()?.let { error ->
-            return@withLock SessionBoundResponse(Result.failure(error), sessionToken)
+            return SessionBoundResponse(Result.failure(error), sessionToken)
         }
         if (!reauthenticated.getOrThrow()) {
-            return@withLock SessionBoundResponse(first, sessionToken)
+            return SessionBoundResponse(first, sessionToken)
         }
 
         val refreshedSession = SharedFlowCentre.currentSession.value
         if (refreshedSession?.account?.userId != sessionToken.userId ||
             !SharedFlowCentre.isCurrentSession(refreshedSession.token)
         ) {
-            return@withLock null
+            return null
         }
         val retried = runRequestCatching { callback(refreshedSession.token) }
-        if (!SharedFlowCentre.isCurrentSession(refreshedSession.token)) return@withLock null
-        SessionBoundResponse(retried, refreshedSession.token)
+        if (!SharedFlowCentre.isCurrentSession(refreshedSession.token)) return null
+        return SessionBoundResponse(retried, refreshedSession.token)
     }
 
     private suspend fun <T> runRequestCatching(callback: suspend () -> T): Result<T> = try {

--- a/composeApp/src/commonMain/kotlin/service/AuthService.kt
+++ b/composeApp/src/commonMain/kotlin/service/AuthService.kt
@@ -175,6 +175,16 @@ class AuthService(
         true
     }
 
+    /** Reads the current user's Home World while holding the same lock as user updates. */
+    internal fun isCurrentUserHomeWorld(
+        sessionToken: AccountSessionToken,
+        expectedWorldId: String,
+    ): Boolean = synchronized(currentUserLock) {
+        if (!SharedFlowCentre.isCurrentSession(sessionToken)) return@synchronized false
+        currentUser?.let { it.id == sessionToken.userId && it.homeLocation == expectedWorldId }
+            ?: false
+    }
+
     fun applySocketUserUpdate(user: UserContent) {
         synchronized(currentUserLock) {
             val existing = currentUser ?: return@synchronized

--- a/composeApp/src/commonMain/kotlin/service/HomeWorldService.kt
+++ b/composeApp/src/commonMain/kotlin/service/HomeWorldService.kt
@@ -3,6 +3,7 @@ package io.github.vrcmteam.vrcm.service
 import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.network.api.users.UsersApi
+import io.github.vrcmteam.vrcm.network.api.users.data.CurrentUpdateUserData
 import io.github.vrcmteam.vrcm.network.api.users.data.UpdateUserInfoData
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.flow.Flow
@@ -36,6 +37,11 @@ internal class InvalidHomeWorldException : IllegalArgumentException("Invalid VRC
 
 internal class HomeWorldUpdateInFlightException : IllegalStateException(
     "A Home World update is already in progress"
+)
+
+private data class PendingHomeWorldUpdate(
+    val user: CurrentUpdateUserData,
+    val stateRevision: Long,
 )
 
 /** Updates the authenticated user's Home World without allowing stale sessions to publish state. */
@@ -106,37 +112,51 @@ internal class HomeWorldService(
             expectedSessionToken == null || current.token == expectedSessionToken
         }
             ?: return Result.failure(HomeWorldSessionChangedException())
-        val response = authService.runSessionBoundCatching(session.token) {
+        val response = authService.runSessionBoundCatchingWithToken(session.token) { activeSessionToken ->
             authService.withHomeWorldMutation {
-                if (expectedWorldId != null && expectedSessionToken != null &&
-                    !authService.isCurrentUserHomeWorld(
-                        sessionToken = expectedSessionToken,
-                        expectedWorldId = expectedWorldId,
-                    )
+                if (expectedSessionToken != null &&
+                    activeSessionToken.userId != expectedSessionToken.userId
                 ) {
-                    throw HomeWorldStateChangedException()
+                    throw HomeWorldSessionChangedException()
                 }
-                usersApi.updateUserInfo(
-                    userId = session.account.userId,
-                    updateUserInfoData = UpdateUserInfoData(homeLocation = homeLocation),
+                val stateRevision = when (val state = authService.homeWorldMutationState(
+                    sessionToken = activeSessionToken,
+                    expectedWorldId = expectedWorldId,
+                )) {
+                    is HomeWorldMutationState.Ready -> state.revision
+                    HomeWorldMutationState.SessionChanged ->
+                        throw HomeWorldSessionChangedException()
+                    HomeWorldMutationState.HomeWorldChanged ->
+                        throw HomeWorldStateChangedException()
+                }
+                PendingHomeWorldUpdate(
+                    user = usersApi.updateUserInfo(
+                        userId = activeSessionToken.userId,
+                        updateUserInfoData = UpdateUserInfoData(homeLocation = homeLocation),
+                    ),
+                    stateRevision = stateRevision,
                 )
             }
         } ?: return Result.failure(HomeWorldSessionChangedException())
 
         return authService.withHomeWorldMutation {
-            response.result.mapCatching { updatedUser ->
+            response.result.mapCatching { pendingUpdate ->
+                val updatedUser = pendingUpdate.user
                 check(updatedUser.id == response.sessionToken.userId) {
                     "Home World update returned a different user"
                 }
-                if (!authService.applyCurrentUserHomeLocationLocked(
-                        sessionToken = response.sessionToken,
-                        userId = updatedUser.id,
-                        homeLocation = updatedUser.homeLocation,
-                    )
-                ) {
-                    throw HomeWorldSessionChangedException()
+                when (authService.commitHomeWorldMutationLocked(
+                    sessionToken = response.sessionToken,
+                    userId = updatedUser.id,
+                    expectedRevision = pendingUpdate.stateRevision,
+                    homeLocation = updatedUser.homeLocation,
+                )) {
+                    HomeWorldMutationCommitResult.Applied -> updatedUser.homeLocation
+                    HomeWorldMutationCommitResult.SessionChanged ->
+                        throw HomeWorldSessionChangedException()
+                    HomeWorldMutationCommitResult.StateChanged ->
+                        throw HomeWorldStateChangedException()
                 }
-                updatedUser.homeLocation
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/service/HomeWorldService.kt
+++ b/composeApp/src/commonMain/kotlin/service/HomeWorldService.kt
@@ -107,33 +107,37 @@ internal class HomeWorldService(
         }
             ?: return Result.failure(HomeWorldSessionChangedException())
         val response = authService.runSessionBoundCatching(session.token) {
-            if (expectedWorldId != null && expectedSessionToken != null &&
-                !authService.isCurrentUserHomeWorld(
-                    sessionToken = expectedSessionToken,
-                    expectedWorldId = expectedWorldId,
+            authService.withHomeWorldMutation {
+                if (expectedWorldId != null && expectedSessionToken != null &&
+                    !authService.isCurrentUserHomeWorld(
+                        sessionToken = expectedSessionToken,
+                        expectedWorldId = expectedWorldId,
+                    )
+                ) {
+                    throw HomeWorldStateChangedException()
+                }
+                usersApi.updateUserInfo(
+                    userId = session.account.userId,
+                    updateUserInfoData = UpdateUserInfoData(homeLocation = homeLocation),
                 )
-            ) {
-                throw HomeWorldStateChangedException()
             }
-            usersApi.updateUserInfo(
-                userId = session.account.userId,
-                updateUserInfoData = UpdateUserInfoData(homeLocation = homeLocation),
-            )
         } ?: return Result.failure(HomeWorldSessionChangedException())
 
-        return response.result.mapCatching { updatedUser ->
-            check(updatedUser.id == response.sessionToken.userId) {
-                "Home World update returned a different user"
+        return authService.withHomeWorldMutation {
+            response.result.mapCatching { updatedUser ->
+                check(updatedUser.id == response.sessionToken.userId) {
+                    "Home World update returned a different user"
+                }
+                if (!authService.applyCurrentUserHomeLocationLocked(
+                        sessionToken = response.sessionToken,
+                        userId = updatedUser.id,
+                        homeLocation = updatedUser.homeLocation,
+                    )
+                ) {
+                    throw HomeWorldSessionChangedException()
+                }
+                updatedUser.homeLocation
             }
-            if (!authService.applyCurrentUserHomeLocation(
-                    sessionToken = response.sessionToken,
-                    userId = updatedUser.id,
-                    homeLocation = updatedUser.homeLocation,
-                )
-            ) {
-                throw HomeWorldSessionChangedException()
-            }
-            updatedUser.homeLocation
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/service/HomeWorldService.kt
+++ b/composeApp/src/commonMain/kotlin/service/HomeWorldService.kt
@@ -108,14 +108,13 @@ internal class HomeWorldService(
         expectedWorldId: String?,
         expectedSessionToken: AccountSessionToken?,
     ): Result<String> {
-        val session = SharedFlowCentre.currentSession.value?.takeIf { current ->
-            expectedSessionToken == null || current.token == expectedSessionToken
-        }
+        val expectedUserId = expectedSessionToken?.userId
+            ?: SharedFlowCentre.currentSession.value?.account?.userId
             ?: return Result.failure(HomeWorldSessionChangedException())
-        val response = authService.runSessionBoundCatchingWithToken(session.token) { activeSessionToken ->
+        val response = authService.runSessionBoundCatchingForUser(expectedUserId) { activeSessionToken ->
             authService.withHomeWorldMutation {
                 if (expectedSessionToken != null &&
-                    activeSessionToken.userId != expectedSessionToken.userId
+                    activeSessionToken.userId != expectedUserId
                 ) {
                     throw HomeWorldSessionChangedException()
                 }

--- a/composeApp/src/commonMain/kotlin/service/HomeWorldService.kt
+++ b/composeApp/src/commonMain/kotlin/service/HomeWorldService.kt
@@ -18,11 +18,18 @@ internal interface HomeWorldManager {
 
     suspend fun setHomeWorld(worldId: String): Result<String>
 
-    suspend fun resetHomeWorld(): Result<String>
+    suspend fun resetHomeWorld(
+        expectedWorldId: String,
+        expectedSessionToken: AccountSessionToken,
+    ): Result<String>
 }
 
 internal class HomeWorldSessionChangedException : IllegalStateException(
     "The authenticated account changed while updating the Home World"
+)
+
+internal class HomeWorldStateChangedException : IllegalStateException(
+    "The Home World changed before the reset could be submitted"
 )
 
 internal class InvalidHomeWorldException : IllegalArgumentException("Invalid VRChat world ID")
@@ -57,23 +64,57 @@ internal class HomeWorldService(
         return updateHomeLocation(worldId.trim())
     }
 
-    override suspend fun resetHomeWorld(): Result<String> = updateHomeLocation("")
+    override suspend fun resetHomeWorld(
+        expectedWorldId: String,
+        expectedSessionToken: AccountSessionToken,
+    ): Result<String> {
+        if (!isWorldId(expectedWorldId)) {
+            return Result.failure(InvalidHomeWorldException())
+        }
+        return updateHomeLocation(
+            homeLocation = "",
+            expectedWorldId = expectedWorldId.trim(),
+            expectedSessionToken = expectedSessionToken,
+        )
+    }
 
-    private suspend fun updateHomeLocation(homeLocation: String): Result<String> {
+    private suspend fun updateHomeLocation(
+        homeLocation: String,
+        expectedWorldId: String? = null,
+        expectedSessionToken: AccountSessionToken? = null,
+    ): Result<String> {
         if (!updateInFlight.compareAndSet(expect = false, update = true)) {
             return Result.failure(HomeWorldUpdateInFlightException())
         }
         return try {
-            performHomeWorldUpdate(homeLocation)
+            performHomeWorldUpdate(
+                homeLocation = homeLocation,
+                expectedWorldId = expectedWorldId,
+                expectedSessionToken = expectedSessionToken,
+            )
         } finally {
             updateInFlight.value = false
         }
     }
 
-    private suspend fun performHomeWorldUpdate(homeLocation: String): Result<String> {
-        val session = SharedFlowCentre.currentSession.value
+    private suspend fun performHomeWorldUpdate(
+        homeLocation: String,
+        expectedWorldId: String?,
+        expectedSessionToken: AccountSessionToken?,
+    ): Result<String> {
+        val session = SharedFlowCentre.currentSession.value?.takeIf { current ->
+            expectedSessionToken == null || current.token == expectedSessionToken
+        }
             ?: return Result.failure(HomeWorldSessionChangedException())
         val response = authService.runSessionBoundCatching(session.token) {
+            if (expectedWorldId != null && expectedSessionToken != null &&
+                !authService.isCurrentUserHomeWorld(
+                    sessionToken = expectedSessionToken,
+                    expectedWorldId = expectedWorldId,
+                )
+            ) {
+                throw HomeWorldStateChangedException()
+            }
             usersApi.updateUserInfo(
                 userId = session.account.userId,
                 updateUserInfoData = UpdateUserInfoData(homeLocation = homeLocation),

--- a/composeApp/src/commonMain/kotlin/service/HomeWorldService.kt
+++ b/composeApp/src/commonMain/kotlin/service/HomeWorldService.kt
@@ -16,8 +16,9 @@ internal data class HomeWorldUserContext(
 internal interface HomeWorldManager {
     val currentUser: Flow<HomeWorldUserContext?>
 
-    /** A null target removes the custom Home World and restores VRChat's default. */
-    suspend fun updateHomeWorld(worldId: String?): Result<String>
+    suspend fun setHomeWorld(worldId: String): Result<String>
+
+    suspend fun resetHomeWorld(): Result<String>
 }
 
 internal class HomeWorldSessionChangedException : IllegalStateException(
@@ -51,12 +52,14 @@ internal class HomeWorldService(
         }
     }
 
-    override suspend fun updateHomeWorld(worldId: String?): Result<String> {
-        val homeLocation = when {
-            worldId == null -> ""
-            isWorldId(worldId) -> worldId.trim()
-            else -> return Result.failure(InvalidHomeWorldException())
-        }
+    override suspend fun setHomeWorld(worldId: String): Result<String> {
+        if (!isWorldId(worldId)) return Result.failure(InvalidHomeWorldException())
+        return updateHomeLocation(worldId.trim())
+    }
+
+    override suspend fun resetHomeWorld(): Result<String> = updateHomeLocation("")
+
+    private suspend fun updateHomeLocation(homeLocation: String): Result<String> {
         if (!updateInFlight.compareAndSet(expect = false, update = true)) {
             return Result.failure(HomeWorldUpdateInFlightException())
         }

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldProfileScreenModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldProfileScreenModelTest.kt
@@ -15,7 +15,9 @@ import io.github.vrcmteam.vrcm.network.api.worlds.data.WorldData
 import io.github.vrcmteam.vrcm.presentation.favorites.FavoriteEntrySource
 import io.github.vrcmteam.vrcm.presentation.screens.world.data.WorldProfileVo
 import io.github.vrcmteam.vrcm.service.AuthService
+import io.github.vrcmteam.vrcm.service.HomeWorldManager
 import io.github.vrcmteam.vrcm.service.HomeWorldService
+import io.github.vrcmteam.vrcm.service.HomeWorldUserContext
 import io.github.vrcmteam.vrcm.service.InstanceCreationService
 import io.github.vrcmteam.vrcm.service.NetworkInstanceCreationRequest
 import io.github.vrcmteam.vrcm.service.data.AccountDto
@@ -46,10 +48,11 @@ import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.Json
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 import org.koin.core.logger.EmptyLogger
@@ -141,6 +144,98 @@ class WorldProfileScreenModelTest : MainDispatcherTest() {
             }
             fixture.client.close()
         }
+    }
+
+    @Test
+    fun setHomeWorldIntentCannotTurnIntoResetBeforeConfirmation() = runTest {
+        val fixture = worldProfileFixture { request ->
+            when (request.url.encodedPath) {
+                "/api/1/auth/user" -> jsonResponse(currentUserJson(cachedAccount()))
+                else -> error("Unexpected request: ${request.method} ${request.url}")
+            }
+        }
+        var model: WorldProfileScreenModel? = null
+        try {
+            fixture.service.restoreAuth()
+            val sessionToken = requireNotNull(SharedFlowCentre.currentSession.value).token
+            val homeWorldManager = RecordingHomeWorldManager(
+                HomeWorldUserContext(sessionToken, homeLocation = "wrld_previous")
+            )
+            model = WorldProfileScreenModel(
+                worldsApi = WorldsApi(fixture.client),
+                instancesApi = InstancesApi(fixture.client),
+                usersApi = UsersApi(fixture.client),
+                groupsApi = GroupsApi(fixture.client),
+                authService = fixture.service,
+                instanceCreationService = InstanceCreationService(
+                    NetworkInstanceCreationRequest(fixture.service, InstancesApi(fixture.client))
+                ),
+                favoriteEntrySource = EmptyFavoriteEntrySource(),
+                inviteApi = InviteApi(fixture.client),
+                worldPlatformService = WorldPlatformService(FileApi(fixture.client), fixture.service),
+                worldProfileCacheStore = RecordingWorldProfileCache(
+                    WorldProfileCache(
+                        world = testWorld(name = "cached").copy(authorId = "usr_other"),
+                        cachedAtEpochMilliseconds = Long.MAX_VALUE,
+                        supportedPlatforms = emptyList(),
+                        platformFileSizes = emptyList(),
+                    )
+                ),
+                homeWorldManager = homeWorldManager,
+                worldEditor = TestNoOpWorldEditor,
+            )
+            val screenModel = requireNotNull(model)
+
+            screenModel.loadWorldData(WorldProfileVo(worldId = "wrld_owned"))
+            runCurrent()
+            assertEquals(
+                HomeWorldActionAvailability.CanSet,
+                screenModel.homeWorldActionState.value.availability,
+            )
+            val selectedAction = requireNotNull(screenModel.homeWorldActionState.value.action)
+
+            homeWorldManager.user.value = HomeWorldUserContext(sessionToken, homeLocation = "wrld_owned")
+            runCurrent()
+            assertEquals(
+                HomeWorldActionAvailability.Current,
+                screenModel.homeWorldActionState.value.availability,
+            )
+
+            screenModel.updateHomeWorld(selectedAction)
+            homeWorldManager.updated.await()
+
+            assertEquals(listOf("wrld_owned"), homeWorldManager.setTargets)
+            assertEquals(0, homeWorldManager.resetCount)
+        } finally {
+            model?.let {
+                ViewModelStore().apply {
+                    put("world-profile", it)
+                    clear()
+                }
+            }
+            fixture.client.close()
+        }
+    }
+}
+
+private class RecordingHomeWorldManager(initialUser: HomeWorldUserContext) : HomeWorldManager {
+    val user = MutableStateFlow<HomeWorldUserContext?>(initialUser)
+    val setTargets = mutableListOf<String>()
+    var resetCount = 0
+    val updated = CompletableDeferred<Unit>()
+
+    override val currentUser = user
+
+    override suspend fun setHomeWorld(worldId: String): Result<String> {
+        setTargets += worldId
+        updated.complete(Unit)
+        return Result.success(worldId)
+    }
+
+    override suspend fun resetHomeWorld(): Result<String> {
+        resetCount++
+        updated.complete(Unit)
+        return Result.success("")
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldProfileScreenModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/presentation/screens/world/WorldProfileScreenModelTest.kt
@@ -2,6 +2,7 @@ package io.github.vrcmteam.vrcm.presentation.screens.world
 
 import androidx.lifecycle.ViewModelStore
 import com.russhwolf.settings.MapSettings
+import io.github.vrcmteam.vrcm.core.shared.AccountSessionToken
 import io.github.vrcmteam.vrcm.core.shared.SharedFlowCentre
 import io.github.vrcmteam.vrcm.di.supports.PersistentCookiesStorage
 import io.github.vrcmteam.vrcm.network.api.attributes.FavoriteType
@@ -232,7 +233,10 @@ private class RecordingHomeWorldManager(initialUser: HomeWorldUserContext) : Hom
         return Result.success(worldId)
     }
 
-    override suspend fun resetHomeWorld(): Result<String> {
+    override suspend fun resetHomeWorld(
+        expectedWorldId: String,
+        expectedSessionToken: AccountSessionToken,
+    ): Result<String> {
         resetCount++
         updated.complete(Unit)
         return Result.success("")

--- a/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
@@ -120,6 +120,42 @@ class AuthServiceTest : MainDispatcherTest() {
     }
 
     @Test
+    fun resetHomeWorldRetriesWithTheRefreshedSessionToken() = runTest {
+        var updateRequests = 0
+        val fixture = fixture { request ->
+            when (request.method) {
+                HttpMethod.Put -> {
+                    updateRequests++
+                    if (updateRequests == 1) {
+                        respond(
+                            content = "expired",
+                            status = HttpStatusCode.Unauthorized,
+                        )
+                    } else {
+                        jsonResponse(currentUserJson(cachedAccount(), homeLocation = ""))
+                    }
+                }
+
+                else -> jsonResponse(
+                    currentUserJson(cachedAccount(), homeLocation = "wrld_confirmed")
+                )
+            }
+        }
+        assertIs<AuthState.Authed>(fixture.service.restoreAuth())
+        val sessionToken = requireNotNull(SharedFlowCentre.currentSession.value).token
+
+        val result = HomeWorldService(UsersApi(fixture.client), fixture.service).resetHomeWorld(
+            expectedWorldId = "wrld_confirmed",
+            expectedSessionToken = sessionToken,
+        )
+
+        assertEquals("", result.getOrThrow())
+        assertEquals(2, updateRequests)
+        assertEquals("", fixture.service.currentUserState.value?.homeLocation)
+        fixture.client.close()
+    }
+
+    @Test
     fun accountSwitchRejectsLateHomeWorldResponse() = runTest {
         val updateStarted = CompletableDeferred<Unit>()
         val releaseUpdate = CompletableDeferred<Unit>()
@@ -269,6 +305,52 @@ class AuthServiceTest : MainDispatcherTest() {
         assertEquals("wrld_later", refresh.await().homeLocation)
         assertIs<HomeWorldStateChangedException>(reset.await().exceptionOrNull())
         assertEquals(0, updateRequests)
+        fixture.client.close()
+    }
+
+    @Test
+    fun newerUserRefreshWinsBeforeHomeWorldResponseCommit() = runTest {
+        val updateStarted = CompletableDeferred<Unit>()
+        val releaseUpdate = CompletableDeferred<Unit>()
+        val refreshStarted = CompletableDeferred<Unit>()
+        var userRequests = 0
+        val fixture = fixture { request ->
+            when {
+                request.method == HttpMethod.Put -> {
+                    updateStarted.complete(Unit)
+                    releaseUpdate.await()
+                    jsonResponse(currentUserJson(cachedAccount(), homeLocation = ""))
+                }
+
+                request.method == HttpMethod.Get && userRequests++ == 0 ->
+                    jsonResponse(currentUserJson(cachedAccount(), homeLocation = "wrld_confirmed"))
+
+                request.method == HttpMethod.Get -> {
+                    refreshStarted.complete(Unit)
+                    jsonResponse(currentUserJson(cachedAccount(), homeLocation = "wrld_newer"))
+                }
+
+                else -> error("Unexpected request: ${request.method} ${request.url}")
+            }
+        }
+        assertIs<AuthState.Authed>(fixture.service.restoreAuth())
+        val sessionToken = requireNotNull(SharedFlowCentre.currentSession.value).token
+        val reset = async(start = CoroutineStart.UNDISPATCHED) {
+            HomeWorldService(UsersApi(fixture.client), fixture.service).resetHomeWorld(
+                expectedWorldId = "wrld_confirmed",
+                expectedSessionToken = sessionToken,
+            )
+        }
+        updateStarted.await()
+        val refresh = async(start = CoroutineStart.UNDISPATCHED) {
+            fixture.service.currentUser(isRefresh = true)
+        }
+
+        releaseUpdate.complete(Unit)
+        refreshStarted.await()
+        assertEquals("wrld_newer", refresh.await().homeLocation)
+        assertIs<HomeWorldStateChangedException>(reset.await().exceptionOrNull())
+        assertEquals("wrld_newer", fixture.service.currentUserState.value?.homeLocation)
         fixture.client.close()
     }
 

--- a/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
@@ -197,6 +197,36 @@ class AuthServiceTest : MainDispatcherTest() {
     }
 
     @Test
+    fun resetHomeWorldDoesNotClearAHomeWorldChangedBeforeSubmission() = runTest {
+        var updateRequests = 0
+        val fixture = fixture { request ->
+            if (request.method == HttpMethod.Put) {
+                updateRequests++
+                jsonResponse(currentUserJson(cachedAccount(), homeLocation = ""))
+            } else {
+                jsonResponse(currentUserJson(cachedAccount(), homeLocation = "wrld_confirmed"))
+            }
+        }
+        assertIs<AuthState.Authed>(fixture.service.restoreAuth())
+        val sessionToken = requireNotNull(SharedFlowCentre.currentSession.value).token
+        fixture.service.applyCurrentUserHomeLocation(
+            sessionToken = sessionToken,
+            userId = sessionToken.userId,
+            homeLocation = "wrld_later",
+        )
+
+        val result = HomeWorldService(UsersApi(fixture.client), fixture.service).resetHomeWorld(
+            expectedWorldId = "wrld_confirmed",
+            expectedSessionToken = sessionToken,
+        )
+
+        assertIs<HomeWorldStateChangedException>(result.exceptionOrNull())
+        assertEquals(0, updateRequests)
+        assertEquals("wrld_later", fixture.service.currentUserState.value?.homeLocation)
+        fixture.client.close()
+    }
+
+    @Test
     fun unauthorizedCachedCookieFallsBackToSavedPassword() = runTest {
         val requests = mutableListOf<Pair<String?, String?>>()
         val fixture = fixture { request ->

--- a/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
@@ -111,7 +111,7 @@ class AuthServiceTest : MainDispatcherTest() {
         val result = HomeWorldService(
             usersApi = UsersApi(fixture.client),
             authService = fixture.service,
-        ).updateHomeWorld("wrld_requested")
+        ).setHomeWorld("wrld_requested")
 
         assertEquals("wrld_server_authoritative", result.getOrThrow())
         assertEquals("wrld_server_authoritative", fixture.service.currentUserState.value?.homeLocation)
@@ -142,7 +142,7 @@ class AuthServiceTest : MainDispatcherTest() {
             HomeWorldService(
                 usersApi = UsersApi(fixture.client),
                 authService = fixture.service,
-            ).updateHomeWorld("wrld_requested")
+            ).setHomeWorld("wrld_requested")
         }
         updateStarted.await()
 
@@ -179,18 +179,18 @@ class AuthServiceTest : MainDispatcherTest() {
         assertIs<AuthState.Authed>(fixture.service.restoreAuth())
         val homeWorldService = HomeWorldService(UsersApi(fixture.client), fixture.service)
         val first = async(start = CoroutineStart.UNDISPATCHED) {
-            homeWorldService.updateHomeWorld("wrld_first")
+            homeWorldService.setHomeWorld("wrld_first")
         }
         firstUpdateStarted.await()
 
         assertIs<HomeWorldUpdateInFlightException>(
-            homeWorldService.updateHomeWorld("wrld_duplicate").exceptionOrNull()
+            homeWorldService.setHomeWorld("wrld_duplicate").exceptionOrNull()
         )
         releaseFirstUpdate.complete(Unit)
         assertEquals("wrld_server_1", first.await().getOrThrow())
         assertEquals(
             "wrld_server_2",
-            homeWorldService.updateHomeWorld("wrld_after-completion").getOrThrow(),
+            homeWorldService.setHomeWorld("wrld_after-completion").getOrThrow(),
         )
         assertEquals(2, updateRequests)
         fixture.client.close()

--- a/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
@@ -227,6 +227,52 @@ class AuthServiceTest : MainDispatcherTest() {
     }
 
     @Test
+    fun resetHomeWorldWaitsForUserRefreshBeforeSubmitting() = runTest {
+        val refreshStarted = CompletableDeferred<Unit>()
+        val releaseRefresh = CompletableDeferred<Unit>()
+        var userRequests = 0
+        var updateRequests = 0
+        val fixture = fixture { request ->
+            when {
+                request.method == HttpMethod.Put -> {
+                    updateRequests++
+                    jsonResponse(currentUserJson(cachedAccount(), homeLocation = ""))
+                }
+
+                request.method == HttpMethod.Get && userRequests++ == 0 ->
+                    jsonResponse(currentUserJson(cachedAccount(), homeLocation = "wrld_confirmed"))
+
+                request.method == HttpMethod.Get -> {
+                    refreshStarted.complete(Unit)
+                    releaseRefresh.await()
+                    jsonResponse(currentUserJson(cachedAccount(), homeLocation = "wrld_later"))
+                }
+
+                else -> error("Unexpected request: ${request.method} ${request.url}")
+            }
+        }
+        assertIs<AuthState.Authed>(fixture.service.restoreAuth())
+        val sessionToken = requireNotNull(SharedFlowCentre.currentSession.value).token
+        val refresh = async(start = CoroutineStart.UNDISPATCHED) {
+            fixture.service.currentUser(isRefresh = true)
+        }
+        refreshStarted.await()
+        val reset = async(start = CoroutineStart.UNDISPATCHED) {
+            HomeWorldService(UsersApi(fixture.client), fixture.service).resetHomeWorld(
+                expectedWorldId = "wrld_confirmed",
+                expectedSessionToken = sessionToken,
+            )
+        }
+
+        assertEquals(0, updateRequests)
+        releaseRefresh.complete(Unit)
+        assertEquals("wrld_later", refresh.await().homeLocation)
+        assertIs<HomeWorldStateChangedException>(reset.await().exceptionOrNull())
+        assertEquals(0, updateRequests)
+        fixture.client.close()
+    }
+
+    @Test
     fun unauthorizedCachedCookieFallsBackToSavedPassword() = runTest {
         val requests = mutableListOf<Pair<String?, String?>>()
         val fixture = fixture { request ->

--- a/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/service/AuthServiceTest.kt
@@ -156,6 +156,41 @@ class AuthServiceTest : MainDispatcherTest() {
     }
 
     @Test
+    fun resetHomeWorldUsesCurrentTokenAfterSameAccountSessionRotation() = runTest {
+        var putRequests = 0
+        val fixture = fixture { request ->
+            when (request.method) {
+                HttpMethod.Put -> {
+                    putRequests++
+                    jsonResponse(currentUserJson(cachedAccount(), homeLocation = ""))
+                }
+
+                else -> jsonResponse(
+                    currentUserJson(cachedAccount(), homeLocation = "wrld_confirmed")
+                )
+            }
+        }
+        assertIs<AuthState.Authed>(fixture.service.restoreAuth())
+        val confirmedSession = requireNotNull(SharedFlowCentre.currentSession.value)
+
+        assertIs<AuthState.Authed>(
+            fixture.service.login(cachedAccount().username, cachedAccount().password.orEmpty())
+        )
+        val rotatedSession = requireNotNull(SharedFlowCentre.currentSession.value)
+        assertEquals(confirmedSession.token.userId, rotatedSession.token.userId)
+        assertFalse(confirmedSession.token == rotatedSession.token)
+
+        val result = HomeWorldService(UsersApi(fixture.client), fixture.service).resetHomeWorld(
+            expectedWorldId = "wrld_confirmed",
+            expectedSessionToken = confirmedSession.token,
+        )
+
+        assertEquals("", result.getOrThrow())
+        assertEquals(1, putRequests)
+        fixture.client.close()
+    }
+
+    @Test
     fun accountSwitchRejectsLateHomeWorldResponse() = runTest {
         val updateStarted = CompletableDeferred<Unit>()
         val releaseUpdate = CompletableDeferred<Unit>()


### PR DESCRIPTION
## 修复说明

- 对照 VRCX 当前实现与稳定版实现，确认接口合同一致：设置使用 `PUT /users/{userId}` 发送目标世界 ID，重置才发送空 `homeLocation`。
- 定位到 VRCX 将 `Make Home(id)` 与 `Reset Home()` 作为两个独立命令，而 VRCM 原实现到确认时才根据可变状态重新推导操作，并以可空 `worldId` 隐式表示重置；状态在菜单点击与确认之间变化时，设置意图会被翻转为重置。
- 将 Home World 服务拆为显式的设置与重置入口，并在菜单点击时捕获不可变操作意图；设置意图即使随后观察到当前世界状态，也只会幂等发送该世界 ID，不再转为空字符串。
- 重置操作在提交前继续要求当前世界仍是 Home World，避免迟到的重置确认清空后来设置的其他世界。
- 重置确认会携带当时的世界 ID 和会话 token；服务只用该 token 的 userId 约束账号，并在首次 PUT 及每次重试前读取当前有效 token 校验账号和 Home World，401 或正常续期后都允许同一账号继续，只有真正切换账号或 Home World 已变化才拒绝。
- PUT 前在 Home World mutation gate 内捕获只随用户或 `homeLocation` 变化的 revision；响应回写重新进入 gate，并仅在会话 token 和 revision 仍匹配时采用服务端结果，避免旧 PUT 响应覆盖期间完成的较新用户刷新。
- 增加状态转换回归测试；修复前实际收到 `[null]`，修复后收到 `wrld_owned` 且未调用重置。

## 实现假设清单

- VRChat Home World 合同以 VRCX 已验证行为为基准：设置发送 `{"homeLocation":"wrld_..."}`，重置发送 `{"homeLocation":""}`。
- 服务端返回的 `homeLocation` 继续作为权威状态，本次不改变现有响应回写、认证续期、会话绑定和重复提交保护。
- 对同一个世界重复执行设置是幂等操作，比把用户已选择的设置意图转换成重置更安全。
- 本次没有使用真实 VRChat 账号执行写请求，避免未经明确指定修改账号状态；请求格式由现有 Mock 请求体测试和 VRCX 对照实现验证。

## 代码逻辑图

```mermaid
flowchart TD
    A[打开世界更多操作] --> B{Home World 状态}
    B -- CanSet --> C[捕获 Set 意图]
    B -- Current --> D[捕获 Reset 意图及世界 ID 和会话 token]
    B -- Unavailable --> E[禁用操作]
    C --> F[显示设置确认]
    D --> G[显示重置确认]
    F --> H[按确认 token 的 userId 读取当前会话]
    G --> H
    H --> I[runSessionBoundCatchingForUser]
    I --> J[使用当前有效 token 进入 mutation gate]
    J --> K{账号及重置期望状态仍匹配}
    K -- 否 --> L[返回会话或状态变化失败]
    K -- 是 --> M[捕获 Home World revision]
    M --> N[PUT users userId]
    N -- 401 --> O[同账号续期并取得新 token]
    O --> I
    N -- 返回 --> P[释放 gate 并保留响应与 revision]
    P --> Q[重新进入 mutation gate]
    Q --> R{token 当前且 revision 未变化}
    R -- 是 --> S[采用服务端 homeLocation 并提示结果]
    R -- 否 --> T[丢弃旧响应并保留较新状态]
```

## 验证

- 本轮正常续期边界回归：`~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.service.AuthServiceTest.resetHomeWorldUsesCurrentTokenAfterSameAccountSessionRotation" --console=plain`：通过。
- 本轮续期回归：`~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.service.AuthServiceTest.resetHomeWorldRetriesWithTheRefreshedSessionToken" --console=plain`：通过。
- 本轮响应提交竞态回归：`~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.service.AuthServiceTest.newerUserRefreshWinsBeforeHomeWorldResponseCommit" --console=plain`：通过。
- 本轮并发回归：`~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.service.AuthServiceTest.resetHomeWorldWaitsForUserRefreshBeforeSubmitting" --console=plain`：通过。
- 本轮竞态回归：`~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.service.AuthServiceTest.resetHomeWorldDoesNotClearAHomeWorldChangedBeforeSubmission" --console=plain`：通过。
- 相关集合：`~/ai/bin/gradle-run.sh ./gradlew :composeApp:desktopTest --tests "io.github.vrcmteam.vrcm.presentation.screens.world.WorldProfileScreenModelTest.setHomeWorldIntentCannotTurnIntoResetBeforeConfirmation" --tests "io.github.vrcmteam.vrcm.presentation.screens.world.HomeWorldActionStateTest" --tests "io.github.vrcmteam.vrcm.network.api.users.UsersApiHomeWorldTest" --tests "io.github.vrcmteam.vrcm.service.AuthServiceTest" --console=plain`：通过。
- `./gradlew :composeApp:compileKotlinDesktop --console=plain`：通过。
- `git diff --check upstream/newui...HEAD`：通过。
- 完整 `:composeApp:desktopTest` 已执行，但上游既有 `WorldProfileInstanceCloseTest.closeWinsOverAnEarlierInstanceRefreshResponse` 在 `runBlocking` 中永久等待；单独执行该测试也在相同位置挂起，因此无法得到完整套件结束结果。
